### PR TITLE
feat: add configuration whether to deep clone objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ The attributes defined in `Riok.Mapperly.Abstractions` can be used to customize 
 The `MapperAttribute` provides options to customize the generated mapper class.
 The generated class name, the instance field name and the default enum mapping strategy is adjustable.
 
+### Copy behaviour
+
+By default, Mapperly does not create deep copies of objects to improve performance.
+If an object can be directly assigned to the target, it will do so
+(eg. if the source and target type are both `Car[]`, the array and its entries will not be cloned).
+To create deep copies, set the `UseDeepCloning` property on the `MapperAttribute` to `true`.
+
 #### Properties
 
 On each mapping method declaration property mappings can be customized.

--- a/src/Riok.Mapperly.Abstractions/MapperAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperAttribute.cs
@@ -22,4 +22,12 @@ public sealed class MapperAttribute : Attribute
     /// Can be overwritten on specific enums via mapping method configurations.
     /// </summary>
     public EnumMappingStrategy EnumMappingStrategy { get; set; } = EnumMappingStrategy.ByValue;
+
+    /// <summary>
+    /// Whether to always deep copy objects.
+    /// Eg. when the type <c>Person[]</c> should be mapped to the same type <c>Person[]</c>,
+    /// with <c><see cref="UseDeepCloning"/>=true</c>, the same array is reused.
+    /// With <c><see cref="UseDeepCloning"/>=false</c>, the array and each person is cloned.
+    /// </summary>
+    public bool UseDeepCloning { get; set; }
 }

--- a/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
@@ -15,7 +15,7 @@ public class DescriptorBuilder
     private static readonly IReadOnlyCollection<MappingBuilder> _mappingBuilders = new MappingBuilder[]
     {
         SpecialTypeMappingBuilder.TryBuildMapping,
-        ImmutableTypeMappingBuilder.TryBuildMapping,
+        DirectAssignmentMappingBuilder.TryBuildMapping,
         DictionaryMappingBuilder.TryBuildMapping,
         EnumerableMappingBuilder.TryBuildMapping,
         ImplicitCastMappingBuilder.TryBuildMapping,
@@ -56,14 +56,16 @@ public class DescriptorBuilder
         _context = sourceContext;
         Compilation = compilation;
         _mapperDescriptor = new MapperDescriptor(mapperSymbol.Name);
-        Configure();
+        MapperConfiguration = Configure();
     }
 
     internal IReadOnlyDictionary<Type, Attribute> DefaultConfigurations => _defaultConfigurations;
 
     internal Compilation Compilation { get; }
 
-    private void Configure()
+    public MapperAttribute MapperConfiguration { get; }
+
+    private MapperAttribute Configure()
     {
         var mapperAttribute = AttributeDataAccessor.AccessFirstOrDefault<MapperAttribute>(Compilation, _mapperSymbol) ?? new();
         if (!_mapperSymbol.ContainingNamespace.IsGlobalNamespace)
@@ -77,6 +79,7 @@ public class DescriptorBuilder
         _mapperDescriptor.InstanceName = mapperAttribute.InstanceName;
 
         _defaultConfigurations.Add(typeof(MapEnumAttribute), new MapEnumAttribute(mapperAttribute.EnumMappingStrategy));
+        return mapperAttribute;
     }
 
     private string BuildName()

--- a/src/Riok.Mapperly/Descriptors/MappingBuilder/DirectAssignmentMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilder/DirectAssignmentMappingBuilder.cs
@@ -4,11 +4,12 @@ using Riok.Mapperly.Helpers;
 
 namespace Riok.Mapperly.Descriptors.MappingBuilder;
 
-public static class ImmutableTypeMappingBuilder
+public static class DirectAssignmentMappingBuilder
 {
     public static TypeMapping? TryBuildMapping(MappingBuilderContext ctx)
     {
-        return SymbolEqualityComparer.IncludeNullability.Equals(ctx.Source, ctx.Target) && ctx.Source.IsImmutable()
+        return SymbolEqualityComparer.IncludeNullability.Equals(ctx.Source, ctx.Target)
+            && (!ctx.MapperConfiguration.UseDeepCloning || ctx.Source.IsImmutable())
             ? new DirectAssignmentMapping(ctx.Source)
             : null;
     }

--- a/src/Riok.Mapperly/Descriptors/MappingBuilder/ExplicitCastMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilder/ExplicitCastMappingBuilder.cs
@@ -8,7 +8,7 @@ public static class ExplicitCastMappingBuilder
 {
     public static CastMapping? TryBuildMapping(MappingBuilderContext ctx)
     {
-        if (!ctx.Source.IsImmutable() && !ctx.Target.IsImmutable())
+        if (ctx.MapperConfiguration.UseDeepCloning && !ctx.Source.IsImmutable() && !ctx.Target.IsImmutable())
             return null;
 
         var conversion = ctx.Compilation.ClassifyConversion(ctx.Source, ctx.Target);

--- a/src/Riok.Mapperly/Descriptors/MappingBuilder/ImplicitCastMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilder/ImplicitCastMappingBuilder.cs
@@ -8,7 +8,7 @@ public static class ImplicitCastMappingBuilder
 {
     public static CastMapping? TryBuildMapping(MappingBuilderContext ctx)
     {
-        if (!ctx.Source.IsImmutable() && !ctx.Target.IsImmutable())
+        if (ctx.MapperConfiguration.UseDeepCloning && !ctx.Source.IsImmutable() && !ctx.Target.IsImmutable())
             return null;
 
         var conversion = ctx.Compilation.ClassifyConversion(ctx.Source, ctx.Target);

--- a/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Riok.Mapperly.Abstractions;
 
 namespace Riok.Mapperly.Descriptors;
 
@@ -12,6 +13,8 @@ public class SimpleMappingBuilderContext
     }
 
     public Compilation Compilation => _builder.Compilation;
+
+    public MapperAttribute MapperConfiguration => _builder.MapperConfiguration;
 
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, ISymbol? location, params object[] messageArgs)
         => ReportDiagnostic(descriptor, location?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(), messageArgs);

--- a/test/Riok.Mapperly.Tests/Mapping/DirectAssignmentTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/DirectAssignmentTest.cs
@@ -1,6 +1,6 @@
 namespace Riok.Mapperly.Tests.Mapping;
 
-public class ValueTypeTest
+public class DirectAssignmentTest
 {
     [Fact]
     public void CustomReadOnlyStructToSameCustomReadOnlyStruct()

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
@@ -10,6 +10,18 @@ public class EnumerableTest
             "int[]");
         TestHelper.GenerateSingleMapperMethodBody(source)
             .Should()
+            .Be("return source;");
+    }
+
+    [Fact]
+    public void ArrayToArrayOfPrimitiveTypesDeepCloning()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "int[]",
+            "int[]",
+            TestSourceBuilderOptions.Default with { UseDeepCloning = true });
+        TestHelper.GenerateSingleMapperMethodBody(source)
+            .Should()
             .Be("return (int[])source.Clone();");
     }
 
@@ -20,6 +32,19 @@ public class EnumerableTest
             "B[]",
             "B[]",
             "class B { public int Value {get; set; }}");
+        TestHelper.GenerateSingleMapperMethodBody(source)
+            .Should()
+            .Be("return source;");
+    }
+
+    [Fact]
+    public void ArrayCustomClassToArrayCustomClassDeepCloning()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "B[]",
+            "B[]",
+            TestSourceBuilderOptions.Default with { UseDeepCloning = true },
+            "class B { public int Value { get; set; }}");
         TestHelper.GenerateMapperMethodBody(source)
             .Should()
             .Be("return System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Select(source, x => MapToB(x)));");
@@ -31,6 +56,18 @@ public class EnumerableTest
         var source = TestSourceBuilder.Mapping(
             "string[]",
             "string[]");
+        TestHelper.GenerateSingleMapperMethodBody(source)
+            .Should()
+            .Be("return source;");
+    }
+
+    [Fact]
+    public void ArrayToArrayOfStringDeepCloning()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "string[]",
+            "string[]",
+            TestSourceBuilderOptions.Default with { UseDeepCloning = true });
         TestHelper.GenerateSingleMapperMethodBody(source)
             .Should()
             .Be("return (string[])source.Clone();");
@@ -66,7 +103,7 @@ public class EnumerableTest
             "IEnumerable<int>");
         TestHelper.GenerateSingleMapperMethodBody(source)
             .Should()
-            .Be("return (System.Collections.Generic.IEnumerable<int>)source;");
+            .Be("return source;");
     }
 
     [Fact]

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
@@ -29,6 +29,20 @@ public class ObjectPropertyTest
 
         TestHelper.GenerateSingleMapperMethodBody(source)
             .Should()
+            .Be("return source;");
+    }
+
+    [Fact]
+    public void SameTypeDeepCopies()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "A",
+            TestSourceBuilderOptions.Default with { UseDeepCloning = true },
+            "class A { public string StringValue { get; set; } }");
+
+        TestHelper.GenerateSingleMapperMethodBody(source)
+            .Should()
             .Be(@"var target = new A();
     target.StringValue = source.StringValue;
     return target;".ReplaceLineEndings());
@@ -43,8 +57,21 @@ public class ObjectPropertyTest
             "ref struct A {}");
         TestHelper.GenerateSingleMapperMethodBody(source)
             .Should()
+            .Be("return source;");
+    }
+
+    [Fact]
+    public void CustomRefStructToSameCustomStructDeepCloning()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "A",
+            TestSourceBuilderOptions.Default with { UseDeepCloning = true },
+            "ref struct A {}");
+        TestHelper.GenerateSingleMapperMethodBody(source)
+            .Should()
             .Be(@"var target = new A();
-    return target;");
+    return target;".ReplaceLineEndings());
     }
 
     [Fact]

--- a/test/Riok.Mapperly.Tests/TestSourceBuilder.cs
+++ b/test/Riok.Mapperly.Tests/TestSourceBuilder.cs
@@ -26,12 +26,19 @@ using Riok.Mapperly.Abstractions;
 
 {(options.Namespace != null ? $"namespace {options.Namespace};" : string.Empty)}
 
-[Mapper]
+{BuildAttribute(options)}
 public {(options.AsInterface ? "interface I" : "abstract class ")}Mapper
 {{
     {body}
 }}
 ";
+    }
+
+    private static string BuildAttribute(TestSourceBuilderOptions options)
+    {
+        return options.UseDeepCloning
+            ? "[Mapper(UseDeepCloning = true)]"
+            : "[Mapper]";
     }
 
     public static string MapperWithBodyAndTypes(string body, params string[] types)

--- a/test/Riok.Mapperly.Tests/TestSourceBuilderOptions.cs
+++ b/test/Riok.Mapperly.Tests/TestSourceBuilderOptions.cs
@@ -1,6 +1,9 @@
 namespace Riok.Mapperly.Tests;
 
-public record TestSourceBuilderOptions(bool AsInterface = true, string? Namespace = null)
+public record TestSourceBuilderOptions(
+    bool AsInterface = true,
+    string? Namespace = null,
+    bool UseDeepCloning = false)
 {
     public static readonly TestSourceBuilderOptions Default = new();
 }


### PR DESCRIPTION
Add a configuration whether objects are directly assigned if possible or need to be deeply cloned
By default direct assignments are allowed