### PR TITLE
Added support for static mappers

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBuilder/UserMethodMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilder/UserMethodMappingBuilder.cs
@@ -93,13 +93,11 @@ public static class UserMethodMappingBuilder
         => m.Parameters.Length == 2
             && m.ReturnsVoid
             && !m.IsAsync
-            && !m.IsStatic
             && !m.IsGenericMethod;
 
     private static bool IsNewInstanceMappingMethod(IMethodSymbol m)
         => m.Parameters.Length == 1
             && !m.ReturnsVoid
             && !m.IsAsync
-            && !m.IsStatic
             && !m.IsGenericMethod;
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/MethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MethodMapping.cs
@@ -22,6 +22,10 @@ public abstract class MethodMapping : TypeMapping
 
     protected bool Partial { get; set; }
 
+    protected bool IsStatic { get; set; }
+
+    protected bool IsExtensionMethod { get; set; }
+
     protected string MethodName
     {
         get => _methodName ?? throw new InvalidOperationException();
@@ -62,13 +66,24 @@ public abstract class MethodMapping : TypeMapping
     {
         return new[]
         {
-            Parameter(Identifier(MappingSourceParameterName)).WithType(IdentifierName(SourceType.ToDisplayString())),
+            Parameter(Identifier(MappingSourceParameterName)).WithType(IdentifierName(SourceType.ToDisplayString())).WithModifiers(BuildParameterModifiers()),
         };
+    }
+
+    private SyntaxTokenList BuildParameterModifiers()
+    {
+        if (IsExtensionMethod)
+            return TokenList(Token(SyntaxKind.ThisKeyword));
+
+        return TokenList();
     }
 
     private IEnumerable<SyntaxToken> BuildModifiers()
     {
         yield return Accessibility(Accessibility);
+
+        if (IsStatic)
+            yield return Token(SyntaxKind.StaticKeyword);
 
         if (Partial)
             yield return Token(SyntaxKind.PartialKeyword);

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserDefinedExistingInstanceMethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserDefinedExistingInstanceMethodMapping.cs
@@ -17,6 +17,8 @@ public class UserDefinedExistingInstanceMethodMapping : ObjectPropertyMapping, I
         : base(method.Parameters[0].Type.UpgradeNullable(), method.Parameters[1].Type.UpgradeNullable())
     {
         Partial = true;
+        IsStatic = method.IsStatic;
+        IsExtensionMethod = method.IsExtensionMethod;
         Accessibility = method.DeclaredAccessibility;
         MappingSourceParameterName = method.Parameters[0].Name;
         Method = method;

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserDefinedNewInstanceMethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserDefinedNewInstanceMethodMapping.cs
@@ -17,6 +17,8 @@ public class UserDefinedNewInstanceMethodMapping : MethodMapping, IUserMapping
         : base(method.Parameters.Single().Type.UpgradeNullable(), method.ReturnType.UpgradeNullable())
     {
         Partial = true;
+        IsStatic = method.IsStatic;
+        IsExtensionMethod = method.IsExtensionMethod;
         Accessibility = method.DeclaredAccessibility;
         MappingSourceParameterName = method.Parameters[0].Name;
         Method = method;


### PR DESCRIPTION
Resolves issue #58

I have tested it with this trivial sample:
```csharp
[Mapper]
public static partial class TestStaticMapper
{
    public static partial IdObjectDto IdObjectToIdObjectDto(IdObject value);
    public static partial IdObjectDto ToDto(this IdObject value);

    public static partial void IdObjectToIdObjectDto2(IdObjectDto input, IdObject output);
    public static partial void ToDto2(this IdObject input, IdObject output);
}


[Mapper]
public partial class TestMapper
{
    public partial IdObjectDto ModelToDto(IdObject value);
    public static partial IdObjectDto ToDto(IdObject value);

    public partial void ModelToDto2(IdObject value, IdObjectDto dto);
    public static partial void ToDto2(IdObject value, IdObjectDto dto);
}
```

I originally thought I would add tests, but to be honest, I have no idea how to make them work as I have trouble even compiling them. I guess I need to work on my "build tools" skills :-)