### PR TITLE
Added property name mapping strategy according to issue #186

### DIFF
--- a/docs/docs/02-configuration/01-mapper.md
+++ b/docs/docs/02-configuration/01-mapper.md
@@ -37,3 +37,27 @@ public partial class CarMapper
     public partial CarDto ToDto(Car car);
 }
 ```
+
+## Property name mapping strategy
+
+By default, property names are matched using a case sensitive strategy. If all properties differ only in casing, for example ModelName on the source and modelName on the target, the `[MapperAttribute]` can be used with the `PropertyNameMappingStrategy` option.
+
+```csharp
+// highlight-start
+[Mapper(PropertyNameMappingStrategy = PropertyNameMappingStrategy.CaseInsensitive)]
+// highlight-end
+public partial class CarMapper
+{
+    public partial CarDto ToDto(Car car);
+}
+
+public class Car
+{
+    public string ModelName { get; set; }
+}
+
+public class CarDto
+{
+    public string modelName { get; set; }
+}
+```

--- a/src/Riok.Mapperly.Abstractions/MapperAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperAttribute.cs
@@ -7,6 +7,11 @@ namespace Riok.Mapperly.Abstractions;
 public sealed class MapperAttribute : Attribute
 {
     /// <summary>
+    /// Strategy on how to match mapping property names.
+    /// </summary>
+    public PropertyNameMappingStrategy PropertyNameMappingStrategy { get; set; } = PropertyNameMappingStrategy.CaseSensitive;
+
+    /// <summary>
     /// The default enum mapping strategy.
     /// Can be overwritten on specific enums via mapping method configurations.
     /// </summary>

--- a/src/Riok.Mapperly.Abstractions/PropertyNameMappingStrategy.cs
+++ b/src/Riok.Mapperly.Abstractions/PropertyNameMappingStrategy.cs
@@ -1,0 +1,17 @@
+namespace Riok.Mapperly.Abstractions;
+
+/// <summary>
+/// Defines the strategy to use when mapping a property to another property.
+/// </summary>
+public enum PropertyNameMappingStrategy
+{
+    /// <summary>
+    /// Matches a property by its name in case sensitive manner.
+    /// </summary>
+    CaseSensitive,
+
+    /// <summary>
+    /// Matches a property by its name in case insensitive manner.
+    /// </summary>
+    CaseInsensitive
+}

--- a/src/Riok.Mapperly/Descriptors/MappingBuilder/ObjectPropertyMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilder/ObjectPropertyMappingBuilder.cs
@@ -16,6 +16,11 @@ public static class ObjectPropertyMappingBuilder
 
     public static void BuildMappingBody(ObjectPropertyMappingBuilderContext ctx)
     {
+        var propertyNameComparer = ctx.BuilderContext.MapperConfiguration.PropertyNameMappingStrategy ==
+                       PropertyNameMappingStrategy.CaseSensitive
+            ? StringComparer.Ordinal
+            : StringComparer.OrdinalIgnoreCase;
+
         foreach (var targetProperty in ctx.TargetProperties.Values)
         {
             if (ctx.PropertyConfigsByRootTargetName.Remove(targetProperty.Name, out var propertyConfigs))
@@ -35,6 +40,7 @@ public static class ObjectPropertyMappingBuilder
                 ctx.Mapping.SourceType,
                 MemberPathCandidateBuilder.BuildMemberPathCandidates(targetProperty.Name),
                 ctx.IgnoredSourcePropertyNames,
+                propertyNameComparer,
                 out var sourcePropertyPath))
             {
                 ctx.BuilderContext.ReportDiagnostic(

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
@@ -1,3 +1,5 @@
+using Riok.Mapperly.Abstractions;
+
 namespace Riok.Mapperly.Tests.Mapping;
 
 [UsesVerify]
@@ -184,6 +186,40 @@ public class ObjectPropertyTest
             .HaveSingleMethodBody(@"var target = new B();
     target.StringValue2 = source.StringValue;
     return target;");
+    }
+
+    [Fact]
+    public void WithPropertyNameMappingStrategyCaseInsensitive()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A source);",
+            new TestSourceBuilderOptions
+            {
+                PropertyNameMappingStrategy = PropertyNameMappingStrategy.CaseInsensitive
+            },
+            "class A { public string StringValue { get; set; } }",
+            "class B { public string stringvalue { get; set; } }");
+
+        TestHelper.GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(@"var target = new B();
+    target.stringvalue = source.StringValue;
+    return target;");
+    }
+
+    [Fact]
+    public Task WithPropertyNameMappingStrategyCaseSensitive()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A source);",
+            new TestSourceBuilderOptions
+            {
+                PropertyNameMappingStrategy = PropertyNameMappingStrategy.CaseSensitive
+            },
+            "class A { public string StringValue { get; set; } }",
+            "class B { public string stringvalue { get; set; } }");
+
+        return TestHelper.VerifyGenerator(source);
     }
 
     [Fact]

--- a/test/Riok.Mapperly.Tests/TestSourceBuilder.cs
+++ b/test/Riok.Mapperly.Tests/TestSourceBuilder.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Riok.Mapperly.Abstractions;
 
 namespace Riok.Mapperly.Tests;
 
@@ -38,12 +39,17 @@ public partial class Mapper
 
     private static string BuildAttribute(TestSourceBuilderOptions options)
     {
-        var attrs = new[]
+        var attrs = new List<string>
         {
             Attribute(options.UseDeepCloning),
             Attribute(options.ThrowOnMappingNullMismatch),
-            Attribute(options.ThrowOnPropertyMappingNullMismatch),
+            Attribute(options.ThrowOnPropertyMappingNullMismatch)
         };
+
+        if (options.PropertyNameMappingStrategy != PropertyNameMappingStrategy.CaseSensitive)
+        {
+            attrs.Add($"{nameof(MapperAttribute.PropertyNameMappingStrategy)} = {nameof(PropertyNameMappingStrategy)}.{options.PropertyNameMappingStrategy}");
+        }
 
         return $"[Mapper({string.Join(", ", attrs)})]";
     }

--- a/test/Riok.Mapperly.Tests/TestSourceBuilderOptions.cs
+++ b/test/Riok.Mapperly.Tests/TestSourceBuilderOptions.cs
@@ -1,10 +1,13 @@
+using Riok.Mapperly.Abstractions;
+
 namespace Riok.Mapperly.Tests;
 
 public record TestSourceBuilderOptions(
     string? Namespace = null,
     bool UseDeepCloning = false,
     bool ThrowOnMappingNullMismatch = true,
-    bool ThrowOnPropertyMappingNullMismatch = false)
+    bool ThrowOnPropertyMappingNullMismatch = false,
+    PropertyNameMappingStrategy PropertyNameMappingStrategy = PropertyNameMappingStrategy.CaseSensitive)
 {
     public static readonly TestSourceBuilderOptions Default = new();
     public static readonly TestSourceBuilderOptions WithDeepCloning = new(UseDeepCloning: true);

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.WithPropertyNameMappingStrategyCaseSensitive#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.WithPropertyNameMappingStrategyCaseSensitive#Mapper.g.verified.cs
@@ -1,0 +1,10 @@
+﻿//HintName: Mapper.g.cs
+#nullable enable
+public partial class Mapper
+{
+    private partial B Map(A source)
+    {
+        var target = new B();
+        return target;
+    }
+}

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.WithPropertyNameMappingStrategyCaseSensitive.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.WithPropertyNameMappingStrategyCaseSensitive.verified.txt
@@ -1,0 +1,28 @@
+﻿{
+  Diagnostics: [
+    {
+      Id: RMG012,
+      Title: Mapping source property not found,
+      Severity: Info,
+      WarningLevel: 1,
+      Location: : (10,4)-(10,28),
+      Description: ,
+      HelpLink: ,
+      MessageFormat: Property {0} on source type {1} was not found,
+      Message: Property stringvalue on source type A was not found,
+      Category: Mapper
+    },
+    {
+      Id: RMG020,
+      Title: Source property is not mapped to any target property,
+      Severity: Info,
+      WarningLevel: 1,
+      Location: : (10,4)-(10,28),
+      Description: ,
+      HelpLink: ,
+      MessageFormat: The property {0} on the mapping source type {1} is not mapped to any property on the mapping target type {2},
+      Message: The property StringValue on the mapping source type A is not mapped to any property on the mapping target type B,
+      Category: Mapper
+    }
+  ]
+}


### PR DESCRIPTION
This adds support for property naming strategy (case sensitive/insensitve).

For example:

```
[Mapper(PropertyNameMappingStrategy=PropertyNameMappingStrategy.CaseInsensitive)]
class Mapper { partial B Map(A source); }

class A { public string StringValue { get; set; } }

class B { public string stringvalue { get; set; } }
````

Using `PropertyNameMappingStrategy.CaseInsensitive` will match property `A.StringValue` with `B.stringvalue`.

PR contains 2 unit tests: `WithPropertyNameMappingStrategyCaseInsensitive` and `WithPropertyNameMappingStrategyCaseSensitive`.

Let me know if such changes can be added into main repo. Also if naming convention i use are acceptable or need some tuning.