### PR TITLE
chore: replace set-output with github action output file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,4 @@ jobs:
           NUGET_SOURCE: ${{ inputs.nuget_source }}
           NUGET_API_KEY: ${{ secrets.nuget_api_key }}
       - id: release-version
-        run: echo "::set-output name=version::${{ env.RELEASE_VERSION }}"
+        run: echo "version=${{ env.RELEASE_VERSION }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
GitHub Actions deprecated set-output, replacing with github action output file.