### PR TITLE
fix: do not map from indexed properties

### DIFF
--- a/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
@@ -57,3 +57,11 @@ Rule ID | Category | Severity | Notes
 RMG023  | Mapper   | Error    | Mapping source property for a required target property not found
 RMG024  | Mapper   | Error    | The reference handler parameter is not of the correct type
 RMG025  | Mapper   | Error    | To use reference handling it needs to be enabled on the mapper attribute
+
+## Release 2.7
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+RMG026  | Mapper   | Info     | Cannot map from indexed property

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilder/ObjectPropertyMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilder/ObjectPropertyMappingBodyBuilder.cs
@@ -143,6 +143,18 @@ public static class ObjectPropertyMappingBodyBuilder
             return false;
         }
 
+        // cannot map from an indexed property
+        if (sourcePropertyPath.Member.IsIndexer)
+        {
+            ctx.BuilderContext.ReportDiagnostic(
+                DiagnosticDescriptors.CannotMapFromIndexedProperty,
+                ctx.Mapping.SourceType,
+                sourcePropertyPath.FullName,
+                ctx.Mapping.TargetType,
+                targetPropertyPath.FullName);
+            return false;
+        }
+
         return true;
     }
 

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -205,4 +205,12 @@ internal static class DiagnosticDescriptors
         DiagnosticCategories.Mapper,
         DiagnosticSeverity.Error,
         true);
+
+    public static readonly DiagnosticDescriptor CannotMapFromIndexedProperty = new DiagnosticDescriptor(
+        "RMG026",
+        "Cannot map from indexed property",
+        "Cannot map from indexed property {0}.{1} to property {2}.{3}",
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Info,
+        true);
 }

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
@@ -1,4 +1,5 @@
 using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Diagnostics;
 
 namespace Riok.Mapperly.Tests.Mapping;
 
@@ -114,6 +115,20 @@ public class ObjectPropertyTest
             "class B { public string StringValue { get; set; } public string StringValue2 { get; } }");
 
         return TestHelper.VerifyGenerator(source);
+    }
+
+    [Fact]
+    public void ShouldIgnoreIndexedPropertyOnSourceWithDiagnostic()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            "class A { public int this[int index] { get => -1; set { } } }",
+            "class B { public int this[int index] { get => -1; set { } } }");
+
+        TestHelper.GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(new DiagnosticMatcher(DiagnosticDescriptors.CannotMapFromIndexedProperty, "Cannot map from indexed property A.this[] to property B.this[]"));
     }
 
     [Fact]


### PR DESCRIPTION
Do not map from indexed properties and add a diagnostic instead.
Rel. https://github.com/riok/mapperly/issues/226