### PR TITLE
Adds support for readonly IList mapping 

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilder/NewInstanceObjectPropertyMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilder/NewInstanceObjectPropertyMappingBodyBuilder.cs
@@ -107,7 +107,7 @@ public static class NewInstanceObjectPropertyMappingBodyBuilder
         PropertyPath sourcePath)
     {
         var targetPath = new PropertyPath(new[] { targetProperty });
-        if (!ObjectPropertyMappingBodyBuilder.ValidateMappingSpecification(ctx, sourcePath, targetPath, true))
+        if (!ObjectPropertyMappingBodyBuilder.ValidateAssignmentMappingSpecification(ctx, sourcePath, targetPath, true))
             return;
 
         var delegateMapping = ctx.BuilderContext.FindMapping(sourcePath.MemberType, targetProperty.Type)

--- a/src/Riok.Mapperly/Descriptors/MappingBuilder/DirectAssignmentMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilder/DirectAssignmentMappingBuilder.cs
@@ -9,6 +9,7 @@ public static class DirectAssignmentMappingBuilder
     public static TypeMapping? TryBuildMapping(MappingBuilderContext ctx)
     {
         return SymbolEqualityComparer.IncludeNullability.Equals(ctx.Source, ctx.Target)
+            && (ctx.TargetRefKind == RefKind.None || ctx.TargetRefKind == RefKind.Out)
             && (!ctx.MapperConfiguration.UseDeepCloning || ctx.Source.IsImmutable())
             ? new DirectAssignmentMapping(ctx.Source)
             : null;

--- a/src/Riok.Mapperly/Descriptors/MappingBuilder/EnumerableMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilder/EnumerableMappingBuilder.cs
@@ -31,8 +31,8 @@ public static class EnumerableMappingBuilder
             return new CastMapping(ctx.Source, ctx.Target);
 
         // if source is an array and target is an array or IReadOnlyCollection faster mappings can be applied
-        if (ctx.Source.IsArrayType()
-            && (ctx.Target.IsArrayType() || SymbolEqualityComparer.Default.Equals(ctx.Target.OriginalDefinition, ctx.Types.IReadOnlyCollection)))
+        if (ctx.Source.IsArrayType() &&
+           (ctx.Target.IsArrayType() || SymbolEqualityComparer.Default.Equals(ctx.Target.OriginalDefinition, ctx.Types.IReadOnlyCollection)))
         {
             // if element mapping is synthetic
             // a single Array.Clone / cast mapping call should be sufficient and fast,
@@ -44,6 +44,11 @@ public static class EnumerableMappingBuilder
                 ? new ArrayCloneMapping(ctx.Source, ctx.Target)
                 : new CastMapping(ctx.Source, ctx.Target);
         }
+
+        // need to use special existing type list add mapping
+        if (ctx.TargetRefKind == RefKind.Ref &&
+            SymbolEqualityComparer.Default.Equals(ctx.Target.OriginalDefinition, ctx.Types.IList))
+            return new IListReadonlyMapping(ctx.Source, ctx.Target, elementMapping, enumeratedTargetType);
 
         // try linq mapping: x.Select(Map).ToArray/ToList
         // if that doesn't work do a foreach with add calls

--- a/src/Riok.Mapperly/Descriptors/MappingBuilder/ObjectPropertyMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilder/ObjectPropertyMappingBuilderContext.cs
@@ -68,6 +68,9 @@ public class ObjectPropertyMappingBuilderContext
     public void AddPropertyAssignmentMapping(PropertyAssignmentMapping propertyMapping)
         => AddPropertyAssignmentMapping(Mapping, propertyMapping);
 
+    public void AddPropertyReferenceMapping(PropertyReferenceMapping propertyMapping)
+        => AddPropertyReferenceMapping(Mapping, propertyMapping);
+
     public void AddNullDelegatePropertyAssignmentMapping(PropertyAssignmentMapping propertyMapping)
     {
         var nullConditionSourcePath = new PropertyPath(propertyMapping.SourcePath.PathWithoutTrailingNonNullable().ToList());
@@ -81,6 +84,14 @@ public class ObjectPropertyMappingBuilderContext
         container.AddPropertyMappings(BuildNullPropertyInitializers(mapping.TargetPath));
         container.AddPropertyMapping(mapping);
     }
+
+    private void AddPropertyReferenceMapping(IPropertyAssignmentMappingContainer container, PropertyReferenceMapping mapping)
+    {
+        SetSourcePropertyMapped(mapping.SourcePath);
+        container.AddPropertyMappings(BuildNullPropertyInitializers(mapping.TargetPath));
+        container.AddPropertyMapping(mapping);
+    }
+
 
     protected void SetSourcePropertyMapped(PropertyPath sourcePath)
         => _unmappedSourcePropertyNames.Remove(sourcePath.Path.First().Name);

--- a/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
@@ -16,12 +16,14 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
         DescriptorBuilder builder,
         ITypeSymbol source,
         ITypeSymbol target,
+        RefKind targetRefKind,
         ISymbol? userSymbol)
         : base(builder)
     {
         _builder = builder;
         Source = source;
         Target = target;
+        TargetRefKind = targetRefKind;
         _userSymbol = userSymbol;
     }
 
@@ -29,8 +31,10 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
 
     public ITypeSymbol Target { get; }
 
-    public ITypeMapping? FindMapping(ITypeSymbol sourceType, ITypeSymbol targetType)
-        => _builder.FindMapping(sourceType.UpgradeNullable(), targetType.UpgradeNullable());
+    public RefKind TargetRefKind { get; }
+
+    public ITypeMapping? FindMapping(ITypeSymbol sourceType, ITypeSymbol targetType, RefKind targetRefKind = RefKind.None)
+        => _builder.FindMapping(sourceType.UpgradeNullable(), targetType.UpgradeNullable(), targetRefKind);
 
     /// <summary>
     /// Tries to find an existing mapping for the provided types.
@@ -44,8 +48,8 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
     /// <param name="sourceType">The source type.</param>
     /// <param name="targetType">The target type.</param>
     /// <returns>The found or created mapping, or <c>null</c> if no mapping could be created.</returns>
-    public ITypeMapping? FindOrBuildMapping(ITypeSymbol sourceType, ITypeSymbol targetType)
-        => _builder.FindOrBuildMapping(sourceType.UpgradeNullable(), targetType.UpgradeNullable());
+    public ITypeMapping? FindOrBuildMapping(ITypeSymbol sourceType, ITypeSymbol targetType, RefKind targetRefKind = RefKind.None)
+        => _builder.FindOrBuildMapping(sourceType.UpgradeNullable(), targetType.UpgradeNullable(), targetRefKind);
 
     /// <summary>
     /// Tries to build a new mapping for the given types.
@@ -56,8 +60,8 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
     /// <param name="source">The source type.</param>
     /// <param name="target">The target type.</param>
     /// <returns>The created mapping or <c>null</c> if none could be created.</returns>
-    public ITypeMapping? BuildDelegateMapping(ITypeSymbol source, ITypeSymbol target)
-        => _builder.BuildDelegateMapping(_userSymbol, source.UpgradeNullable(), target.UpgradeNullable());
+    public ITypeMapping? BuildDelegateMapping(ITypeSymbol source, ITypeSymbol target, RefKind targetRefKind = RefKind.None)
+        => _builder.BuildDelegateMapping(_userSymbol, source.UpgradeNullable(), target.UpgradeNullable(), targetRefKind);
 
     /// <summary>
     /// Tries to build a new mapping for the given types while keeping the current user symbol reference.

--- a/src/Riok.Mapperly/Descriptors/MappingCollection.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingCollection.cs
@@ -22,9 +22,9 @@ public class MappingCollection
 
     public IReadOnlyCollection<ITypeMapping> All => _allMappings;
 
-    public ITypeMapping? FindMapping(ITypeSymbol sourceType, ITypeSymbol targetType)
+    public ITypeMapping? FindMapping(ITypeSymbol sourceType, ITypeSymbol targetType, RefKind targetRefKind = RefKind.None)
     {
-        _mappings.TryGetValue(new TypeMappingKey(sourceType, targetType), out var mapping);
+        _mappings.TryGetValue(new TypeMappingKey(sourceType, targetType, targetRefKind), out var mapping);
         return mapping;
     }
 
@@ -51,17 +51,20 @@ public class MappingCollection
 
         private readonly ITypeSymbol _source;
         private readonly ITypeSymbol _target;
+        private readonly RefKind _targetRefKind;
 
         public TypeMappingKey(ITypeMapping mapping)
         {
             _source = mapping.SourceType;
             _target = mapping.TargetType;
+            _targetRefKind = RefKind.None;
         }
 
-        public TypeMappingKey(ITypeSymbol source, ITypeSymbol target)
+        public TypeMappingKey(ITypeSymbol source, ITypeSymbol target, RefKind targetRefKind = RefKind.None)
         {
             _source = source;
             _target = target;
+            _targetRefKind = targetRefKind;
         }
 
         private bool Equals(TypeMappingKey other)

--- a/src/Riok.Mapperly/Descriptors/Mappings/IListReadonlyMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/IListReadonlyMapping.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Riok.Mapperly.Emit.SyntaxFactoryHelper;
+
+namespace Riok.Mapperly.Descriptors.Mappings;
+
+/// <summary>
+/// Used when target is some readonly field that implements IList
+/// as normal assignment mapping will not work
+/// </summary>
+internal class IListReadonlyMapping : MethodMapping
+{
+    private const string ListCountName = "Count";
+    private const string LoopCounterName = "i";
+    private const string AddMethodName = "Add";
+
+    private readonly ITypeMapping _elementMapping;
+    private readonly ITypeSymbol _targetArrayElementType;
+
+    public IListReadonlyMapping(
+        ITypeSymbol sourceType,
+        ITypeSymbol targetType,
+        ITypeMapping elementMapping,
+        ITypeSymbol targetArrayElementType) : base(sourceType, targetType, RefKind.Ref)
+    {
+        _elementMapping = elementMapping;
+        _targetArrayElementType = targetArrayElementType;
+    }
+
+    protected override ITypeSymbol? ReturnType => null;
+
+    public override IEnumerable<StatementSyntax> BuildBody(TypeMappingBuildContext ctx)
+    {
+        var targetVariableName = DefaultReferenceHandlerParameterName;
+        var loopCounterVariableName = ctx.NameBuilder.New(LoopCounterName);
+
+        // target.Add(Map(source[i]));
+        var forLoopBuilderCtx = ctx.WithSource(ElementAccess(ctx.Source, IdentifierName(loopCounterVariableName)));
+        var mappedIndexedSourceValue = _elementMapping.Build(forLoopBuilderCtx);
+        var add = Invocation(MemberAccess(targetVariableName, AddMethodName), mappedIndexedSourceValue);
+        var assignmentBlock = Block(SingletonList<StatementSyntax>(ExpressionStatement(add)));
+
+        // for(var i = 0; i < source.Length; i++)
+        //      target.Add(Map(source[i]));
+        yield return IncrementalForLoop(loopCounterVariableName, assignmentBlock, MemberAccess(ctx.Source, ListCountName));
+    }
+}

--- a/src/Riok.Mapperly/Descriptors/Mappings/ITypeMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ITypeMapping.cs
@@ -12,6 +12,8 @@ public interface ITypeMapping
 
     ITypeSymbol TargetType { get; }
 
+    RefKind TargetRefKind { get; }
+
     /// <summary>
     /// Gets a value indicating if this mapping can be called / built by another mapping.
     /// This should be <c>true</c> for most mappings.

--- a/src/Riok.Mapperly/Descriptors/Mappings/MethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MethodMapping.cs
@@ -33,6 +33,19 @@ public abstract class MethodMapping : TypeMapping
         SourceParameter = sourceParameter;
     }
 
+    protected MethodMapping(ITypeSymbol sourceType, ITypeSymbol targetType, RefKind targetRefKind)
+        : this(new MethodParameter(SourceParameterIndex, DefaultSourceParameterName, sourceType),
+              new MethodParameter(ReferenceHandlerParameterIndex, DefaultReferenceHandlerParameterName, targetType, targetRefKind))
+    {
+    }
+    protected MethodMapping(MethodParameter sourceParameter, MethodParameter targetParameter)
+        : base(sourceParameter.Type, targetParameter.Type, targetParameter.RefKind)
+    {
+        SourceParameter = sourceParameter;
+        if (targetParameter.RefKind != RefKind.None)
+            ReferenceHandlerParameter = targetParameter;
+    }
+
     protected Accessibility Accessibility { get; set; } = Accessibility.Private;
 
     protected bool IsPartial { get; set; }

--- a/src/Riok.Mapperly/Descriptors/Mappings/PropertyMappings/PropertyReferenceMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/PropertyMappings/PropertyReferenceMapping.cs
@@ -1,0 +1,86 @@
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Riok.Mapperly.Descriptors.Mappings.PropertyMappings;
+
+/// <summary>
+/// Represents a property mapping to a reference property
+/// when simple assignment cannot be used.
+/// ref used for compatibility with readonly value types
+/// (eg. map(source.B, ref target.A))
+/// </summary>
+[DebuggerDisplay("PropertyMapping({SourcePath.FullName} => {TargetPath.FullName})")]
+public class PropertyReferenceMapping : IPropertyAssignmentMapping
+{
+    private readonly IPropertyMapping _mapping;
+
+    public PropertyReferenceMapping(
+        PropertyPath targetPath,
+        IPropertyMapping mapping)
+    {
+        TargetPath = targetPath;
+        _mapping = mapping;
+    }
+
+    public PropertyPath SourcePath => _mapping.SourcePath;
+
+    public PropertyPath TargetPath { get; }
+
+    public StatementSyntax Build(
+        TypeMappingBuildContext ctx,
+        ExpressionSyntax targetAccess)
+    {
+        return ExpressionStatement(BuildExpression(ctx, targetAccess));
+    }
+
+    public ExpressionSyntax BuildExpression(
+        TypeMappingBuildContext ctx,
+        ExpressionSyntax? targetAccess)
+    {
+        var targetPropertyAccess = TargetPath.BuildAccess(targetAccess);
+        ctx = ctx.WithRefHandler(targetPropertyAccess);
+        var mappingMethod = _mapping.Build(ctx);
+
+        // MapTo(source.property, in target.Property);
+        return mappingMethod;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(null, obj))
+            return false;
+
+        if (ReferenceEquals(this, obj))
+            return true;
+
+        if (obj.GetType() != GetType())
+            return false;
+
+        return Equals((PropertyAssignmentMapping)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = _mapping.GetHashCode();
+            hashCode = (hashCode * 397) ^ SourcePath.GetHashCode();
+            hashCode = (hashCode * 397) ^ TargetPath.GetHashCode();
+            return hashCode;
+        }
+    }
+
+    public static bool operator ==(PropertyReferenceMapping? left, PropertyReferenceMapping? right)
+        => Equals(left, right);
+
+    public static bool operator !=(PropertyReferenceMapping? left, PropertyReferenceMapping? right)
+        => !Equals(left, right);
+
+    protected bool Equals(PropertyReferenceMapping other)
+    {
+        return _mapping.Equals(other._mapping)
+            && SourcePath.Equals(other.SourcePath)
+            && TargetPath.Equals(other.TargetPath);
+    }
+}

--- a/src/Riok.Mapperly/Descriptors/Mappings/TypeMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/TypeMapping.cs
@@ -8,10 +8,11 @@ namespace Riok.Mapperly.Descriptors.Mappings;
 [DebuggerDisplay("{GetType()}({SourceType.Name} => {TargetType.Name})")]
 public abstract class TypeMapping : ITypeMapping
 {
-    protected TypeMapping(ITypeSymbol sourceType, ITypeSymbol targetType)
+    protected TypeMapping(ITypeSymbol sourceType, ITypeSymbol targetType, RefKind targetRefKind = RefKind.None)
     {
         SourceType = sourceType;
         TargetType = targetType;
+        TargetRefKind = targetRefKind;
     }
 
     public ITypeSymbol SourceType { get; }
@@ -23,6 +24,8 @@ public abstract class TypeMapping : ITypeMapping
 
     /// <inheritdoc cref="ITypeMapping.IsSynthetic"/>
     public virtual bool IsSynthetic => false;
+
+    public RefKind TargetRefKind { get; }
 
     public abstract ExpressionSyntax Build(TypeMappingBuildContext ctx);
 }

--- a/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
+++ b/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
@@ -9,6 +9,8 @@ public class WellKnownTypes
 {
     private readonly Compilation _compilation;
 
+    private INamedTypeSymbol? _string;
+
     private INamedTypeSymbol? _referenceHandlerAttribute;
     private INamedTypeSymbol? _objectFactoryAttribute;
     private INamedTypeSymbol? _mapperConstructorAttribute;
@@ -18,6 +20,7 @@ public class WellKnownTypes
     private INamedTypeSymbol? _iReferenceHandler;
     private INamedTypeSymbol? _preserveReferenceHandler;
 
+    private INamedTypeSymbol? _iList;
     private INamedTypeSymbol? _iDictionary;
     private INamedTypeSymbol? _iReadOnlyDictionary;
     private INamedTypeSymbol? _iEnumerable;
@@ -32,12 +35,14 @@ public class WellKnownTypes
         _compilation = compilation;
     }
 
+    public INamedTypeSymbol String => _string ??= GetTypeSymbol(typeof(string));
     public INamedTypeSymbol ReferenceHandlerAttribute => _referenceHandlerAttribute ??= GetTypeSymbol(typeof(ReferenceHandlerAttribute));
     public INamedTypeSymbol ObjectFactoryAttribute => _objectFactoryAttribute ??= GetTypeSymbol(typeof(ObjectFactoryAttribute));
     public INamedTypeSymbol MapperConstructorAttribute => _mapperConstructorAttribute ??= GetTypeSymbol(typeof(MapperConstructorAttribute));
     public INamedTypeSymbol ObsoleteAttribute => _obsoleteAttribute ??= GetTypeSymbol(typeof(ObsoleteAttribute));
     public INamedTypeSymbol IReferenceHandler => _iReferenceHandler ??= GetTypeSymbol(typeof(IReferenceHandler));
     public INamedTypeSymbol PreserveReferenceHandler => _preserveReferenceHandler ??= GetTypeSymbol(typeof(PreserveReferenceHandler));
+    public INamedTypeSymbol IList => _iList ??= GetTypeSymbol(typeof(IList<>));
     public INamedTypeSymbol IDictionary => _iDictionary ??= GetTypeSymbol(typeof(IDictionary<,>));
     public INamedTypeSymbol IReadOnlyDictionary => _iReadOnlyDictionary ??= GetTypeSymbol(typeof(IReadOnlyDictionary<,>));
     public INamedTypeSymbol IEnumerable => _iEnumerable ??= GetTypeSymbol(typeof(IEnumerable<>));

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -70,10 +70,10 @@ internal static class DiagnosticDescriptors
         DiagnosticSeverity.Error,
         true);
 
-    public static readonly DiagnosticDescriptor CannotMapToReadOnlyProperty = new DiagnosticDescriptor(
+    public static readonly DiagnosticDescriptor CannotMapToReadOnlyValueProperty = new DiagnosticDescriptor(
         "RMG009",
-        "Cannot map to read only property",
-        "Cannot map property {0}.{1} of type {2} to read only property {3}.{4} of type {5}",
+        "Cannot map to read only value property",
+        "Cannot map property {0}.{1} of type {2} to read only property {3}.{4} of value type {5}",
         DiagnosticCategories.Mapper,
         DiagnosticSeverity.Info,
         true);

--- a/src/Riok.Mapperly/Emit/SyntaxFactoryHelper.cs
+++ b/src/Riok.Mapperly/Emit/SyntaxFactoryHelper.cs
@@ -175,8 +175,7 @@ public static class SyntaxFactoryHelper
 
     public static ParameterSyntax Parameter(bool addThisKeyword, MethodParameter parameter)
     {
-        var param = SyntaxFactory.Parameter(Identifier(parameter.Name))
-            .WithType(IdentifierName(parameter.Type.ToDisplayString()));
+        ParameterSyntax param = SyntaxFactory.Parameter(Identifier(parameter.Name)).WithType(IdentifierName(parameter.Type.ToDisplayString()));
 
         if (addThisKeyword && parameter.Ordinal == 0)
         {

--- a/src/Riok.Mapperly/MapperGenerator.cs
+++ b/src/Riok.Mapperly/MapperGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -18,6 +19,14 @@ public class MapperGenerator : IIncrementalGenerator
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
+#if DEBUG
+        if (!Debugger.IsAttached)
+        {
+            // Uncomment out when debugging launcher, don't leave this uncommented because it
+            // will screw up vs when launching
+            // Debugger.Launch();
+        }
+#endif
         var mapperClassDeclarations = context.SyntaxProvider
             .CreateSyntaxProvider(
                 static (s, _) => IsSyntaxTargetForGeneration(s),

--- a/src/Riok.Mapperly/Symbols/MethodParameter.cs
+++ b/src/Riok.Mapperly/Symbols/MethodParameter.cs
@@ -6,11 +6,12 @@ namespace Riok.Mapperly.Symbols;
 
 public readonly struct MethodParameter
 {
-    public MethodParameter(int ordinal, string name, ITypeSymbol type)
+    public MethodParameter(int ordinal, string name, ITypeSymbol type, RefKind refKind = RefKind.None)
     {
         Ordinal = ordinal;
         Name = name;
         Type = type;
+        RefKind = refKind;
     }
 
     public MethodParameter(IParameterSymbol symbol)
@@ -23,6 +24,8 @@ public readonly struct MethodParameter
     public string Name { get; }
 
     public ITypeSymbol Type { get; }
+
+    public RefKind RefKind { get; }
 
     public MethodArgument WithArgument(ExpressionSyntax? argument)
         => new(this, argument ?? throw new ArgumentNullException(nameof(argument)));

--- a/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDto.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDto.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Riok.Mapperly.IntegrationTests.Models;
 
 namespace Riok.Mapperly.IntegrationTests.Dto
@@ -63,6 +64,11 @@ namespace Riok.Mapperly.IntegrationTests.Dto
         public InheritanceSubObjectDto? SubObject { get; set; }
 
         public string? IgnoredStringValue { get; set; }
+
         public int IgnoredIntValue { get; set; }
+
+        private readonly IList<int> _readOnlyList = new List<int>();
+
+        public IList<int> ReadOnlyList { get => _readOnlyList; }
     }
 }

--- a/test/Riok.Mapperly.IntegrationTests/Models/TestObject.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Models/TestObject.cs
@@ -63,5 +63,9 @@ namespace Riok.Mapperly.IntegrationTests.Models
         public string? IgnoredStringValue { get; set; }
 
         public int IgnoredIntValue { get; set; }
+
+        public readonly IList<int> _readOnlyList = new List<int>();
+
+        public IList<int> ReadOnlyList { get => _readOnlyList; }
     }
 }

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
@@ -431,7 +431,7 @@ public class EnumerableTest
         var source = TestSourceBuilder.Mapping(
             "A",
             "B",
-            "class A { public C[] Value { get; set;} }",
+            "class A { public C[] Value { get; set; } }",
             "class B { public D[] Value { get; set; } }",
             "class C { public string Value { get; set; } }",
             "class D { public string Value { get; set; } }");


### PR DESCRIPTION
This PR addresses #226 by introducing a new pathway for generating and keeping track of reference based mappings inside of mapperly.  This should allow (for example) and IList to IList map to still be a simple assignment, but special cases and IList to readonly IList mapping to be via adding to an existing IList reference.  