### PR TITLE
fix: register output as implementation source output

### DIFF
--- a/docs/docs/02-configuration/12-analyzer-diagnostics.mdx
+++ b/docs/docs/02-configuration/12-analyzer-diagnostics.mdx
@@ -6,6 +6,15 @@ Mapperly emits several diagnostics:
 
 <AnalyzerRules></AnalyzerRules>
 
+:::info
+Mapperly only emits updated source code on build.
+You won't see the updated mapper code or mapper diagnostics until you perform a build.
+
+This is done for performance reasons,
+otherwise the IDE could become laggy.
+Improvements are tracked in [#72](https://github.com/riok/mapperly/issues/72).
+:::
+
 ## Editorconfig
 
 The severity of these diagnostics can be customized via an `.editorconfig` file:

--- a/docs/docs/02-configuration/13-generated-source.mdx
+++ b/docs/docs/02-configuration/13-generated-source.mdx
@@ -55,3 +55,12 @@ dotnet build /p:EmitCompilerGeneratedFiles=true /p:CompilerGeneratedFilesOutputP
 
 </TabItem>
 </Tabs>
+
+:::info
+Mapperly only emits updated source code on build.
+You won't see the updated mapper code or mapper diagnostics until you perform a build.
+
+This is done for performance reasons,
+otherwise the IDE could become laggy.
+Improvements are tracked in [#72](https://github.com/riok/mapperly/issues/72).
+:::

--- a/src/Riok.Mapperly/MapperGenerator.cs
+++ b/src/Riok.Mapperly/MapperGenerator.cs
@@ -25,7 +25,7 @@ public class MapperGenerator : IIncrementalGenerator
             .WhereNotNull();
 
         var compilationAndMappers = context.CompilationProvider.Combine(mapperClassDeclarations.Collect());
-        context.RegisterSourceOutput(compilationAndMappers, static (spc, source) => Execute(source.Left, source.Right, spc));
+        context.RegisterImplementationSourceOutput(compilationAndMappers, static (spc, source) => Execute(source.Left, source.Right, spc));
     }
 
     private static bool IsSyntaxTargetForGeneration(SyntaxNode node)


### PR DESCRIPTION
To address performance issues register output as implementation source output until #72 is addressed.