### PR TITLE
fix: add target type to the RMG012 diagnostic

### DIFF
--- a/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
@@ -15,7 +15,7 @@ RMG008  | Mapper   | Error    | Could not create mapping.
 RMG009  | Mapper   | Info     | Cannot map to read only property.
 RMG010  | Mapper   | Info     | Cannot map from write only property.
 RMG011  | Mapper   | Info     | Cannot map to write only property path.
-RMG012  | Mapper   | Info     | Mapping source property not found.
+RMG012  | Mapper   | Info     | Source property was not found for target property
 RMG013  | Mapper   | Error    | No accessible constructor with mappable arguments found
 RMG014  | Mapper   | Warning  | Cannot map to the configured constructor to be used by Mapperly
 RMG015  | Mapper   | Info     | Cannot map to init only property path

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectPropertyMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectPropertyMappingBodyBuilder.cs
@@ -56,6 +56,7 @@ public static class NewInstanceObjectPropertyMappingBodyBuilder
                         ? DiagnosticDescriptors.RequiredPropertyNotMapped
                         : DiagnosticDescriptors.SourcePropertyNotFound,
                     targetProperty.Name,
+                    ctx.Mapping.TargetType,
                     ctx.Mapping.SourceType);
                 continue;
             }
@@ -97,6 +98,7 @@ public static class NewInstanceObjectPropertyMappingBodyBuilder
             ctx.BuilderContext.ReportDiagnostic(
                 DiagnosticDescriptors.SourcePropertyNotFound,
                 targetProperty.Name,
+                ctx.Mapping.TargetType,
                 ctx.Mapping.SourceType);
             return;
         }
@@ -314,6 +316,7 @@ public static class NewInstanceObjectPropertyMappingBodyBuilder
             ctx.BuilderContext.ReportDiagnostic(
                 DiagnosticDescriptors.SourcePropertyNotFound,
                 propertyConfig.Source,
+                ctx.Mapping.TargetType,
                 ctx.Mapping.SourceType);
             return false;
         }

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectPropertyMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectPropertyMappingBodyBuilder.cs
@@ -50,6 +50,7 @@ public static class ObjectPropertyMappingBodyBuilder
                 ctx.BuilderContext.ReportDiagnostic(
                     DiagnosticDescriptors.SourcePropertyNotFound,
                     targetProperty.Name,
+                    ctx.Mapping.TargetType,
                     ctx.Mapping.SourceType);
                 continue;
             }

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -96,8 +96,8 @@ internal static class DiagnosticDescriptors
 
     public static readonly DiagnosticDescriptor SourcePropertyNotFound = new DiagnosticDescriptor(
         "RMG012",
-        "Mapping source property not found",
-        "Property {0} on source type {1} was not found",
+        "Source property was not found for target property",
+        "The property {0} on the mapping target type {1} was not found on the mapping source type {2}",
         DiagnosticCategories.Mapper,
         DiagnosticSeverity.Info,
         true);
@@ -185,7 +185,7 @@ internal static class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor RequiredPropertyNotMapped = new DiagnosticDescriptor(
         "RMG023",
         "Source property was not found for required target property",
-        "Required property {0} on mapping target type was not found on the mapping source type {1}",
+        "Required property {0} on mapping target type {1} was not found on the mapping source type {2}",
         DiagnosticCategories.Mapper,
         DiagnosticSeverity.Error,
         true);

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyIgnoreTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyIgnoreTest.cs
@@ -34,7 +34,7 @@ public class ObjectPropertyIgnoreTest
         TestHelper.GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
             .HaveDiagnostic(new(DiagnosticDescriptors.SourcePropertyNotMapped, "The property StringValue2 on the mapping source type A is not mapped to any property on the mapping target type B"))
-            .HaveDiagnostic(new(DiagnosticDescriptors.SourcePropertyNotFound, "Property StringValue on source type A was not found"))
+            .HaveDiagnostic(new(DiagnosticDescriptors.SourcePropertyNotFound, "The property StringValue on the mapping target type B was not found on the mapping source type A"))
             .HaveSingleMethodBody("target.IntValue = source.IntValue;");
     }
 
@@ -48,7 +48,7 @@ public class ObjectPropertyIgnoreTest
 
         TestHelper.GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
-            .HaveDiagnostic(new(DiagnosticDescriptors.SourcePropertyNotFound, "Property IntValue on source type A was not found"))
+            .HaveDiagnostic(new(DiagnosticDescriptors.SourcePropertyNotFound, "The property IntValue on the mapping target type B was not found on the mapping source type A"))
             .HaveSingleMethodBody(
                 """
                 var target = new B();

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyInitPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyInitPropertyTest.cs
@@ -201,7 +201,7 @@ public class ObjectPropertyInitPropertyTest
 
         TestHelper.GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
-            .HaveDiagnostic(new(DiagnosticDescriptors.SourcePropertyNotFound, "Property StringValue on source type A was not found"))
+            .HaveDiagnostic(new(DiagnosticDescriptors.SourcePropertyNotFound, "The property StringValue on the mapping target type B was not found on the mapping source type A"))
             .HaveDiagnostic(new(DiagnosticDescriptors.SourcePropertyNotMapped, "The property StringValue2 on the mapping source type A is not mapped to any property on the mapping target type B"));
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyInitPropertyTest.InitOnlyPropertyWithConfigurationNotFoundSourcePropertyShouldDiagnostic.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyInitPropertyTest.InitOnlyPropertyWithConfigurationNotFoundSourcePropertyShouldDiagnostic.verified.txt
@@ -2,14 +2,14 @@
   Diagnostics: [
     {
       Id: RMG012,
-      Title: Mapping source property not found,
+      Title: Source property was not found for target property,
       Severity: Info,
       WarningLevel: 1,
       Location: : (11,4)-(11,74),
       Description: ,
       HelpLink: ,
-      MessageFormat: Property {0} on source type {1} was not found,
-      Message: Property StringValue on source type A was not found,
+      MessageFormat: The property {0} on the mapping target type {1} was not found on the mapping source type {2},
+      Message: The property StringValue on the mapping target type B was not found on the mapping source type A,
       Category: Mapper
     },
     {

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyInitPropertyTest.RequiredPropertySourceNotFoundShouldDiagnostic.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyInitPropertyTest.RequiredPropertySourceNotFoundShouldDiagnostic.verified.txt
@@ -8,8 +8,8 @@
       Location: : (11,4)-(11,28),
       Description: ,
       HelpLink: ,
-      MessageFormat: Required property {0} on mapping target type was not found on the mapping source type {1},
-      Message: Required property StringValue on mapping target type was not found on the mapping source type A,
+      MessageFormat: Required property {0} on mapping target type {1} was not found on the mapping source type {2},
+      Message: Required property StringValue on mapping target type B was not found on the mapping source type A,
       Category: Mapper
     },
     {

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.WithManualMappedNotFoundTargetPropertyShouldDiagnostic.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.WithManualMappedNotFoundTargetPropertyShouldDiagnostic.verified.txt
@@ -2,14 +2,14 @@
   Diagnostics: [
     {
       Id: RMG012,
-      Title: Mapping source property not found,
+      Title: Source property was not found for target property,
       Severity: Info,
       WarningLevel: 1,
       Location: : (11,4)-(11,88),
       Description: ,
       HelpLink: ,
-      MessageFormat: Property {0} on source type {1} was not found,
-      Message: Property StringValue2 on source type A was not found,
+      MessageFormat: The property {0} on the mapping target type {1} was not found on the mapping source type {2},
+      Message: The property StringValue2 on the mapping target type B was not found on the mapping source type A,
       Category: Mapper
     },
     {

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.WithPropertyNameMappingStrategyCaseSensitive.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.WithPropertyNameMappingStrategyCaseSensitive.verified.txt
@@ -2,14 +2,14 @@
   Diagnostics: [
     {
       Id: RMG012,
-      Title: Mapping source property not found,
+      Title: Source property was not found for target property,
       Severity: Info,
       WarningLevel: 1,
       Location: : (11,4)-(11,28),
       Description: ,
       HelpLink: ,
-      MessageFormat: Property {0} on source type {1} was not found,
-      Message: Property stringvalue on source type A was not found,
+      MessageFormat: The property {0} on the mapping target type {1} was not found on the mapping source type {2},
+      Message: The property stringvalue on the mapping target type B was not found on the mapping source type A,
       Category: Mapper
     },
     {

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.WithUnmatchedPropertyShouldDiagnostic.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.WithUnmatchedPropertyShouldDiagnostic.verified.txt
@@ -2,14 +2,14 @@
   Diagnostics: [
     {
       Id: RMG012,
-      Title: Mapping source property not found,
+      Title: Source property was not found for target property,
       Severity: Info,
       WarningLevel: 1,
       Location: : (11,4)-(11,28),
       Description: ,
       HelpLink: ,
-      MessageFormat: Property {0} on source type {1} was not found,
-      Message: Property StringValueB on source type A was not found,
+      MessageFormat: The property {0} on the mapping target type {1} was not found on the mapping source type {2},
+      Message: The property StringValueB on the mapping target type B was not found on the mapping source type A,
       Category: Mapper
     },
     {

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ManuallyMappedPropertiesShouldWork.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ManuallyMappedPropertiesShouldWork.verified.txt
@@ -2,26 +2,26 @@
   Diagnostics: [
     {
       Id: RMG012,
-      Title: Mapping source property not found,
+      Title: Source property was not found for target property,
       Severity: Info,
       WarningLevel: 1,
       Location: : (11,4)-(11,65),
       Description: ,
       HelpLink: ,
-      MessageFormat: Property {0} on source type {1} was not found,
-      Message: Property MyValue2 on source type A was not found,
+      MessageFormat: The property {0} on the mapping target type {1} was not found on the mapping source type {2},
+      Message: The property MyValue2 on the mapping target type B was not found on the mapping source type A,
       Category: Mapper
     },
     {
       Id: RMG012,
-      Title: Mapping source property not found,
+      Title: Source property was not found for target property,
       Severity: Info,
       WarningLevel: 1,
       Location: : (11,65)-(11,128),
       Description: ,
       HelpLink: ,
-      MessageFormat: Property {0} on source type {1} was not found,
-      Message: Property MyValue on source type A was not found,
+      MessageFormat: The property {0} on the mapping target type {1} was not found on the mapping source type {2},
+      Message: The property MyValue on the mapping target type B was not found on the mapping source type A,
       Category: Mapper
     }
   ]


### PR DESCRIPTION
RMG023 was also updated to include the target type, due to the way the message is invoked alongside RMG012. The message format of RMG012 was updated to follow the format of RMG020.

This relates to #68 