### PR TITLE
Add ensure capacity for enumerable types.

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacity.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacity.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Descriptors.Mappings;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Riok.Mapperly.Emit.SyntaxFactoryHelper;
+
+namespace Riok.Mapperly.Descriptors.Enumerables.EnsureCapacity;
+
+public abstract class EnsureCapacity
+{
+    private const string EnsureCapacityName = "EnsureCapacity";
+
+    public abstract StatementSyntax Build(TypeMappingBuildContext ctx, ExpressionSyntax target);
+
+    protected static ExpressionStatementSyntax EnsureCapacityStatement(ExpressionSyntax target, ExpressionSyntax sourceCount, ExpressionSyntax targetCount)
+    {
+        var sumMethod = BinaryExpression(SyntaxKind.AddExpression, sourceCount, targetCount);
+        return ExpressionStatement(Invocation(MemberAccess(target, EnsureCapacityName), sumMethod));
+    }
+}

--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityBuilder.cs
@@ -1,0 +1,71 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Riok.Mapperly.Helpers;
+
+namespace Riok.Mapperly.Descriptors.Enumerables.EnsureCapacity;
+
+/// <summary>
+/// Generates an <see cref="EnsureCapacity?"/> of types <see cref="EnsureCapacityNonEnumerated"/> or <see cref="EnsureCapacityMember"/> depending on type information.
+/// </summary>
+public static class EnsureCapacityBuilder
+{
+    private const string EnsureCapacityName = "EnsureCapacity";
+    private const string CountPropertyName = nameof(ICollection<object>.Count);
+    private const string LengthPropertyName = nameof(Array.Length);
+    private const string TryGetNonEnumeratedCountMethodName = "TryGetNonEnumeratedCount";
+
+    public static EnsureCapacity? TryBuildEnsureCapacity(ITypeSymbol sourceType, ITypeSymbol targetType, WellKnownTypes types)
+    {
+        var capacityMethod = targetType.GetAllMethods(EnsureCapacityName)
+                        .OfType<IMethodSymbol>()
+                        .FirstOrDefault(x => x.Parameters.Length == 1
+                        && x.Parameters[0].Type.SpecialType == SpecialType.System_Int32
+                        && !x.IsStatic);
+
+        // if EnsureCapacity is not available then return null
+        if (capacityMethod == null)
+            return null;
+
+        // if target does not have a count then return null
+        if (!TryGetNonEnumeratedCount(targetType, types, out var targetSizeProperty))
+            return null;
+
+        // if target and source count are known then create a simple EnsureCapacity statement
+        if (TryGetNonEnumeratedCount(sourceType, types, out var sourceSizeProperty))
+            return new EnsureCapacityMember(targetSizeProperty, sourceSizeProperty);
+
+        sourceType.ImplementsGeneric(types.IEnumerableT, out var iEnumerable);
+
+        var nonEnumeratedCountMethod = types.Enumerable.GetMembers(TryGetNonEnumeratedCountMethodName)
+                                                        .OfType<IMethodSymbol>()
+                                                        .FirstOrDefault(x => x.ReturnType.SpecialType == SpecialType.System_Boolean && x.IsStatic && x.Parameters.Length == 2 && x.IsGenericMethod);
+
+        // if source does not have a count use GetNonEnumeratedCount, calling EnusureCapacity if count is available
+        var typedNonEnumeratedCount = nonEnumeratedCountMethod.Construct(iEnumerable!.TypeArguments.ToArray());
+        return new EnsureCapacityNonEnumerated(targetSizeProperty, typedNonEnumeratedCount);
+    }
+
+    private static bool TryGetNonEnumeratedCount(ITypeSymbol value, WellKnownTypes types, [NotNullWhen(true)] out string? expression)
+    {
+        if (value.IsArrayType())
+        {
+            expression = LengthPropertyName;
+            return true;
+        }
+
+        if (value.ImplementsGeneric(types.ICollectionT, CountPropertyName, out _, out var hasCollectionCount) && !hasCollectionCount)
+        {
+            expression = CountPropertyName;
+            return true;
+        }
+
+        if (value.ImplementsGeneric(types.IReadOnlyCollectionT, CountPropertyName, out _, out var hasReadOnlyCount) && !hasReadOnlyCount)
+        {
+            expression = CountPropertyName;
+            return true;
+        }
+
+        expression = null;
+        return false;
+    }
+}

--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityMember.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityMember.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Descriptors.Mappings;
+using static Riok.Mapperly.Emit.SyntaxFactoryHelper;
+
+namespace Riok.Mapperly.Descriptors.Enumerables.EnsureCapacity;
+
+/// <summary>
+/// Represents a call to EnsureCapacity on a collection where both the source and targets sizes are accessible.
+/// </summary>
+/// <remarks>
+/// <code>
+/// target.EnsureCapacity(source.Length + target.Count);
+/// </code>
+/// </remarks>
+public class EnsureCapacityMember : EnsureCapacity
+{
+    private readonly string _targetAccessor;
+    private readonly string _sourceAccessor;
+
+    public EnsureCapacityMember(string targetAccessor, string sourceAccessor)
+    {
+        _targetAccessor = targetAccessor;
+        _sourceAccessor = sourceAccessor;
+    }
+
+    public override StatementSyntax Build(TypeMappingBuildContext ctx, ExpressionSyntax target)
+    {
+        return EnsureCapacityStatement(target, MemberAccess(ctx.Source, _sourceAccessor), MemberAccess(target, _targetAccessor));
+    }
+}

--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityNonEnumerated.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityNonEnumerated.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Descriptors.Mappings;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Riok.Mapperly.Emit.SyntaxFactoryHelper;
+
+namespace Riok.Mapperly.Descriptors.Enumerables.EnsureCapacity;
+
+/// <summary>
+/// Represents a call to EnsureCapacity on a collection where there is an attempt
+/// to get the  number of elements in the source collection without enumeration,
+/// calling EnsureCapacity if it is available.
+/// </summary>
+/// <remarks>
+/// <code>
+/// if(Enumerable.TryGetNonEnumeratedCount(source, out var sourceCount)
+///     target.EnsureCapacity(sourceCount + target.Count);
+/// </code>
+/// </remarks>
+public class EnsureCapacityNonEnumerated : EnsureCapacity
+{
+    private readonly string _targetAccessor;
+    private readonly IMethodSymbol _getNonEnumeratedMethod;
+
+    public EnsureCapacityNonEnumerated(string targetAccessor, IMethodSymbol getNonEnumeratedMethod)
+    {
+        _targetAccessor = targetAccessor;
+        _getNonEnumeratedMethod = getNonEnumeratedMethod;
+    }
+
+    public override StatementSyntax Build(TypeMappingBuildContext ctx, ExpressionSyntax target)
+    {
+        var targetCount = MemberAccess(target, _targetAccessor);
+
+        var countIdentifier = Identifier(ctx.NameBuilder.New("sourceCount"));
+        var countIdentifierName = IdentifierName(countIdentifier);
+
+        var enumerableArgument = Argument(ctx.Source);
+
+        var outVarArgument = Argument(
+            DeclarationExpression(
+                VarIdentifier,
+                SingleVariableDesignation(countIdentifier)))
+            .WithRefOrOutKeyword(Token(SyntaxKind.OutKeyword));
+
+        var getNonEnumeratedInvocation = StaticInvocation(_getNonEnumeratedMethod, enumerableArgument, outVarArgument);
+        return IfStatement(getNonEnumeratedInvocation, Block(EnsureCapacityStatement(target, countIdentifierName, targetCount)));
+    }
+}

--- a/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/ForEachAddEnumerableExistingTargetMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/ForEachAddEnumerableExistingTargetMapping.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Descriptors.Enumerables.EnsureCapacity;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Riok.Mapperly.Emit.SyntaxFactoryHelper;
 
@@ -15,16 +16,19 @@ public class ForEachAddEnumerableExistingTargetMapping : ExistingTargetMapping
 
     private readonly ITypeMapping _elementMapping;
     private readonly string _insertMethodName;
+    private readonly EnsureCapacity? _ensureCapacityBuilder;
 
     public ForEachAddEnumerableExistingTargetMapping(
         ITypeSymbol sourceType,
         ITypeSymbol targetType,
         ITypeMapping elementMapping,
-        string insertMethodName)
+        string insertMethodName,
+        EnsureCapacity? ensureCapacityBuilder)
         : base(sourceType, targetType)
     {
         _elementMapping = elementMapping;
         _insertMethodName = insertMethodName;
+        _ensureCapacityBuilder = ensureCapacityBuilder;
     }
 
     public override IEnumerable<StatementSyntax> Build(TypeMappingBuildContext ctx, ExpressionSyntax target)
@@ -33,13 +37,16 @@ public class ForEachAddEnumerableExistingTargetMapping : ExistingTargetMapping
         var convertedSourceItemExpression = _elementMapping.Build(ctx.WithSource(loopItemVariableName));
         var addMethod = MemberAccess(target, _insertMethodName);
 
-        return new StatementSyntax[]
+        var ensureCapacityStatement = _ensureCapacityBuilder?.Build(ctx, target);
+        if (ensureCapacityStatement != null)
         {
-            ForEachStatement(
+            yield return ensureCapacityStatement;
+        }
+
+        yield return ForEachStatement(
                 VarIdentifier,
                 Identifier(loopItemVariableName),
                 ctx.Source,
-                Block(ExpressionStatement(Invocation(addMethod, convertedSourceItemExpression))))
-        };
+                Block(ExpressionStatement(Invocation(addMethod, convertedSourceItemExpression))));
     }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/ForEachAddEnumerableMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ForEachAddEnumerableMapping.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Descriptors.Enumerables.EnsureCapacity;
 using Riok.Mapperly.Descriptors.Mappings.ExistingTarget;
 using Riok.Mapperly.Descriptors.ObjectFactories;
 using static Riok.Mapperly.Emit.SyntaxFactoryHelper;
@@ -19,8 +20,9 @@ public class ForEachAddEnumerableMapping : ExistingTargetMappingMethodWrapper
         ITypeSymbol targetType,
         ITypeMapping elementMapping,
         ObjectFactory? objectFactory,
-        string insertMethodName)
-        : base(new ForEachAddEnumerableExistingTargetMapping(sourceType, targetType, elementMapping, insertMethodName))
+        string insertMethodName,
+        EnsureCapacity? ensureCapacityBuilder)
+        : base(new ForEachAddEnumerableExistingTargetMapping(sourceType, targetType, elementMapping, insertMethodName, ensureCapacityBuilder))
     {
         _objectFactory = objectFactory;
     }

--- a/src/Riok.Mapperly/Emit/SyntaxFactoryHelper.cs
+++ b/src/Riok.Mapperly/Emit/SyntaxFactoryHelper.cs
@@ -240,6 +240,15 @@ public static class SyntaxFactoryHelper
             method.Name,
             arguments);
 
+    public static InvocationExpressionSyntax StaticInvocation(IMethodSymbol method, params ArgumentSyntax[] arguments)
+    {
+        var receiverType = FullyQualifiedIdentifierName(method.ReceiverType?.NonNullable()!) ?? throw new ArgumentNullException(nameof(method.ReceiverType));
+
+        var receiverTypeIdentifier = IdentifierName(receiverType);
+        var methodAccess = MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, receiverTypeIdentifier, IdentifierName(method.Name));
+        return InvocationExpression(methodAccess).WithArgumentList(ArgumentList(arguments));
+    }
+
     public static ForStatementSyntax IncrementalForLoop(string counterName, StatementSyntax body, ExpressionSyntax maxValueExclusive)
     {
         var counterDeclaration = DeclareVariable(counterName, IntLiteral(0));

--- a/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.MapToExistingQueueShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.MapToExistingQueueShouldWork#Mapper.g.verified.cs
@@ -6,6 +6,7 @@ public partial class Mapper
     {
         if (source == null)
             return;
+        target.EnsureCapacity(source.Count + target.Count);
         foreach (var item in source)
         {
             target.Enqueue(MapToB(item));

--- a/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.MapToExistingStackShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.MapToExistingStackShouldWork#Mapper.g.verified.cs
@@ -6,6 +6,7 @@ public partial class Mapper
     {
         if (source == null)
             return;
+        target.EnsureCapacity(source.Count + target.Count);
         foreach (var item in source)
         {
             target.Push(MapToB(item));


### PR DESCRIPTION
Complete #251 for enumerable types. I'm not sure how Explicit `Count` values should be treated, right now it gets the runtime type using the `is` operator. I think it should either try not to get the value or just cast the value so the explicit property can be accessed.

- Added `EnsureCapacityBuilder`, `CanEnsureCapacity` checks if ensure capacity can be used, storing the relevant information in `EnsureCapacityInfo` to be used by `TryBuildEnsureCapacityStatement` when the syntax is built.
  - If both source and target have compile time sizes `TryBuildEnsureCapacityStatement` generates a simple call to `EnsureCapacity`.
  - If source does not have a length/count property, `is` statements are created to check the runtime type, invoking `EnsureCapacity` with the resulting type.
  - Not sure where `EnsureCapacityBuilder` should be placed.
- Added tests, waiting for integration tests from github actions.