### PR TITLE
Fix crash when object to object mapping

### DIFF
--- a/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
@@ -77,4 +77,5 @@ Rule ID | Category | Severity | Notes
 RMG029  | Mapper   | Error    | Queryable projection mappings do not support reference handling
 RMG030  | Mapper   | Error    | Reference loop detected while mapping to an init only property
 RMG031  | Mapper   | Warning  | Reference loop detected while mapping to a constructor property
-RMG032 | Mapper | Warning | The enum mapping strategy ByName cannot be used in projection mappings
+RMG032  | Mapper   | Warning  | The enum mapping strategy ByName cannot be used in projection mappings
+RMG033  | Mapper   | Info     | Object mapped to another object without deep clone

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/SpecialTypeMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/SpecialTypeMappingBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.Descriptors.Mappings;
+using Riok.Mapperly.Diagnostics;
 
 namespace Riok.Mapperly.Descriptors.MappingBuilders;
 
@@ -13,10 +14,18 @@ public static class SpecialTypeMappingBuilder
 
         return ctx.Target.SpecialType switch
         {
+            SpecialType.System_Object when ctx.MapperConfiguration.UseDeepCloning && ctx.Source.SpecialType == SpecialType.System_Object
+                => BuildDeepCloneObjectToObjectMapping(ctx),
             SpecialType.System_Object when ctx.MapperConfiguration.UseDeepCloning
                 => new CastMapping(ctx.Source, ctx.Target, ctx.FindOrBuildMapping(ctx.Source, ctx.Source)),
             SpecialType.System_Object => new CastMapping(ctx.Source, ctx.Target),
             _ => null,
         };
+    }
+
+    private static DirectAssignmentMapping BuildDeepCloneObjectToObjectMapping(MappingBuilderContext ctx)
+    {
+        ctx.ReportDiagnostic(DiagnosticDescriptors.MappedObjectToObjectWithoutDeepClone, ctx.Source.Name, ctx.Target.Name);
+        return new DirectAssignmentMapping(ctx.Source);
     }
 }

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -261,4 +261,12 @@ internal static class DiagnosticDescriptors
         DiagnosticCategories.Mapper,
         DiagnosticSeverity.Warning,
         true);
+
+    public static readonly DiagnosticDescriptor MappedObjectToObjectWithoutDeepClone = new DiagnosticDescriptor(
+        "RMG033",
+        "Object mapped to another object without deep clone",
+        "Object mapped to another object without deep clone, consider implementing the mapping manually",
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Info,
+        true);
 }

--- a/test/Riok.Mapperly.Tests/Mapping/SpecialTypeTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/SpecialTypeTest.cs
@@ -1,3 +1,5 @@
+using Riok.Mapperly.Diagnostics;
+
 namespace Riok.Mapperly.Tests.Mapping;
 
 public class SpecialTypeTest
@@ -25,6 +27,32 @@ public class SpecialTypeTest
         TestHelper.GenerateMapper(source)
             .Should()
             .HaveMapMethodBody("return (object)MapToA(source);");
+    }
+
+    [Fact]
+    public void ObjectToObjectDeepCloning()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "object",
+            "object",
+            TestSourceBuilderOptions.WithDeepCloning);
+        TestHelper.GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveMapMethodBody("return source;")
+            .HaveDiagnostic(new(DiagnosticDescriptors.MappedObjectToObjectWithoutDeepClone));
+    }
+
+    [Fact]
+    public void NullableObjectToNullableObjectDeepCloning()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "object?",
+            "object?",
+            TestSourceBuilderOptions.WithDeepCloning);
+        TestHelper.GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveMapMethodBody("return source == null ? default : source;")
+            .HaveDiagnostic(new(DiagnosticDescriptors.MappedObjectToObjectWithoutDeepClone));
     }
 
     [Fact]


### PR DESCRIPTION
Resolves #313

Resolve ide hanging/crash when object to object mapping when deep clone is enabled. I mentioned my concerns in the issue, is it correct for a simple copy to be used when deep cloning is enabled? Should I instead make this a diagnostic errror or would updating the docs and adding a note to the `UseDeepCloning` attribute be enough?

- Added another branch to `SpecialTypeMappingBuilder` for object->object edge case
- Added object->object and object?->object? tests
