### PR TITLE
fix: Insert a cast to `IDictionary` when an explicit setter is present

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/DictionaryMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/DictionaryMappingBuilder.cs
@@ -11,6 +11,7 @@ namespace Riok.Mapperly.Descriptors.MappingBuilders;
 public static class DictionaryMappingBuilder
 {
     private const string CountPropertyName = nameof(IDictionary<object, object>.Count);
+    private const string SetterIndexerPropertyName = "set_Item";
 
     private const string ToImmutableDictionaryMethodName = nameof(ImmutableDictionary.ToImmutableDictionary);
     private const string ToImmutableSortedDictionaryMethodName = nameof(ImmutableSortedDictionary.ToImmutableSortedDictionary);
@@ -64,7 +65,8 @@ public static class DictionaryMappingBuilder
             keyMapping,
             valueMapping,
             false,
-            objectFactory: objectFactory);
+            objectFactory: objectFactory,
+            explicitCast: GetExplicitIndexer(ctx));
     }
 
     public static IExistingTargetMapping? TryBuildExistingTargetMapping(MappingBuilderContext ctx)
@@ -87,7 +89,8 @@ public static class DictionaryMappingBuilder
             ctx.Source,
             ctx.Target,
             keyMapping,
-            valueMapping);
+            valueMapping,
+            explicitCast: GetExplicitIndexer(ctx));
     }
 
     private static (ITypeMapping, ITypeMapping)? BuildKeyValueMapping(MappingBuilderContext ctx)
@@ -148,6 +151,14 @@ public static class DictionaryMappingBuilder
         return (enumeratedType.TypeArguments[0], enumeratedType.TypeArguments[1]);
     }
 
+    private static INamedTypeSymbol? GetExplicitIndexer(MappingBuilderContext ctx)
+    {
+        if (ctx.Target.ImplementsGeneric(ctx.Types.IDictionaryT, SetterIndexerPropertyName, out var typedInter, out var isExplicit) && !isExplicit)
+            return null;
+
+        return typedInter;
+    }
+
     private static LinqDicitonaryMapping? ResolveImmutableCollectMethod(MappingBuilderContext ctx, ITypeMapping keyMapping, ITypeMapping valueMapping)
     {
         if (SymbolEqualityComparer.Default.Equals(ctx.Target.OriginalDefinition, ctx.Types.ImmutableSortedDictionaryT))
@@ -159,4 +170,5 @@ public static class DictionaryMappingBuilder
 
         return null;
     }
+
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/ForEachSetDictionaryExistingTargetMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/ForEachSetDictionaryExistingTargetMapping.cs
@@ -12,25 +12,40 @@ namespace Riok.Mapperly.Descriptors.Mappings.ExistingTarget;
 public class ForEachSetDictionaryExistingTargetMapping : ExistingTargetMapping
 {
     private const string LoopItemVariableName = "item";
+    private const string ExplicitCastVariableName = "targetDict";
     private const string KeyPropertyName = nameof(KeyValuePair<object, object>.Key);
     private const string ValuePropertyName = nameof(KeyValuePair<object, object>.Value);
 
     private readonly ITypeMapping _keyMapping;
     private readonly ITypeMapping _valueMapping;
+    private readonly INamedTypeSymbol? _explicitCast;
 
     public ForEachSetDictionaryExistingTargetMapping(
         ITypeSymbol sourceType,
         ITypeSymbol targetType,
         ITypeMapping keyMapping,
-        ITypeMapping valueMapping)
+        ITypeMapping valueMapping,
+        INamedTypeSymbol? explicitCast)
         : base(sourceType, targetType)
     {
         _keyMapping = keyMapping;
         _valueMapping = valueMapping;
+        _explicitCast = explicitCast;
     }
 
     public override IEnumerable<StatementSyntax> Build(TypeMappingBuildContext ctx, ExpressionSyntax target)
     {
+        if (_explicitCast != null)
+        {
+            var type = FullyQualifiedIdentifier(_explicitCast);
+            var cast = CastExpression(type, target);
+
+            var castedVariable = ctx.NameBuilder.New(ExplicitCastVariableName);
+            target = IdentifierName(castedVariable);
+
+            yield return LocalDeclarationStatement(DeclareVariable(castedVariable, cast));
+        }
+
         var loopItemVariableName = ctx.NameBuilder.New(LoopItemVariableName);
 
         var convertedKeyExpression = _keyMapping.Build(ctx.WithSource(MemberAccess(loopItemVariableName, KeyPropertyName)));
@@ -40,13 +55,10 @@ public class ForEachSetDictionaryExistingTargetMapping : ExistingTargetMapping
             ElementAccess(target, convertedKeyExpression),
             convertedValueExpression);
 
-        return new StatementSyntax[]
-        {
-            ForEachStatement(
+        yield return ForEachStatement(
                 VarIdentifier,
                 Identifier(loopItemVariableName),
                 ctx.Source,
-                Block(ExpressionStatement(assignment))),
-        };
+                Block(ExpressionStatement(assignment)));
     }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/ForEachSetDictionaryMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ForEachSetDictionaryMapping.cs
@@ -25,8 +25,9 @@ public class ForEachSetDictionaryMapping : ExistingTargetMappingMethodWrapper
         ITypeMapping valueMapping,
         bool sourceHasCount,
         ITypeSymbol? typeToInstantiate = null,
-        ObjectFactory? objectFactory = null)
-        : base(new ForEachSetDictionaryExistingTargetMapping(sourceType, targetType, keyMapping, valueMapping))
+        ObjectFactory? objectFactory = null,
+        INamedTypeSymbol? explicitCast = null)
+        : base(new ForEachSetDictionaryExistingTargetMapping(sourceType, targetType, keyMapping, valueMapping, explicitCast))
     {
         _sourceHasCount = sourceHasCount;
         _objectFactory = objectFactory;


### PR DESCRIPTION
Resolves #286
- Looks for an explicit setter, casting the target dictionary if one is found. - not sure if `GetExplicitIndexer` should be in `DictionaryMappingBuilder` or `ForEachSetDictionaryExistingTargetMapping`
- All casts use the global type
- Added tests