### PR TITLE
feat: add support for Immutable dictionaries

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
@@ -119,11 +119,11 @@ public static class EnumerableMappingBuilder
     {
         var collectMethod = collectMethodName == null
             ? null
-            : ResolveStaticMethod(ctx.Types.Enumerable, collectMethodName);
+            : ctx.Types.Enumerable.GetStaticGenericMethod(collectMethodName);
 
         var selectMethod = elementMapping.IsSynthetic
             ? null
-            : ResolveStaticMethod(ctx.Types.Enumerable, SelectMethodName);
+            : ctx.Types.Enumerable.GetStaticGenericMethod(SelectMethodName);
 
         return new LinqEnumerableMapping(ctx.Source, ctx.Target, elementMapping, selectMethod, collectMethod);
     }
@@ -145,7 +145,7 @@ public static class EnumerableMappingBuilder
     {
         var selectMethod = elementMapping.IsSynthetic
             ? null
-            : ResolveStaticMethod(ctx.Types.Enumerable, SelectMethodName);
+            : ctx.Types.Enumerable.GetStaticGenericMethod(SelectMethodName);
 
         return new LinqConstructorMapping(ctx.Source, ctx.Target, elementMapping, selectMethod);
     }
@@ -210,7 +210,7 @@ public static class EnumerableMappingBuilder
 
         var selectMethod = elementMapping.IsSynthetic
             ? null
-            : ResolveStaticMethod(ctx.Types.Enumerable, SelectMethodName);
+            : ctx.Types.Enumerable.GetStaticGenericMethod(SelectMethodName);
 
         return new LinqEnumerableMapping(ctx.Source, ctx.Target, elementMapping, selectMethod, collectMethod);
     }
@@ -218,31 +218,24 @@ public static class EnumerableMappingBuilder
     private static IMethodSymbol? ResolveImmutableCollectMethod(MappingBuilderContext ctx)
     {
         if (SymbolEqualityComparer.Default.Equals(ctx.Target.OriginalDefinition, ctx.Types.ImmutableArrayT))
-            return ResolveStaticMethod(ctx.Types.ImmutableArray, ToImmutableArrayMethodName);
+            return ctx.Types.ImmutableArray.GetStaticGenericMethod(ToImmutableArrayMethodName);
 
         if (SymbolEqualityComparer.Default.Equals(ctx.Target.OriginalDefinition, ctx.Types.ImmutableListT))
-            return ResolveStaticMethod(ctx.Types.ImmutableList, ToImmutableListMethodName);
+            return ctx.Types.ImmutableList.GetStaticGenericMethod(ToImmutableListMethodName);
 
         if (SymbolEqualityComparer.Default.Equals(ctx.Target.OriginalDefinition, ctx.Types.ImmutableHashSetT))
-            return ResolveStaticMethod(ctx.Types.ImmutableHashSet, ToImmutableHashSetMethodName);
+            return ctx.Types.ImmutableHashSet.GetStaticGenericMethod(ToImmutableHashSetMethodName);
 
         if (SymbolEqualityComparer.Default.Equals(ctx.Target.OriginalDefinition, ctx.Types.ImmutableQueueT))
-            return ResolveStaticMethod(ctx.Types.ImmutableQueue, CreateRangeQueueMethodName);
+            return ctx.Types.ImmutableQueue.GetStaticGenericMethod(CreateRangeQueueMethodName);
 
         if (SymbolEqualityComparer.Default.Equals(ctx.Target.OriginalDefinition, ctx.Types.ImmutableStackT))
-            return ResolveStaticMethod(ctx.Types.ImmutableStack, CreateRangeStackMethodName);
+            return ctx.Types.ImmutableStack.GetStaticGenericMethod(CreateRangeStackMethodName);
 
         if (SymbolEqualityComparer.Default.Equals(ctx.Target.OriginalDefinition, ctx.Types.ImmutableSortedSetT))
-            return ResolveStaticMethod(ctx.Types.ImmutableSortedSet, ToImmutableSortedSetMethodName);
+            return ctx.Types.ImmutableSortedSet.GetStaticGenericMethod(ToImmutableSortedSetMethodName);
 
         return null;
-    }
-
-    private static IMethodSymbol? ResolveStaticMethod(INamedTypeSymbol namedType, string methodName)
-    {
-        return namedType.GetMembers(methodName)
-            .OfType<IMethodSymbol>()
-            .FirstOrDefault(m => m.IsStatic && m.IsGenericMethod);
     }
 
     private static ITypeSymbol? GetEnumeratedType(MappingBuilderContext ctx, ITypeSymbol type)

--- a/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/ForEachSetDictionaryExistingTargetMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/ForEachSetDictionaryExistingTargetMapping.cs
@@ -12,8 +12,8 @@ namespace Riok.Mapperly.Descriptors.Mappings.ExistingTarget;
 public class ForEachSetDictionaryExistingTargetMapping : ExistingTargetMapping
 {
     private const string LoopItemVariableName = "item";
-    private const string KeyValueKeyPropertyName = nameof(KeyValuePair<object, object>.Key);
-    private const string KeyValueValuePropertyName = nameof(KeyValuePair<object, object>.Value);
+    private const string KeyPropertyName = nameof(KeyValuePair<object, object>.Key);
+    private const string ValuePropertyName = nameof(KeyValuePair<object, object>.Value);
 
     private readonly ITypeMapping _keyMapping;
     private readonly ITypeMapping _valueMapping;
@@ -33,8 +33,8 @@ public class ForEachSetDictionaryExistingTargetMapping : ExistingTargetMapping
     {
         var loopItemVariableName = ctx.NameBuilder.New(LoopItemVariableName);
 
-        var convertedKeyExpression = _keyMapping.Build(ctx.WithSource(MemberAccess(loopItemVariableName, KeyValueKeyPropertyName)));
-        var convertedValueExpression = _valueMapping.Build(ctx.WithSource(MemberAccess(loopItemVariableName, KeyValueValuePropertyName)));
+        var convertedKeyExpression = _keyMapping.Build(ctx.WithSource(MemberAccess(loopItemVariableName, KeyPropertyName)));
+        var convertedValueExpression = _valueMapping.Build(ctx.WithSource(MemberAccess(loopItemVariableName, ValuePropertyName)));
 
         var assignment = Assignment(
             ElementAccess(target, convertedKeyExpression),

--- a/src/Riok.Mapperly/Descriptors/Mappings/LinqDictionaryMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/LinqDictionaryMapping.cs
@@ -1,0 +1,56 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Riok.Mapperly.Emit.SyntaxFactoryHelper;
+
+namespace Riok.Mapperly.Descriptors.Mappings;
+
+/// <summary>
+/// Represents an enumerable mapping which works by using linq (select + collect).
+/// </summary>
+public class LinqDicitonaryMapping : TypeMapping
+{
+    private const string LambdaParamName = "x";
+
+    private const string KeyPropertyName = nameof(KeyValuePair<object, object>.Key);
+    private const string ValuePropertyName = nameof(KeyValuePair<object, object>.Value);
+
+    private readonly IMethodSymbol _collectMethod;
+    private readonly ITypeMapping _keyMapping;
+    private readonly ITypeMapping _valueMapping;
+
+    public LinqDicitonaryMapping(
+        ITypeSymbol sourceType,
+        ITypeSymbol targetType,
+        IMethodSymbol collectMethod,
+        ITypeMapping keyMapping,
+        ITypeMapping valueMapping)
+        : base(sourceType, targetType)
+    {
+        _collectMethod = collectMethod;
+        _keyMapping = keyMapping;
+        _valueMapping = valueMapping;
+    }
+
+    public override ExpressionSyntax Build(TypeMappingBuildContext ctx)
+    {
+        var lambdaParamName = ctx.NameBuilder.New(LambdaParamName);
+
+        // if key and value types do not change then use a simple call
+        // ie: source.ToImmutableDictionary();
+        if (_keyMapping.IsSynthetic && _valueMapping.IsSynthetic)
+            return StaticInvocation(_collectMethod, ctx.Source);
+
+        // create expressions mapping the key and value and then create the final expression
+        // ie: source.ToImmutableDictionary(x => x.Key, x=> (int)x.Value);
+        var keyMapExpression = _keyMapping.Build(ctx.WithSource(MemberAccess(lambdaParamName, KeyPropertyName)));
+        var keyExpression = SimpleLambdaExpression(Parameter(Identifier(lambdaParamName)))
+            .WithExpressionBody(keyMapExpression);
+
+        var valueMapExpression = _valueMapping.Build(ctx.WithSource(MemberAccess(lambdaParamName, ValuePropertyName)));
+        var valueExpression = SimpleLambdaExpression(Parameter(Identifier(lambdaParamName)))
+            .WithExpressionBody(valueMapExpression);
+
+        return StaticInvocation(_collectMethod, ctx.Source, keyExpression, valueExpression);
+    }
+}

--- a/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
+++ b/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
@@ -49,6 +49,7 @@ public class WellKnownTypes
     private INamedTypeSymbol? _immutableSortedSetT;
     private INamedTypeSymbol? _immutableDictionary;
     private INamedTypeSymbol? _immutableDictionaryT;
+    private INamedTypeSymbol? _iImmutableDictionaryT;
     private INamedTypeSymbol? _immutableSortedDictionary;
     private INamedTypeSymbol? _immutableSortedDictionaryT;
 
@@ -98,7 +99,9 @@ public class WellKnownTypes
     public INamedTypeSymbol ImmutableSortedSet => _immutableSortedSet ??= GetTypeSymbol(typeof(ImmutableSortedSet));
     public INamedTypeSymbol ImmutableSortedSetT => _immutableSortedSetT ??= GetTypeSymbol(typeof(ImmutableSortedSet<>));
     public INamedTypeSymbol ImmutableDictionary => _immutableDictionary ??= GetTypeSymbol(typeof(ImmutableDictionary));
+    public INamedTypeSymbol IImmutableDictionaryT => _iImmutableDictionaryT ??= GetTypeSymbol(typeof(IImmutableDictionary<,>));
     public INamedTypeSymbol ImmutableDictionaryT => _immutableDictionaryT ??= GetTypeSymbol(typeof(ImmutableDictionary<,>));
+
     public INamedTypeSymbol ImmutableSortedDictionary => _immutableSortedDictionary ??= GetTypeSymbol(typeof(ImmutableSortedDictionary));
     public INamedTypeSymbol ImmutableSortedDictionaryT => _immutableSortedDictionaryT ??= GetTypeSymbol(typeof(ImmutableSortedDictionary<,>));
 

--- a/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
+++ b/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
@@ -78,6 +78,13 @@ internal static class SymbolExtensions
             .WhereNotNull();
     }
 
+    internal static IMethodSymbol? GetStaticGenericMethod(this INamedTypeSymbol namedType, string methodName)
+    {
+        return namedType.GetMembers(methodName)
+                        .OfType<IMethodSymbol>()
+                        .FirstOrDefault(m => m.IsStatic && m.IsGenericMethod);
+    }
+
     internal static bool ImplementsGeneric(
         this ITypeSymbol t,
         INamedTypeSymbol genericInterfaceSymbol,

--- a/test/Riok.Mapperly.IntegrationTests/BaseMapperTest.cs
+++ b/test/Riok.Mapperly.IntegrationTests/BaseMapperTest.cs
@@ -86,7 +86,9 @@ namespace Riok.Mapperly.IntegrationTests
                 ImmutableHashSetValue = ImmutableHashSet.Create("1", "2", "3"),
                 ImmutableQueueValue = ImmutableQueue.Create("1", "2", "3"),
                 ImmutableStackValue = ImmutableStack.Create("1", "2", "3"),
-                ImmutableSortedSetValue = ImmutableSortedSet.Create("1", "2", "3")
+                ImmutableSortedSetValue = ImmutableSortedSet.Create("1", "2", "3"),
+                ImmutableDictionaryValue = new Dictionary<string, string>() { { "1", "1" }, { "2", "2" }, { "3", "3" } }.ToImmutableDictionary(),
+                ImmutableSortedDictionaryValue = new Dictionary<string, string>() { { "1", "1" }, { "2", "2" }, { "3", "3" } }.ToImmutableSortedDictionary(),
             };
         }
 

--- a/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDto.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDto.cs
@@ -69,6 +69,10 @@ namespace Riok.Mapperly.IntegrationTests.Dto
 
         public ImmutableSortedSet<int> ImmutableSortedSetValue { get; set; } = ImmutableSortedSet<int>.Empty;
 
+        public ImmutableDictionary<int, int> ImmutableDictionaryValue { get; set; } = ImmutableDictionary<int, int>.Empty;
+
+        public ImmutableSortedDictionary<int, int> ImmutableSortedDictionaryValue { get; set; } = ImmutableSortedDictionary<int, int>.Empty;
+
         public TestEnumDtoByValue EnumValue { get; set; }
 
         public TestEnumDtoByName EnumName { get; set; }

--- a/test/Riok.Mapperly.IntegrationTests/Models/TestObject.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Models/TestObject.cs
@@ -66,6 +66,10 @@ namespace Riok.Mapperly.IntegrationTests.Models
 
         public ImmutableSortedSet<string> ImmutableSortedSetValue { get; set; } = ImmutableSortedSet<string>.Empty;
 
+        public ImmutableDictionary<string, string> ImmutableDictionaryValue { get; set; } = ImmutableDictionary<string, string>.Empty;
+
+        public ImmutableSortedDictionary<string, string> ImmutableSortedDictionaryValue { get; set; } = ImmutableSortedDictionary<string, string>.Empty;
+
         public TestEnum EnumValue { get; set; }
 
         public TestEnum EnumName { get; set; }

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/MapperTest.RunMappingShouldWork.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/MapperTest.RunMappingShouldWork.verified.txt
@@ -98,6 +98,16 @@
     2,
     3
   ],
+  ImmutableDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  ImmutableSortedDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
   EnumValue: DtoValue1,
   EnumName: Value10,
   EnumRawValue: 20,

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/MapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/MapperTest.SnapshotGeneratedSource.verified.cs
@@ -106,6 +106,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(testObject.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(testObject.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)testObject.EnumValue;
             target.EnumName = MapToEnumDtoByName(testObject.EnumName);
             target.EnumRawValue = (byte)testObject.EnumRawValue;
@@ -162,6 +164,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x5 => x5.ToString()));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x6 => x6.ToString()));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x7 => x7.ToString()));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(dto.ImmutableDictionaryValue, x8 => x8.Key.ToString(), x8 => x8.Value.ToString());
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(dto.ImmutableSortedDictionaryValue, x9 => x9.Key.ToString(), x9 => x9.Value.ToString());
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumValue;
             target.EnumName = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumName;
             target.EnumRawValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumRawValue;
@@ -233,6 +237,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(source.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(source.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)source.EnumValue;
             target.EnumName = MapToEnumDtoByName(source.EnumName);
             target.EnumRawValue = (byte)source.EnumRawValue;

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/StaticMapperTest.RunExtensionMappingShouldWork.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/StaticMapperTest.RunExtensionMappingShouldWork.verified.txt
@@ -93,6 +93,16 @@
     2,
     3
   ],
+  ImmutableDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  ImmutableSortedDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
   EnumValue: DtoValue1,
   EnumName: Value10,
   EnumRawValue: 20,

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/StaticMapperTest.RunMappingShouldWork.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/StaticMapperTest.RunMappingShouldWork.verified.txt
@@ -98,6 +98,16 @@
     2,
     3
   ],
+  ImmutableDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  ImmutableSortedDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
   EnumValue: DtoValue1,
   EnumName: Value10,
   EnumRawValue: 20,

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -98,6 +98,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(src.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(src.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(src.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(src.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(src.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)src.EnumValue;
             target.EnumName = MapToEnumDtoByName(src.EnumName);
             target.EnumRawValue = (byte)src.EnumRawValue;
@@ -171,6 +173,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(testObject.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(testObject.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)testObject.EnumValue;
             target.EnumName = MapToEnumDtoByName(testObject.EnumName);
             target.EnumRawValue = (byte)testObject.EnumRawValue;
@@ -227,6 +231,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x5 => x5.ToString()));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x6 => x6.ToString()));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x7 => x7.ToString()));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(dto.ImmutableDictionaryValue, x8 => x8.Key.ToString(), x8 => x8.Value.ToString());
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(dto.ImmutableSortedDictionaryValue, x9 => x9.Key.ToString(), x9 => x9.Value.ToString());
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumValue;
             target.EnumName = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumName;
             target.EnumRawValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumRawValue;
@@ -298,6 +304,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(source.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(source.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)source.EnumValue;
             target.EnumName = MapToEnumDtoByName(source.EnumName);
             target.EnumRawValue = (byte)source.EnumRawValue;

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/MapperTest.RunMappingShouldWork.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/MapperTest.RunMappingShouldWork.verified.txt
@@ -98,6 +98,16 @@
     2,
     3
   ],
+  ImmutableDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  ImmutableSortedDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
   EnumValue: DtoValue1,
   EnumName: Value10,
   EnumRawValue: 20,

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/MapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/MapperTest.SnapshotGeneratedSource.verified.cs
@@ -103,6 +103,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(testObject.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(testObject.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)testObject.EnumValue;
             target.EnumName = MapToEnumDtoByName(testObject.EnumName);
             target.EnumRawValue = (byte)testObject.EnumRawValue;
@@ -156,6 +158,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x5 => x5.ToString()));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x6 => x6.ToString()));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x7 => x7.ToString()));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(dto.ImmutableDictionaryValue, x8 => x8.Key.ToString(), x8 => x8.Value.ToString());
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(dto.ImmutableSortedDictionaryValue, x9 => x9.Key.ToString(), x9 => x9.Value.ToString());
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumValue;
             target.EnumName = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumName;
             target.EnumRawValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumRawValue;
@@ -227,6 +231,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(source.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(source.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)source.EnumValue;
             target.EnumName = MapToEnumDtoByName(source.EnumName);
             target.EnumRawValue = (byte)source.EnumRawValue;

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/StaticMapperTest.RunExtensionMappingShouldWork.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/StaticMapperTest.RunExtensionMappingShouldWork.verified.txt
@@ -93,6 +93,16 @@
     2,
     3
   ],
+  ImmutableDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  ImmutableSortedDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
   EnumValue: DtoValue1,
   EnumName: Value10,
   EnumRawValue: 20,

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/StaticMapperTest.RunMappingShouldWork.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/StaticMapperTest.RunMappingShouldWork.verified.txt
@@ -98,6 +98,16 @@
     2,
     3
   ],
+  ImmutableDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  ImmutableSortedDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
   EnumValue: DtoValue1,
   EnumName: Value10,
   EnumRawValue: 20,

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -95,6 +95,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(src.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(src.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(src.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(src.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(src.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)src.EnumValue;
             target.EnumName = MapToEnumDtoByName(src.EnumName);
             target.EnumRawValue = (byte)src.EnumRawValue;
@@ -165,6 +167,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(testObject.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(testObject.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)testObject.EnumValue;
             target.EnumName = MapToEnumDtoByName(testObject.EnumName);
             target.EnumRawValue = (byte)testObject.EnumRawValue;
@@ -218,6 +222,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x5 => x5.ToString()));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x6 => x6.ToString()));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x7 => x7.ToString()));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(dto.ImmutableDictionaryValue, x8 => x8.Key.ToString(), x8 => x8.Value.ToString());
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(dto.ImmutableSortedDictionaryValue, x9 => x9.Key.ToString(), x9 => x9.Value.ToString());
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumValue;
             target.EnumName = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumName;
             target.EnumRawValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumRawValue;
@@ -289,6 +295,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(source.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(source.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)source.EnumValue;
             target.EnumName = MapToEnumDtoByName(source.EnumName);
             target.EnumRawValue = (byte)source.EnumRawValue;

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/MapperTest.RunMappingShouldWork.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/MapperTest.RunMappingShouldWork.verified.txt
@@ -98,6 +98,16 @@
     2,
     3
   ],
+  ImmutableDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  ImmutableSortedDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
   EnumValue: DtoValue1,
   EnumName: Value10,
   EnumRawValue: 20,

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/MapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/MapperTest.SnapshotGeneratedSource.verified.cs
@@ -106,6 +106,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(testObject.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(testObject.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)testObject.EnumValue;
             target.EnumName = MapToEnumDtoByName(testObject.EnumName);
             target.EnumRawValue = (byte)testObject.EnumRawValue;
@@ -162,6 +164,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x5 => x5.ToString()));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x6 => x6.ToString()));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x7 => x7.ToString()));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(dto.ImmutableDictionaryValue, x8 => x8.Key.ToString(), x8 => x8.Value.ToString());
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(dto.ImmutableSortedDictionaryValue, x9 => x9.Key.ToString(), x9 => x9.Value.ToString());
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumValue;
             target.EnumName = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumName;
             target.EnumRawValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumRawValue;
@@ -233,6 +237,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(source.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(source.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)source.EnumValue;
             target.EnumName = MapToEnumDtoByName(source.EnumName);
             target.EnumRawValue = (byte)source.EnumRawValue;

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/StaticMapperTest.RunExtensionMappingShouldWork.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/StaticMapperTest.RunExtensionMappingShouldWork.verified.txt
@@ -93,6 +93,16 @@
     2,
     3
   ],
+  ImmutableDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  ImmutableSortedDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
   EnumValue: DtoValue1,
   EnumName: Value10,
   EnumRawValue: 20,

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/StaticMapperTest.RunMappingShouldWork.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/StaticMapperTest.RunMappingShouldWork.verified.txt
@@ -98,6 +98,16 @@
     2,
     3
   ],
+  ImmutableDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  ImmutableSortedDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
   EnumValue: DtoValue1,
   EnumName: Value10,
   EnumRawValue: 20,

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -98,6 +98,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(src.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(src.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(src.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(src.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(src.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)src.EnumValue;
             target.EnumName = MapToEnumDtoByName(src.EnumName);
             target.EnumRawValue = (byte)src.EnumRawValue;
@@ -171,6 +173,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(testObject.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(testObject.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)testObject.EnumValue;
             target.EnumName = MapToEnumDtoByName(testObject.EnumName);
             target.EnumRawValue = (byte)testObject.EnumRawValue;
@@ -227,6 +231,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x5 => x5.ToString()));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x6 => x6.ToString()));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x7 => x7.ToString()));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(dto.ImmutableDictionaryValue, x8 => x8.Key.ToString(), x8 => x8.Value.ToString());
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(dto.ImmutableSortedDictionaryValue, x9 => x9.Key.ToString(), x9 => x9.Value.ToString());
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumValue;
             target.EnumName = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumName;
             target.EnumRawValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumRawValue;
@@ -298,6 +304,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x6 => ParseableInt(x6)));
             target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x7 => ParseableInt(x7)));
             target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x8 => ParseableInt(x8)));
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(source.ImmutableDictionaryValue, x9 => ParseableInt(x9.Key), x9 => ParseableInt(x9.Value));
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(source.ImmutableSortedDictionaryValue, x10 => ParseableInt(x10.Key), x10 => ParseableInt(x10.Value));
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)source.EnumValue;
             target.EnumName = MapToEnumDtoByName(source.EnumName);
             target.EnumRawValue = (byte)source.EnumRawValue;

--- a/test/Riok.Mapperly.Tests/Mapping/DictionaryTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/DictionaryTest.cs
@@ -251,6 +251,90 @@ public class DictionaryTest
     }
 
     [Fact]
+    public void DictionaryToImmutableDictionary()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "Dictionary<string, string>",
+            "System.Collections.Immutable.ImmutableDictionary<string, string>");
+        TestHelper.GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                return global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(source);
+                """);
+    }
+
+    [Fact]
+    public void DictionaryToImmutableSortedDictionary()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "Dictionary<string, string>",
+            "System.Collections.Immutable.ImmutableSortedDictionary<string, string>");
+        TestHelper.GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                return global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(source);
+                """);
+    }
+
+    [Fact]
+    public void DictionaryToImmutableDictionaryExplicitCastedKeyValue()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "Dictionary<long, long>",
+            "System.Collections.Immutable.ImmutableDictionary<int, int>");
+        TestHelper.GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                return global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(source, x => (int)x.Key, x => (int)x.Value);
+                """);
+    }
+
+    [Fact]
+    public void DictionaryToImmutableDictionaryExplicitCastedValue()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "Dictionary<string, long>",
+            "System.Collections.Immutable.ImmutableDictionary<string, int>");
+        TestHelper.GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                return global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(source, x => x.Key, x => (int)x.Value);
+                """);
+    }
+
+    [Fact]
+    public void EnumerableToReadOnlyImmutableDictionaryShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            "class A { public Dictionary<string, string> Value { get; } }",
+            "class B { public System.Collections.Immutable.ImmutableDictionary<string, string> Value { get; } }");
+
+        TestHelper.GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(new(DiagnosticDescriptors.CannotMapToReadOnlyMember));
+    }
+
+    [Fact]
+    public void EnumerableToReadOnlyImmutableSortedDictionaryShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            "class A { public Dictionary<string, string> Value { get; } }",
+            "class B { public System.Collections.Immutable.ImmutableSortedDictionary<string, string> Value { get; } }");
+
+        TestHelper.GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(new(DiagnosticDescriptors.CannotMapToReadOnlyMember));
+    }
+
+    [Fact]
     public void ReadOnlyDictionaryToReadOnlyDictionaryExistingInstanceShouldIgnore()
     {
         var source = TestSourceBuilder.Mapping(

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
@@ -897,7 +897,7 @@ public class EnumerableTest
             "A",
             "B",
             "class A { public IEnumerable<int> Value { get; } }",
-            "class B { public System.Collections.Immutable.ImmutableList<int> Value { get; } }");
+            "class B { public System.Collections.Immutable.ImmutableArray<int> Value { get; } }");
 
         TestHelper.GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
             .Should()
@@ -910,7 +910,7 @@ public class EnumerableTest
         var source = TestSourceBuilder.Mapping(
             "A",
             "B",
-            "class A { public IEnumerable<int?> Value { get; } }",
+            "class A { public IEnumerable<int> Value { get; } }",
             "class B { public System.Collections.Immutable.ImmutableHashSet<int> Value { get; } }");
 
         TestHelper.GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)


### PR DESCRIPTION
Resolve the last two types from #250 
- Added support for `ImmutableDictionary` and `ImmutableSortedDictionary`
- Added guards to `DictionaryMappingBuilder` to prevent existing immutable types from being assigned to in a foreach loop. - I did not copy the approach of checking for a implicit setter from the Immutable Enumerable types as this would conflict with #341.
- Added tests.