### PR TITLE
fix: add `EnsureCapacity` for dictionary types

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityBuilder.cs
@@ -42,6 +42,10 @@ public static class EnsureCapacityBuilder
                 x => x.ReturnType.SpecialType == SpecialType.System_Boolean && x.IsStatic && x.Parameters.Length == 2 && x.IsGenericMethod
             );
 
+        // if non enumerated method doesnt exist then don't create EnsureCapacity
+        if (nonEnumeratedCountMethod == null)
+            return null;
+
         // if source does not have a count use GetNonEnumeratedCount, calling EnusureCapacity if count is available
         var typedNonEnumeratedCount = nonEnumeratedCountMethod.Construct(iEnumerable!.TypeArguments.ToArray());
         return new EnsureCapacityNonEnumerated(targetSizeProperty, typedNonEnumeratedCount);

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/DictionaryMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/DictionaryMappingBuilder.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Descriptors.Enumerables.EnsureCapacity;
 using Riok.Mapperly.Descriptors.Mappings;
 using Riok.Mapperly.Descriptors.Mappings.ExistingTarget;
 using Riok.Mapperly.Diagnostics;
@@ -64,6 +65,8 @@ public static class DictionaryMappingBuilder
         if (!ctx.Target.ImplementsGeneric(ctx.Types.IDictionaryT, out _))
             return null;
 
+        var ensureCapacityStatement = EnsureCapacityBuilder.TryBuildEnsureCapacity(ctx.Source, ctx.Target, ctx.Types);
+
         return new ForEachSetDictionaryMapping(
             ctx.Source,
             ctx.Target,
@@ -71,7 +74,8 @@ public static class DictionaryMappingBuilder
             valueMapping,
             false,
             objectFactory: objectFactory,
-            explicitCast: GetExplicitIndexer(ctx)
+            explicitCast: GetExplicitIndexer(ctx),
+            ensureCapacity: ensureCapacityStatement
         );
     }
 
@@ -91,12 +95,15 @@ public static class DictionaryMappingBuilder
         }
 
         // add values to dictionary by setting key values in a foreach loop
+        var ensureCapacityStatement = EnsureCapacityBuilder.TryBuildEnsureCapacity(ctx.Source, ctx.Target, ctx.Types);
+
         return new ForEachSetDictionaryExistingTargetMapping(
             ctx.Source,
             ctx.Target,
             keyMapping,
             valueMapping,
-            explicitCast: GetExplicitIndexer(ctx)
+            explicitCast: GetExplicitIndexer(ctx),
+            ensureCapacity: ensureCapacityStatement
         );
     }
 

--- a/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/ForEachSetDictionaryExistingTargetMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/ForEachSetDictionaryExistingTargetMapping.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Descriptors.Enumerables.EnsureCapacity;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Riok.Mapperly.Emit.SyntaxFactoryHelper;
 
@@ -19,19 +20,22 @@ public class ForEachSetDictionaryExistingTargetMapping : ExistingTargetMapping
     private readonly ITypeMapping _keyMapping;
     private readonly ITypeMapping _valueMapping;
     private readonly INamedTypeSymbol? _explicitCast;
+    private readonly EnsureCapacity? _ensureCapacity;
 
     public ForEachSetDictionaryExistingTargetMapping(
         ITypeSymbol sourceType,
         ITypeSymbol targetType,
         ITypeMapping keyMapping,
         ITypeMapping valueMapping,
-        INamedTypeSymbol? explicitCast
+        INamedTypeSymbol? explicitCast,
+        EnsureCapacity? ensureCapacity
     )
         : base(sourceType, targetType)
     {
         _keyMapping = keyMapping;
         _valueMapping = valueMapping;
         _explicitCast = explicitCast;
+        _ensureCapacity = ensureCapacity;
     }
 
     public override IEnumerable<StatementSyntax> Build(TypeMappingBuildContext ctx, ExpressionSyntax target)
@@ -45,6 +49,11 @@ public class ForEachSetDictionaryExistingTargetMapping : ExistingTargetMapping
             target = IdentifierName(castedVariable);
 
             yield return LocalDeclarationStatement(DeclareVariable(castedVariable, cast));
+        }
+
+        if (_ensureCapacity != null)
+        {
+            yield return _ensureCapacity.Build(ctx, target);
         }
 
         var loopItemVariableName = ctx.NameBuilder.New(LoopItemVariableName);

--- a/src/Riok.Mapperly/Descriptors/Mappings/ForEachSetDictionaryMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ForEachSetDictionaryMapping.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Descriptors.Enumerables.EnsureCapacity;
 using Riok.Mapperly.Descriptors.Mappings.ExistingTarget;
 using Riok.Mapperly.Descriptors.ObjectFactories;
 using static Riok.Mapperly.Emit.SyntaxFactoryHelper;
@@ -26,9 +27,12 @@ public class ForEachSetDictionaryMapping : ExistingTargetMappingMethodWrapper
         bool sourceHasCount,
         ITypeSymbol? typeToInstantiate = null,
         ObjectFactory? objectFactory = null,
-        INamedTypeSymbol? explicitCast = null
+        INamedTypeSymbol? explicitCast = null,
+        EnsureCapacity? ensureCapacity = null
     )
-        : base(new ForEachSetDictionaryExistingTargetMapping(sourceType, targetType, keyMapping, valueMapping, explicitCast))
+        : base(
+            new ForEachSetDictionaryExistingTargetMapping(sourceType, targetType, keyMapping, valueMapping, explicitCast, ensureCapacity)
+        )
     {
         _sourceHasCount = sourceHasCount;
         _objectFactory = objectFactory;

--- a/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
+++ b/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
@@ -116,6 +116,12 @@ internal static class SymbolExtensions
             return false;
         }
 
+        if (t.IsAbstract)
+        {
+            isExplicit = false;
+            return true;
+        }
+
         var interfaceSymbol = typedInterface.GetMembers(symbolName).First();
 
         var symbolImplementaton = t.FindImplementationForInterfaceMember(interfaceSymbol);


### PR DESCRIPTION
Resolves #251

- Modifed a bit of #312 to work with dictionaries. 
- Adjusted `ImplementsGeneric` to support interface inheritance, added a guard to `TryBuildEnsureCapacity` because `Dictionary` does have `EnsureCapacity` for older versions.
- Added 3 tests