### PR TITLE
docs: rm unsupported static methods hint

### DIFF
--- a/docs/docs/02-configuration/02-static-mappers.md
+++ b/docs/docs/02-configuration/02-static-mappers.md
@@ -11,7 +11,3 @@ public static partial class CarMapper
     private static int TimeSpanToHours(TimeSpan t) => t.Hours;
 }
 ```
-
-:::info
-Mapperly does not support static partial mapping methods in non-static mapper classes.
-:::


### PR DESCRIPTION
This is supported since https://github.com/riok/mapperly/pull/364