### PR TITLE
Fix unmanaged member deep cloning on .NET Framework.

### DIFF
--- a/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
+++ b/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
@@ -12,7 +12,7 @@ internal static class SymbolExtensions
         symbol.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeSymbol));
 
     internal static bool IsImmutable(this ISymbol symbol) =>
-        symbol is INamedTypeSymbol namedSymbol && (namedSymbol.IsReadOnly || namedSymbol.SpecialType == SpecialType.System_String);
+        symbol is INamedTypeSymbol namedSymbol && (namedSymbol.IsUnmanagedType || namedSymbol.SpecialType == SpecialType.System_String);
 
     internal static bool IsAccessible(this ISymbol symbol, bool allowProtected = false) =>
         symbol.DeclaredAccessibility.HasFlag(Accessibility.Internal)

--- a/test/Riok.Mapperly.IntegrationTests/DeepCloningMapperTest.cs
+++ b/test/Riok.Mapperly.IntegrationTests/DeepCloningMapperTest.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading.Tasks;
+using FluentAssertions;
+using Riok.Mapperly.IntegrationTests.Mapper;
+using Riok.Mapperly.IntegrationTests.Models;
+using VerifyXunit;
+using Xunit;
+
+namespace Riok.Mapperly.IntegrationTests
+{
+    [UsesVerify]
+    public class DeepCloningMapperTest : BaseMapperTest
+    {
+        [Fact]
+        public Task SnapshotGeneratedSource()
+        {
+            var path = GetGeneratedMapperFilePath(nameof(DeepCloningMapper));
+            return Verifier.VerifyFile(path);
+        }
+
+        [Fact]
+        public Task RunMappingShouldWork()
+        {
+            var model = NewTestObj();
+            var dto = DeepCloningMapper.Copy(model);
+            return Verifier.Verify(dto);
+        }
+
+        [Fact]
+        public void RunIdMappingShouldWork()
+        {
+            var source = new IdObject { IdValue = 20 };
+            var copy = DeepCloningMapper.Copy(source);
+            source.Should().NotBeSameAs(copy);
+            copy.IdValue.Should().Be(20);
+        }
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/DeepCloningMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/DeepCloningMapper.cs
@@ -1,0 +1,16 @@
+﻿using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.IntegrationTests.Models;
+
+namespace Riok.Mapperly.IntegrationTests.Mapper
+{
+    [Mapper(UseDeepCloning = true)]
+    public static partial class DeepCloningMapper
+    {
+        public static partial IdObject Copy(IdObject src);
+
+        [MapperIgnoreSource(nameof(TestObject.IgnoredIntValue))]
+        [MapperIgnoreSource(nameof(TestObject.IgnoredStringValue))]
+        [MapperIgnoreSource(nameof(TestObject.ImmutableHashSetValue))]
+        public static partial TestObject Copy(TestObject src);
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/DeepCloningMapperTest.RunMappingShouldWork.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/DeepCloningMapperTest.RunMappingShouldWork.verified.txt
@@ -1,0 +1,113 @@
+﻿{
+  CtorValue: 7,
+  CtorValue2: 100,
+  IntValue: 10,
+  IntInitOnlyValue: 3,
+  RequiredValue: 4,
+  StringValue: fooBar,
+  RenamedStringValue: fooBar2,
+  Flattening: {
+    IdValue: 10
+  },
+  NullableFlattening: {
+    IdValue: 100
+  },
+  UnflatteningIdValue: 20,
+  NullableUnflatteningIdValue: 200,
+  NestedNullable: {
+    IntValue: 100
+  },
+  NestedNullableTargetNotNullable: {},
+  StringNullableTargetNotNullable: fooBar3,
+  RecursiveObject: {
+    CtorValue: 5,
+    CtorValue2: 100,
+    RequiredValue: 4,
+    StringValue: ,
+    RenamedStringValue: ,
+    Flattening: {},
+    ImmutableArrayValue: null,
+    ImmutableQueueValue: [],
+    ImmutableStackValue: [],
+    EnumValue: Value10,
+    EnumName: Value30,
+    EnumReverseStringValue: DtoValue3
+  },
+  SourceTargetSameObjectType: {
+    CtorValue: 8,
+    CtorValue2: 100,
+    IntValue: 99,
+    RequiredValue: 98,
+    StringValue: ,
+    RenamedStringValue: ,
+    Flattening: {},
+    ImmutableArrayValue: null,
+    ImmutableQueueValue: [],
+    ImmutableStackValue: [],
+    EnumReverseStringValue: 
+  },
+  NullableReadOnlyObjectCollection: [
+    {
+      IntValue: 10
+    },
+    {
+      IntValue: 20
+    }
+  ],
+  StackValue: [
+    1,
+    2,
+    3
+  ],
+  QueueValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableArrayValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableListValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableQueueValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableStackValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableSortedSetValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  ImmutableSortedDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  EnumValue: Value10,
+  EnumName: Value10,
+  EnumRawValue: Value20,
+  EnumStringValue: Value30,
+  EnumReverseStringValue: DtoValue3,
+  SubObject: {
+    SubIntValue: 2,
+    BaseIntValue: 1
+  },
+  DateTimeValueTargetDateOnly: 2020-01-03 15:10:05 Utc,
+  DateTimeValueTargetTimeOnly: 2020-01-03 15:10:05 Utc
+}

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/DeepCloningMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/DeepCloningMapperTest.SnapshotGeneratedSource.verified.cs
@@ -1,0 +1,96 @@
+﻿#nullable enable
+namespace Riok.Mapperly.IntegrationTests.Mapper
+{
+    public static partial class DeepCloningMapper
+    {
+        public static partial global::Riok.Mapperly.IntegrationTests.Models.IdObject Copy(global::Riok.Mapperly.IntegrationTests.Models.IdObject src)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Models.IdObject();
+            target.IdValue = src.IdValue;
+            return target;
+        }
+
+        public static partial global::Riok.Mapperly.IntegrationTests.Models.TestObject Copy(global::Riok.Mapperly.IntegrationTests.Models.TestObject src)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Models.TestObject(src.CtorValue, ctorValue2: src.CtorValue2)
+            {
+                IntInitOnlyValue = src.IntInitOnlyValue,
+                RequiredValue = src.RequiredValue
+            };
+            if (src.NullableFlattening != null)
+            {
+                target.NullableFlattening = Copy(src.NullableFlattening);
+            }
+
+            if (src.NestedNullable != null)
+            {
+                target.NestedNullable = MapToTestObjectNested(src.NestedNullable);
+            }
+
+            if (src.NestedNullableTargetNotNullable != null)
+            {
+                target.NestedNullableTargetNotNullable = MapToTestObjectNested(src.NestedNullableTargetNotNullable);
+            }
+
+            if (src.RecursiveObject != null)
+            {
+                target.RecursiveObject = Copy(src.RecursiveObject);
+            }
+
+            if (src.SourceTargetSameObjectType != null)
+            {
+                target.SourceTargetSameObjectType = Copy(src.SourceTargetSameObjectType);
+            }
+
+            if (src.NullableReadOnlyObjectCollection != null)
+            {
+                target.NullableReadOnlyObjectCollection = global::System.Linq.Enumerable.ToArray(global::System.Linq.Enumerable.Select(src.NullableReadOnlyObjectCollection, x => MapToTestObjectNested(x)));
+            }
+
+            if (src.SubObject != null)
+            {
+                target.SubObject = MapToInheritanceSubObject(src.SubObject);
+            }
+
+            target.IntValue = src.IntValue;
+            target.StringValue = src.StringValue;
+            target.RenamedStringValue = src.RenamedStringValue;
+            target.Flattening = Copy(src.Flattening);
+            target.UnflatteningIdValue = src.UnflatteningIdValue;
+            target.NullableUnflatteningIdValue = src.NullableUnflatteningIdValue;
+            target.StringNullableTargetNotNullable = src.StringNullableTargetNotNullable;
+            target.StackValue = new global::System.Collections.Generic.Stack<string>(src.StackValue);
+            target.QueueValue = new global::System.Collections.Generic.Queue<string>(src.QueueValue);
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(src.ImmutableArrayValue);
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(src.ImmutableListValue);
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(src.ImmutableQueueValue);
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(src.ImmutableStackValue);
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(src.ImmutableSortedSetValue);
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(src.ImmutableDictionaryValue);
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(src.ImmutableSortedDictionaryValue);
+            target.EnumValue = src.EnumValue;
+            target.EnumName = src.EnumName;
+            target.EnumRawValue = src.EnumRawValue;
+            target.EnumStringValue = src.EnumStringValue;
+            target.EnumReverseStringValue = src.EnumReverseStringValue;
+            target.DateTimeValueTargetDateOnly = src.DateTimeValueTargetDateOnly;
+            target.DateTimeValueTargetTimeOnly = src.DateTimeValueTargetTimeOnly;
+            return target;
+        }
+
+        private static global::Riok.Mapperly.IntegrationTests.Models.TestObjectNested MapToTestObjectNested(global::Riok.Mapperly.IntegrationTests.Models.TestObjectNested source)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Models.TestObjectNested();
+            target.IntValue = source.IntValue;
+            return target;
+        }
+
+        private static global::Riok.Mapperly.IntegrationTests.Models.InheritanceSubObject MapToInheritanceSubObject(global::Riok.Mapperly.IntegrationTests.Models.InheritanceSubObject source)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Models.InheritanceSubObject();
+            target.SubIntValue = source.SubIntValue;
+            target.BaseIntValue = source.BaseIntValue;
+            return target;
+        }
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/DeepCloningMapperTest.RunMappingShouldWork.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/DeepCloningMapperTest.RunMappingShouldWork.verified.txt
@@ -1,0 +1,113 @@
+﻿{
+  CtorValue: 7,
+  CtorValue2: 100,
+  IntValue: 10,
+  IntInitOnlyValue: 3,
+  RequiredValue: 4,
+  StringValue: fooBar,
+  RenamedStringValue: fooBar2,
+  Flattening: {
+    IdValue: 10
+  },
+  NullableFlattening: {
+    IdValue: 100
+  },
+  UnflatteningIdValue: 20,
+  NullableUnflatteningIdValue: 200,
+  NestedNullable: {
+    IntValue: 100
+  },
+  NestedNullableTargetNotNullable: {},
+  StringNullableTargetNotNullable: fooBar3,
+  RecursiveObject: {
+    CtorValue: 5,
+    CtorValue2: 100,
+    RequiredValue: 4,
+    StringValue: ,
+    RenamedStringValue: ,
+    Flattening: {},
+    ImmutableArrayValue: null,
+    ImmutableQueueValue: [],
+    ImmutableStackValue: [],
+    EnumValue: Value10,
+    EnumName: Value30,
+    EnumReverseStringValue: DtoValue3
+  },
+  SourceTargetSameObjectType: {
+    CtorValue: 8,
+    CtorValue2: 100,
+    IntValue: 99,
+    RequiredValue: 98,
+    StringValue: ,
+    RenamedStringValue: ,
+    Flattening: {},
+    ImmutableArrayValue: null,
+    ImmutableQueueValue: [],
+    ImmutableStackValue: [],
+    EnumReverseStringValue: 
+  },
+  NullableReadOnlyObjectCollection: [
+    {
+      IntValue: 10
+    },
+    {
+      IntValue: 20
+    }
+  ],
+  StackValue: [
+    1,
+    2,
+    3
+  ],
+  QueueValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableArrayValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableListValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableQueueValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableStackValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableSortedSetValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  ImmutableSortedDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  EnumValue: Value10,
+  EnumName: Value10,
+  EnumRawValue: Value20,
+  EnumStringValue: Value30,
+  EnumReverseStringValue: DtoValue3,
+  SubObject: {
+    SubIntValue: 2,
+    BaseIntValue: 1
+  },
+  DateTimeValueTargetDateOnly: 2020-01-03 15:10:05 Utc,
+  DateTimeValueTargetTimeOnly: 2020-01-03 15:10:05 Utc
+}

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/DeepCloningMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/DeepCloningMapperTest.SnapshotGeneratedSource.verified.cs
@@ -1,0 +1,93 @@
+﻿#nullable enable
+namespace Riok.Mapperly.IntegrationTests.Mapper
+{
+    public static partial class DeepCloningMapper
+    {
+        public static partial global::Riok.Mapperly.IntegrationTests.Models.IdObject Copy(global::Riok.Mapperly.IntegrationTests.Models.IdObject src)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Models.IdObject();
+            target.IdValue = src.IdValue;
+            return target;
+        }
+
+        public static partial global::Riok.Mapperly.IntegrationTests.Models.TestObject Copy(global::Riok.Mapperly.IntegrationTests.Models.TestObject src)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Models.TestObject(src.CtorValue, ctorValue2: src.CtorValue2)
+            {IntInitOnlyValue = src.IntInitOnlyValue, RequiredValue = src.RequiredValue};
+            if (src.NullableFlattening != null)
+            {
+                target.NullableFlattening = Copy(src.NullableFlattening);
+            }
+
+            if (src.NestedNullable != null)
+            {
+                target.NestedNullable = MapToTestObjectNested(src.NestedNullable);
+            }
+
+            if (src.NestedNullableTargetNotNullable != null)
+            {
+                target.NestedNullableTargetNotNullable = MapToTestObjectNested(src.NestedNullableTargetNotNullable);
+            }
+
+            if (src.RecursiveObject != null)
+            {
+                target.RecursiveObject = Copy(src.RecursiveObject);
+            }
+
+            if (src.SourceTargetSameObjectType != null)
+            {
+                target.SourceTargetSameObjectType = Copy(src.SourceTargetSameObjectType);
+            }
+
+            if (src.NullableReadOnlyObjectCollection != null)
+            {
+                target.NullableReadOnlyObjectCollection = global::System.Linq.Enumerable.ToArray(global::System.Linq.Enumerable.Select(src.NullableReadOnlyObjectCollection, x => MapToTestObjectNested(x)));
+            }
+
+            if (src.SubObject != null)
+            {
+                target.SubObject = MapToInheritanceSubObject(src.SubObject);
+            }
+
+            target.IntValue = src.IntValue;
+            target.StringValue = src.StringValue;
+            target.RenamedStringValue = src.RenamedStringValue;
+            target.Flattening = Copy(src.Flattening);
+            target.UnflatteningIdValue = src.UnflatteningIdValue;
+            target.NullableUnflatteningIdValue = src.NullableUnflatteningIdValue;
+            target.StringNullableTargetNotNullable = src.StringNullableTargetNotNullable;
+            target.StackValue = new global::System.Collections.Generic.Stack<string>(src.StackValue);
+            target.QueueValue = new global::System.Collections.Generic.Queue<string>(src.QueueValue);
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(src.ImmutableArrayValue);
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(src.ImmutableListValue);
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(src.ImmutableQueueValue);
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(src.ImmutableStackValue);
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(src.ImmutableSortedSetValue);
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(src.ImmutableDictionaryValue);
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(src.ImmutableSortedDictionaryValue);
+            target.EnumValue = src.EnumValue;
+            target.EnumName = src.EnumName;
+            target.EnumRawValue = src.EnumRawValue;
+            target.EnumStringValue = src.EnumStringValue;
+            target.EnumReverseStringValue = src.EnumReverseStringValue;
+            target.DateTimeValueTargetDateOnly = src.DateTimeValueTargetDateOnly;
+            target.DateTimeValueTargetTimeOnly = src.DateTimeValueTargetTimeOnly;
+            return target;
+        }
+
+        private static global::Riok.Mapperly.IntegrationTests.Models.TestObjectNested MapToTestObjectNested(global::Riok.Mapperly.IntegrationTests.Models.TestObjectNested source)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Models.TestObjectNested();
+            target.IntValue = source.IntValue;
+            return target;
+        }
+
+        private static global::Riok.Mapperly.IntegrationTests.Models.InheritanceSubObject MapToInheritanceSubObject(global::Riok.Mapperly.IntegrationTests.Models.InheritanceSubObject source)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Models.InheritanceSubObject();
+            target.SubIntValue = source.SubIntValue;
+            target.BaseIntValue = source.BaseIntValue;
+            return target;
+        }
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/DeepCloningMapperTest.RunMappingShouldWork.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/DeepCloningMapperTest.RunMappingShouldWork.verified.txt
@@ -1,0 +1,113 @@
+﻿{
+  CtorValue: 7,
+  CtorValue2: 100,
+  IntValue: 10,
+  IntInitOnlyValue: 3,
+  RequiredValue: 4,
+  StringValue: fooBar,
+  RenamedStringValue: fooBar2,
+  Flattening: {
+    IdValue: 10
+  },
+  NullableFlattening: {
+    IdValue: 100
+  },
+  UnflatteningIdValue: 20,
+  NullableUnflatteningIdValue: 200,
+  NestedNullable: {
+    IntValue: 100
+  },
+  NestedNullableTargetNotNullable: {},
+  StringNullableTargetNotNullable: fooBar3,
+  RecursiveObject: {
+    CtorValue: 5,
+    CtorValue2: 100,
+    RequiredValue: 4,
+    StringValue: ,
+    RenamedStringValue: ,
+    Flattening: {},
+    ImmutableArrayValue: null,
+    ImmutableQueueValue: [],
+    ImmutableStackValue: [],
+    EnumValue: Value10,
+    EnumName: Value30,
+    EnumReverseStringValue: DtoValue3
+  },
+  SourceTargetSameObjectType: {
+    CtorValue: 8,
+    CtorValue2: 100,
+    IntValue: 99,
+    RequiredValue: 98,
+    StringValue: ,
+    RenamedStringValue: ,
+    Flattening: {},
+    ImmutableArrayValue: null,
+    ImmutableQueueValue: [],
+    ImmutableStackValue: [],
+    EnumReverseStringValue: 
+  },
+  NullableReadOnlyObjectCollection: [
+    {
+      IntValue: 10
+    },
+    {
+      IntValue: 20
+    }
+  ],
+  StackValue: [
+    1,
+    2,
+    3
+  ],
+  QueueValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableArrayValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableListValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableQueueValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableStackValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableSortedSetValue: [
+    1,
+    2,
+    3
+  ],
+  ImmutableDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  ImmutableSortedDictionaryValue: {
+    1: 1,
+    2: 2,
+    3: 3
+  },
+  EnumValue: Value10,
+  EnumName: Value10,
+  EnumRawValue: Value20,
+  EnumStringValue: Value30,
+  EnumReverseStringValue: DtoValue3,
+  SubObject: {
+    SubIntValue: 2,
+    BaseIntValue: 1
+  },
+  DateTimeValueTargetDateOnly: 2020-01-03 15:10:05 Utc,
+  DateTimeValueTargetTimeOnly: 2020-01-03 15:10:05 Utc
+}

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/DeepCloningMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/DeepCloningMapperTest.SnapshotGeneratedSource.verified.cs
@@ -1,0 +1,96 @@
+﻿#nullable enable
+namespace Riok.Mapperly.IntegrationTests.Mapper
+{
+    public static partial class DeepCloningMapper
+    {
+        public static partial global::Riok.Mapperly.IntegrationTests.Models.IdObject Copy(global::Riok.Mapperly.IntegrationTests.Models.IdObject src)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Models.IdObject();
+            target.IdValue = src.IdValue;
+            return target;
+        }
+
+        public static partial global::Riok.Mapperly.IntegrationTests.Models.TestObject Copy(global::Riok.Mapperly.IntegrationTests.Models.TestObject src)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Models.TestObject(src.CtorValue, ctorValue2: src.CtorValue2)
+            {
+                IntInitOnlyValue = src.IntInitOnlyValue,
+                RequiredValue = src.RequiredValue
+            };
+            if (src.NullableFlattening != null)
+            {
+                target.NullableFlattening = Copy(src.NullableFlattening);
+            }
+
+            if (src.NestedNullable != null)
+            {
+                target.NestedNullable = MapToTestObjectNested(src.NestedNullable);
+            }
+
+            if (src.NestedNullableTargetNotNullable != null)
+            {
+                target.NestedNullableTargetNotNullable = MapToTestObjectNested(src.NestedNullableTargetNotNullable);
+            }
+
+            if (src.RecursiveObject != null)
+            {
+                target.RecursiveObject = Copy(src.RecursiveObject);
+            }
+
+            if (src.SourceTargetSameObjectType != null)
+            {
+                target.SourceTargetSameObjectType = Copy(src.SourceTargetSameObjectType);
+            }
+
+            if (src.NullableReadOnlyObjectCollection != null)
+            {
+                target.NullableReadOnlyObjectCollection = global::System.Linq.Enumerable.ToArray(global::System.Linq.Enumerable.Select(src.NullableReadOnlyObjectCollection, x => MapToTestObjectNested(x)));
+            }
+
+            if (src.SubObject != null)
+            {
+                target.SubObject = MapToInheritanceSubObject(src.SubObject);
+            }
+
+            target.IntValue = src.IntValue;
+            target.StringValue = src.StringValue;
+            target.RenamedStringValue = src.RenamedStringValue;
+            target.Flattening = Copy(src.Flattening);
+            target.UnflatteningIdValue = src.UnflatteningIdValue;
+            target.NullableUnflatteningIdValue = src.NullableUnflatteningIdValue;
+            target.StringNullableTargetNotNullable = src.StringNullableTargetNotNullable;
+            target.StackValue = new global::System.Collections.Generic.Stack<string>(src.StackValue);
+            target.QueueValue = new global::System.Collections.Generic.Queue<string>(src.QueueValue);
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(src.ImmutableArrayValue);
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(src.ImmutableListValue);
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(src.ImmutableQueueValue);
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(src.ImmutableStackValue);
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(src.ImmutableSortedSetValue);
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(src.ImmutableDictionaryValue);
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(src.ImmutableSortedDictionaryValue);
+            target.EnumValue = src.EnumValue;
+            target.EnumName = src.EnumName;
+            target.EnumRawValue = src.EnumRawValue;
+            target.EnumStringValue = src.EnumStringValue;
+            target.EnumReverseStringValue = src.EnumReverseStringValue;
+            target.DateTimeValueTargetDateOnly = src.DateTimeValueTargetDateOnly;
+            target.DateTimeValueTargetTimeOnly = src.DateTimeValueTargetTimeOnly;
+            return target;
+        }
+
+        private static global::Riok.Mapperly.IntegrationTests.Models.TestObjectNested MapToTestObjectNested(global::Riok.Mapperly.IntegrationTests.Models.TestObjectNested source)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Models.TestObjectNested();
+            target.IntValue = source.IntValue;
+            return target;
+        }
+
+        private static global::Riok.Mapperly.IntegrationTests.Models.InheritanceSubObject MapToInheritanceSubObject(global::Riok.Mapperly.IntegrationTests.Models.InheritanceSubObject source)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Models.InheritanceSubObject();
+            target.SubIntValue = source.SubIntValue;
+            target.BaseIntValue = source.BaseIntValue;
+            return target;
+        }
+    }
+}

--- a/test/Riok.Mapperly.Tests/Mapping/CastTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/CastTest.cs
@@ -150,8 +150,14 @@ public class CastTest
             "A",
             "B",
             TestSourceBuilderOptions.WithDeepCloning,
-            "struct A { public static explicit operator B(A a) => new(); }",
-            "struct B {}"
+            """
+            struct A
+            {
+                public string Value { get; set; }
+                public static explicit operator B(A a) => new();
+            }
+            """,
+            "struct B { public string Value { get; set; } }"
         );
         TestHelper
             .GenerateMapper(source)
@@ -159,9 +165,23 @@ public class CastTest
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();
+                target.Value = source.Value;
                 return target;
                 """
             );
+    }
+
+    [Fact]
+    public void OperatorExplicitStructWithUnmanagedStructTargetDeepCloning()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithDeepCloning,
+            "struct A { public static explicit operator B(A a) => new(); }",
+            "struct B {}"
+        );
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::B)source;");
     }
 
     [Fact]
@@ -282,8 +302,14 @@ public class CastTest
             "A",
             "B",
             TestSourceBuilderOptions.WithDeepCloning,
-            "struct A { public static implicit operator B(A a) => new(); }",
-            "struct B {}"
+            """
+            struct A
+            {
+                public string Value { get; set; }
+                public static implicit operator B(A a) => new();
+            }
+            """,
+            "struct B { public string Value { get; set; } }"
         );
         TestHelper
             .GenerateMapper(source)
@@ -291,9 +317,23 @@ public class CastTest
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();
+                target.Value = source.Value;
                 return target;
                 """
             );
+    }
+
+    [Fact]
+    public void OperatorImplicitStructWithUnmanagedStructTargetDeepCloning()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithDeepCloning,
+            "struct A { public static implicit operator B(A a) => new(); }",
+            "struct B {}"
+        );
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::B)source;");
     }
 
     [Fact]

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
@@ -221,7 +221,12 @@ public class EnumerableTest
     [Fact]
     public void ArrayToArrayOfMutableStructDeepCloning()
     {
-        var source = TestSourceBuilder.Mapping("A[]", "A[]", TestSourceBuilderOptions.WithDeepCloning, "struct A{}");
+        var source = TestSourceBuilder.Mapping(
+            "A[]",
+            "A[]",
+            TestSourceBuilderOptions.WithDeepCloning,
+            "struct A{ public string Value { get; set; } }"
+        );
         TestHelper
             .GenerateMapper(source)
             .Should()
@@ -239,12 +244,19 @@ public class EnumerableTest
     }
 
     [Fact]
+    public void ArrayToArrayOfUnmanagedStructDeepCloning()
+    {
+        var source = TestSourceBuilder.Mapping("A[]", "A[]", TestSourceBuilderOptions.WithDeepCloning, "struct A{}");
+        TestHelper.GenerateMapper(source).Should().HaveMapMethodBody("return (global::A[])source.Clone();");
+    }
+
+    [Fact]
     public void ArrayToArrayOfMutableStructDeepCloningLoopNameTaken()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             "partial A[] Map(A[] i);",
             TestSourceBuilderOptions.WithDeepCloning,
-            "struct A{}"
+            "struct A{ public string Value { get; set; } }"
         );
         TestHelper
             .GenerateMapper(source)
@@ -268,7 +280,7 @@ public class EnumerableTest
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             "partial A[] Map(A[] target);",
             TestSourceBuilderOptions.WithDeepCloning,
-            "struct A{}"
+            "struct A{ public string Value { get; set; } }"
         );
         TestHelper
             .GenerateMapper(source)

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
@@ -69,15 +69,7 @@ public class ObjectPropertyTest
     public void CustomRefStructToSameCustomStructDeepCloning()
     {
         var source = TestSourceBuilder.Mapping("A", "A", TestSourceBuilderOptions.WithDeepCloning, "ref struct A {}");
-        TestHelper
-            .GenerateMapper(source)
-            .Should()
-            .HaveSingleMethodBody(
-                """
-                var target = new global::A();
-                return target;
-                """
-            );
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return source;");
     }
 
     [Fact]

--- a/test/Riok.Mapperly.Tests/Mapping/SameTypeTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/SameTypeTest.cs
@@ -40,14 +40,34 @@ public class SameTypeTest
     [Fact]
     public void MutableStructToSameMutableStructDeepCloning()
     {
-        var source = TestSourceBuilder.Mapping("A", "A", TestSourceBuilderOptions.WithDeepCloning, "struct A {}");
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "A",
+            TestSourceBuilderOptions.WithDeepCloning,
+            "struct A { public string Value { get; set; } }"
+        );
         TestHelper
             .GenerateMapper(source)
             .Should()
             .HaveSingleMethodBody(
                 """
                 var target = new global::A();
+                target.Value = source.Value;
                 return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void UnmanagedStructToSameUnmanagedStructDeepCloning()
+    {
+        var source = TestSourceBuilder.Mapping("A", "A", TestSourceBuilderOptions.WithDeepCloning, "struct A {}");
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                return source;
                 """
             );
     }

--- a/test/Riok.Mapperly.Tests/Mapping/SpecialTypeTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/SpecialTypeTest.cs
@@ -92,7 +92,19 @@ public class SpecialTypeTest
     [Fact]
     public void CustomMutableStructToObjectDeepCloning()
     {
-        var source = TestSourceBuilder.Mapping("A", "object", TestSourceBuilderOptions.WithDeepCloning, "struct A {}");
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "object",
+            TestSourceBuilderOptions.WithDeepCloning,
+            "struct A { public string Value { get; set; } }"
+        );
         TestHelper.GenerateMapper(source).Should().HaveMapMethodBody("return (object)MapToA(source);");
+    }
+
+    [Fact]
+    public void CustomUnmanagedStructToObjectDeepCloning()
+    {
+        var source = TestSourceBuilder.Mapping("A", "object", TestSourceBuilderOptions.WithDeepCloning, "struct A {}");
+        TestHelper.GenerateMapper(source).Should().HaveMapMethodBody("return (object)source;");
     }
 }


### PR DESCRIPTION
Resolves #362. `UseDeepCloning` with primitive members would work on .NET Core but failed on .NET Framework. 

Normally Mapperly generates a mapping with `DirectAssignmentMappingBuilder` when `ctx.Source.IsImmutable()` returns true. `IsImmutable` checks if the value is `IsReadonly` in .net core all primitive types are `readonly struct` whereas in .net framework they are `structs`, thus returning `IsReadonly`: `false`.
 By adding an `IsUnmanaged` check, `IsUmmutable` should work on .NET Framework and will use shortcuts for user defined unmanaged structs.

- Add `IsUnmanaged` check to `IsImmutable`
- Update struct tests to be managed types and add corresponding unmanaged tests