### PR TITLE
feat: add IgnoreObsoleteMembers and `MapProperty` maps ignored Target

### DIFF
--- a/docs/docs/configuration/mapper.mdx
+++ b/docs/docs/configuration/mapper.mdx
@@ -3,11 +3,14 @@ sidebar_position: 0
 description: Define a mapper with Mapperly.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Mapper configuration
 
 The `MapperAttribute` provides options to customize the generated mapper class.
 
-## Copy behaviour
+## Copy behavior
 
 By default, Mapperly does not create deep copies of objects to improve performance.
 If an object can be directly assigned to the target, it will do so
@@ -55,6 +58,51 @@ public partial class CarMapper
     public partial CarDto ToDto(Car car);
 }
 ```
+
+### Ignore obsolete members stratgey
+
+By default, mapperly will map source/target members marked with `ObsoleteAttribute`. This can be changed by setting the `IgnoreObsoleteMembersStrategy` of a method with `MapperIgnoreObsoleteMembersAttribute`, or by setting the `IgnoreObsoleteMembersStrategy` option of the `MapperAttribute`.
+
+| Name   | Description                                                                     |
+| ------ | ------------------------------------------------------------------------------- |
+| None   | Will map members marked with the `Obsolete` attribute (default)                 |
+| Both   | Ignores source and target members that are mapped with the `Obsolete` attribute |
+| Source | Ignores source members that are mapped with the `Obsolete` attribute            |
+| Target | Ignores target members that are mapped with the `Obsolete` attribute            |
+
+<Tabs>
+<TabItem value="global" label="Global (Mapper Level)" default>
+
+Sets the `IgnoreObsoleteMembersStrategy` for all methods within the mapper, by default it is `None` allowing obsolete source and target members to be mapped. This can be overriden by individual mapping methods using `MapperIgnoreObsoleteMembersAttribute`.
+
+```csharp
+// highlight-start
+[Mapper(IgnoreObsoleteMembersStrategy = IgnoreObsoleteMembersStrategy.Both)]
+// highlight-end
+public partial class CarMapper
+{
+    ...
+}
+```
+
+</TabItem>
+<TabItem value="method" label="Local (mapping method level)">
+
+Method will use the provided ignore obsolete mapping strategy, otherwise the `MapperAttribute` property `IgnoreObsoleteMembersStrategy` will be used.
+
+```csharp
+[Mapper]
+public partial class CarMapper
+{
+    // highlight-start
+    [MapperIgnoreObsoleteMembers(IgnoreObsoleteMembersStrategy.Both)]
+    // highlight-end
+    public partial CarMakeDto MapMake(CarMake make);
+}
+```
+
+</TabItem>
+</Tabs>
 
 ### Property name mapping strategy
 

--- a/src/Riok.Mapperly.Abstractions/IgnoreObsoleteMembersStrategy.cs
+++ b/src/Riok.Mapperly.Abstractions/IgnoreObsoleteMembersStrategy.cs
@@ -1,0 +1,30 @@
+﻿namespace Riok.Mapperly.Abstractions;
+
+/// <summary>
+/// Defines the strategy to use when mapping members marked with <see cref="ObsoleteAttribute"/>.
+/// Note that <see cref="MapPropertyAttribute"/> will always map <see cref="ObsoleteAttribute"/> marked members,
+/// even if they are ignored.
+/// </summary>
+[Flags]
+public enum IgnoreObsoleteMembersStrategy
+{
+    /// <summary>
+    /// Maps <see cref="ObsoleteAttribute"/> marked members.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Will not map <see cref="ObsoleteAttribute"/> marked source or target members.
+    /// </summary>
+    Both = ~None,
+
+    /// <summary>
+    /// Ignores source <see cref="ObsoleteAttribute"/> marked members.
+    /// </summary>
+    Source = 1 << 0,
+
+    /// <summary>
+    /// Ignores target <see cref="ObsoleteAttribute"/> marked members.
+    /// </summary>
+    Target = 1 << 1,
+}

--- a/src/Riok.Mapperly.Abstractions/MapperAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperAttribute.cs
@@ -70,4 +70,10 @@ public sealed class MapperAttribute : Attribute
     /// to keep track of and reuse existing target object instances.
     /// </summary>
     public bool UseReferenceHandling { get; set; }
+
+    /// <summary>
+    /// The ignore obsolete attribute strategy. Determines how <see cref="ObsoleteAttribute"/> marked members are mapped.
+    /// Defaults to <see cref="IgnoreObsoleteMembersStrategy.None"/>.
+    /// </summary>
+    public IgnoreObsoleteMembersStrategy IgnoreObsoleteMembersStrategy { get; set; } = IgnoreObsoleteMembersStrategy.None;
 }

--- a/src/Riok.Mapperly.Abstractions/MapperIgnoreObsoleteMembersAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperIgnoreObsoleteMembersAttribute.cs
@@ -1,0 +1,22 @@
+﻿namespace Riok.Mapperly.Abstractions;
+
+/// <summary>
+/// Specifies options for obsolete ignoring strategy.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class MapperIgnoreObsoleteMembersAttribute : Attribute
+{
+    /// <summary>
+    /// Specifies options for obsolete ignoring strategy.
+    /// </summary>
+    /// <param name="ignoreObsoleteStrategy">The strategy to be used to map <see cref="ObsoleteAttribute"/> marked members. Defaults to <see cref="IgnoreObsoleteMembersStrategy.Both"/>.</param>
+    public MapperIgnoreObsoleteMembersAttribute(IgnoreObsoleteMembersStrategy ignoreObsoleteStrategy = IgnoreObsoleteMembersStrategy.Both)
+    {
+        IgnoreObsoleteStrategy = ignoreObsoleteStrategy;
+    }
+
+    /// <summary>
+    /// The strategy used to map <see cref="ObsoleteAttribute"/> marked members.
+    /// </summary>
+    public IgnoreObsoleteMembersStrategy IgnoreObsoleteStrategy { get; }
+}

--- a/src/Riok.Mapperly.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Riok.Mapperly.Abstractions/PublicAPI.Shipped.txt
@@ -3,6 +3,11 @@
 Riok.Mapperly.Abstractions.EnumMappingStrategy
 Riok.Mapperly.Abstractions.EnumMappingStrategy.ByName = 1 -> Riok.Mapperly.Abstractions.EnumMappingStrategy
 Riok.Mapperly.Abstractions.EnumMappingStrategy.ByValue = 0 -> Riok.Mapperly.Abstractions.EnumMappingStrategy
+Riok.Mapperly.Abstractions.IgnoreObsoleteMembersStrategy
+Riok.Mapperly.Abstractions.IgnoreObsoleteMembersStrategy.Both = -1 -> Riok.Mapperly.Abstractions.IgnoreObsoleteMembersStrategy
+Riok.Mapperly.Abstractions.IgnoreObsoleteMembersStrategy.None = 0 -> Riok.Mapperly.Abstractions.IgnoreObsoleteMembersStrategy
+Riok.Mapperly.Abstractions.IgnoreObsoleteMembersStrategy.Source = 1 -> Riok.Mapperly.Abstractions.IgnoreObsoleteMembersStrategy
+Riok.Mapperly.Abstractions.IgnoreObsoleteMembersStrategy.Target = 2 -> Riok.Mapperly.Abstractions.IgnoreObsoleteMembersStrategy
 Riok.Mapperly.Abstractions.MapEnumAttribute
 Riok.Mapperly.Abstractions.MapEnumAttribute.IgnoreCase.get -> bool
 Riok.Mapperly.Abstractions.MapEnumAttribute.IgnoreCase.set -> void
@@ -19,6 +24,8 @@ Riok.Mapperly.Abstractions.MapperAttribute.EnumMappingIgnoreCase.get -> bool
 Riok.Mapperly.Abstractions.MapperAttribute.EnumMappingIgnoreCase.set -> void
 Riok.Mapperly.Abstractions.MapperAttribute.EnumMappingStrategy.get -> Riok.Mapperly.Abstractions.EnumMappingStrategy
 Riok.Mapperly.Abstractions.MapperAttribute.EnumMappingStrategy.set -> void
+Riok.Mapperly.Abstractions.MapperAttribute.IgnoreObsoleteMembersStrategy.get -> Riok.Mapperly.Abstractions.IgnoreObsoleteMembersStrategy
+Riok.Mapperly.Abstractions.MapperAttribute.IgnoreObsoleteMembersStrategy.set -> void
 Riok.Mapperly.Abstractions.MapperAttribute.MapperAttribute() -> void
 Riok.Mapperly.Abstractions.MapperAttribute.PropertyNameMappingStrategy.get -> Riok.Mapperly.Abstractions.PropertyNameMappingStrategy
 Riok.Mapperly.Abstractions.MapperAttribute.PropertyNameMappingStrategy.set -> void
@@ -33,6 +40,9 @@ Riok.Mapperly.Abstractions.MapperConstructorAttribute.MapperConstructorAttribute
 Riok.Mapperly.Abstractions.MapperIgnoreAttribute
 Riok.Mapperly.Abstractions.MapperIgnoreAttribute.MapperIgnoreAttribute(string! target) -> void
 Riok.Mapperly.Abstractions.MapperIgnoreAttribute.Target.get -> string!
+Riok.Mapperly.Abstractions.MapperIgnoreObsoleteMembersAttribute
+Riok.Mapperly.Abstractions.MapperIgnoreObsoleteMembersAttribute.IgnoreObsoleteStrategy.get -> Riok.Mapperly.Abstractions.IgnoreObsoleteMembersStrategy
+Riok.Mapperly.Abstractions.MapperIgnoreObsoleteMembersAttribute.MapperIgnoreObsoleteMembersAttribute(Riok.Mapperly.Abstractions.IgnoreObsoleteMembersStrategy ignoreObsoleteStrategy = (Riok.Mapperly.Abstractions.IgnoreObsoleteMembersStrategy)-1) -> void
 Riok.Mapperly.Abstractions.MapperIgnoreSourceAttribute
 Riok.Mapperly.Abstractions.MapperIgnoreSourceAttribute.MapperIgnoreSourceAttribute(string! source) -> void
 Riok.Mapperly.Abstractions.MapperIgnoreSourceAttribute.Source.get -> string!

--- a/src/Riok.Mapperly/Configuration/MapperConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/MapperConfiguration.cs
@@ -23,7 +23,12 @@ public class MapperConfiguration
                 Array.Empty<IFieldSymbol>(),
                 Array.Empty<EnumValueMappingConfiguration>()
             ),
-            new PropertiesMappingConfiguration(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<PropertyMappingConfiguration>()),
+            new PropertiesMappingConfiguration(
+                Array.Empty<string>(),
+                Array.Empty<string>(),
+                Array.Empty<PropertyMappingConfiguration>(),
+                Mapper.IgnoreObsoleteMembersStrategy
+            ),
             Array.Empty<DerivedTypeMappingConfiguration>()
         );
     }
@@ -66,7 +71,11 @@ public class MapperConfiguration
             .WhereNotNull()
             .ToList();
         var explicitMappings = _dataAccessor.Access<MapPropertyAttribute, PropertyMappingConfiguration>(method).ToList();
-        return new PropertiesMappingConfiguration(ignoredSourceProperties, ignoredTargetProperties, explicitMappings);
+        var ignoreObsolete = _dataAccessor.Access<MapperIgnoreObsoleteMembersAttribute>(method).FirstOrDefault() is not { } methodIgnore
+            ? _defaultConfiguration.Properties.IgnoreObsoleteMembersStrategy
+            : methodIgnore.IgnoreObsoleteStrategy;
+
+        return new PropertiesMappingConfiguration(ignoredSourceProperties, ignoredTargetProperties, explicitMappings, ignoreObsolete);
     }
 
     private EnumMappingConfiguration BuildEnumConfig(MappingConfigurationReference configRef)

--- a/src/Riok.Mapperly/Configuration/PropertiesMappingConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/PropertiesMappingConfiguration.cs
@@ -1,7 +1,10 @@
+using Riok.Mapperly.Abstractions;
+
 namespace Riok.Mapperly.Configuration;
 
 public record PropertiesMappingConfiguration(
     IReadOnlyCollection<string> IgnoredSources,
     IReadOnlyCollection<string> IgnoredTargets,
-    IReadOnlyCollection<PropertyMappingConfiguration> ExplicitMappings
+    IReadOnlyCollection<PropertyMappingConfiguration> ExplicitMappings,
+    IgnoreObsoleteMembersStrategy IgnoreObsoleteMembersStrategy
 );

--- a/src/Riok.Mapperly/Symbols/FieldMember.cs
+++ b/src/Riok.Mapperly/Symbols/FieldMember.cs
@@ -14,6 +14,7 @@ public class FieldMember : IMappableMember
 
     public string Name => _fieldSymbol.Name;
     public ITypeSymbol Type => _fieldSymbol.Type;
+    public ISymbol MemberSymbol => _fieldSymbol;
     public bool IsNullable => _fieldSymbol.NullableAnnotation == NullableAnnotation.Annotated || Type.IsNullable();
     public bool IsIndexer => false;
     public bool CanGet => !_fieldSymbol.IsReadOnly && _fieldSymbol.IsAccessible();

--- a/src/Riok.Mapperly/Symbols/IMappableMember.cs
+++ b/src/Riok.Mapperly/Symbols/IMappableMember.cs
@@ -12,6 +12,8 @@ public interface IMappableMember
 
     ITypeSymbol Type { get; }
 
+    ISymbol MemberSymbol { get; }
+
     bool IsNullable { get; }
 
     bool IsIndexer { get; }

--- a/src/Riok.Mapperly/Symbols/PropertyMember.cs
+++ b/src/Riok.Mapperly/Symbols/PropertyMember.cs
@@ -14,6 +14,7 @@ internal class PropertyMember : IMappableMember
 
     public string Name => _propertySymbol.Name;
     public ITypeSymbol Type => _propertySymbol.Type;
+    public ISymbol MemberSymbol => _propertySymbol;
     public bool IsNullable => _propertySymbol.NullableAnnotation == NullableAnnotation.Annotated || Type.IsNullable();
     public bool IsIndexer => _propertySymbol.IsIndexer;
     public bool CanGet => !_propertySymbol.IsWriteOnly && _propertySymbol.GetMethod?.IsAccessible() != false;

--- a/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDto.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDto.cs
@@ -111,6 +111,9 @@ namespace Riok.Mapperly.IntegrationTests.Dto
 
         public int IgnoredIntValue { get; set; }
 
+        [Obsolete]
+        public int IgnoredObsoleteValue { get; set; }
+
         public DateOnly DateTimeValueTargetDateOnly { get; set; }
 
         public TimeOnly DateTimeValueTargetTimeOnly { get; set; }

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/DeepCloningMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/DeepCloningMapper.cs
@@ -11,6 +11,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         [MapperIgnoreSource(nameof(TestObject.IgnoredIntValue))]
         [MapperIgnoreSource(nameof(TestObject.IgnoredStringValue))]
         [MapperIgnoreSource(nameof(TestObject.ImmutableHashSetValue))]
+        [MapperIgnoreObsoleteMembers]
         public static partial TestObject Copy(TestObject src);
     }
 }

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/ProjectionMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/ProjectionMapper.cs
@@ -19,6 +19,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         [MapperIgnoreTarget(nameof(TestObjectDtoProjection.IgnoredIntValue))]
         [MapperIgnoreSource(nameof(TestObjectProjection.IgnoredStringValue))]
         [MapProperty(nameof(TestObjectProjection.RenamedStringValue), nameof(TestObjectDtoProjection.RenamedStringValue2))]
+        [MapperIgnoreObsoleteMembers]
         private static partial TestObjectDtoProjection ProjectToDto(this TestObjectProjection testObject);
 
         private static TestObjectDtoManuallyMappedProjection? MapManual(string str)

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/StaticTestMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/StaticTestMapper.cs
@@ -29,6 +29,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
 
         [MapperIgnoreSource(nameof(TestObject.IgnoredIntValue))]
         [MapperIgnoreTarget(nameof(TestObjectDto.IgnoredStringValue))]
+        [MapperIgnoreObsoleteMembers]
         public static partial TestObjectDto MapToDtoExt(this TestObject src);
 
         public static TestObjectDto MapToDto(TestObject src)
@@ -53,6 +54,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         )]
         [MapperIgnoreSource(nameof(TestObject.IgnoredIntValue))]
         [MapperIgnoreTarget(nameof(TestObjectDto.IgnoredIntValue))]
+        [MapperIgnoreObsoleteMembers]
         private static partial TestObjectDto MapToDtoInternal(TestObject testObject);
 
         // disable obsolete warning, as the obsolete attribute should still be tested.

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/TestMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/TestMapper.cs
@@ -47,6 +47,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             nameof(TestObject.NullableUnflatteningIdValue),
             nameof(TestObjectDto.NullableUnflattening) + "." + nameof(TestObjectDto.NullableUnflattening.IdValue)
         )]
+        [MapperIgnoreObsoleteMembers]
         private partial TestObjectDto MapToDtoInternal(TestObject testObject);
 
         // disable obsolete warning, as the obsolete attribute should still be tested.

--- a/test/Riok.Mapperly.Tests/Mapping/IgnoreObsoleteTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/IgnoreObsoleteTest.cs
@@ -1,0 +1,379 @@
+﻿using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Diagnostics;
+
+namespace Riok.Mapperly.Tests.Mapping;
+
+[UsesVerify]
+public class IgnoreObsoleteTest
+{
+    private const string _classA = """
+        class A
+        {
+            public int Value { get; set; }
+
+            [Obsolete]
+            public int Ignored { get; set; }
+        }
+        """;
+
+    private const string _classB = """
+        class B
+        {
+            public int Value { get; set; }
+
+            [Obsolete]
+            public int Ignored { get; set; }
+        }
+        """;
+
+    [Fact]
+    public void ClassAttributeIgnoreObsoleteNone()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithIgnoreObsolete(IgnoreObsoleteMembersStrategy.None),
+            _classA,
+            _classB
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                target.Ignored = source.Ignored;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ClassAttributeIgnoreObsoleteBoth()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithIgnoreObsolete(IgnoreObsoleteMembersStrategy.Both),
+            _classA,
+            _classB
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ClassAttributeIgnoreSourceShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithIgnoreObsolete(IgnoreObsoleteMembersStrategy.Source),
+            _classA,
+            _classB
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            )
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotFound);
+    }
+
+    [Fact]
+    public void ClassAttributeIgnoreTargetShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithIgnoreObsolete(IgnoreObsoleteMembersStrategy.Target),
+            _classA,
+            _classB
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            )
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotMapped);
+    }
+
+    [Fact]
+    public void MethodAttributeIgnoreObsoleteNone()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapperIgnoreObsoleteMembers(IgnoreObsoleteMembersStrategy.None)] partial B Map(A source);",
+            _classA,
+            _classB
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                target.Ignored = source.Ignored;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MethodAttributeIgnoreObsoleteBoth()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes("[MapperIgnoreObsoleteMembers] partial B Map(A source);", _classA, _classB);
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MethodAttributeIgnoreObsoleteSourceShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapperIgnoreObsoleteMembers(IgnoreObsoleteMembersStrategy.Source)] partial B Map(A source);",
+            _classA,
+            _classB
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            )
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotFound);
+    }
+
+    [Fact]
+    public void MethodAttributeIgnoreObsoleteTargetShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapperIgnoreObsoleteMembers(IgnoreObsoleteMembersStrategy.Target)] partial B Map(A source);",
+            _classA,
+            _classB
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            )
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotMapped);
+    }
+
+    [Fact]
+    public void MethodAttributeOverridesClassAttribute()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapperIgnoreObsoleteMembers(IgnoreObsoleteMembersStrategy.None)] partial B Map(A source);",
+            TestSourceBuilderOptions.WithIgnoreObsolete(IgnoreObsoleteMembersStrategy.Both),
+            _classA,
+            _classB
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                target.Ignored = source.Ignored;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MapPropertyOverridesIgnoreObsoleteBoth()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+                [MapProperty("Ignored", "Ignored")]
+                [MapperIgnoreObsoleteMembers]
+                partial B Map(A source);
+                """,
+            _classA,
+            _classB
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                target.Ignored = source.Ignored;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MapPropertyOverridesIgnoreObsoleteSource()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+                [MapProperty("Ignored", "Ignored")]
+                [MapperIgnoreObsoleteMembers(IgnoreObsoleteMembersStrategy.Source)]
+                partial B Map(A source);
+                """,
+            _classA,
+            _classB
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                target.Ignored = source.Ignored;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MapPropertyOverridesIgnoreObsoleteTarget()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+                [MapProperty("Ignored", "Ignored")]
+                [MapperIgnoreObsoleteMembers(IgnoreObsoleteMembersStrategy.Target)]
+                partial B Map(A source);
+                """,
+            _classA,
+            _classB
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                target.Ignored = source.Ignored;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MapInitPropertyWhenIgnoreObsoleteTarget()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+                [MapProperty("Ignored", "Ignored")]
+                [MapperIgnoreObsoleteMembers(IgnoreObsoleteMembersStrategy.Target)]
+                partial B Map(A source);
+                """,
+            _classA,
+            """
+                class B
+                {
+                    public int Value { get; set; }
+
+                    [Obsolete]
+                    public int Ignored { get; init; }
+                }
+                """
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B()
+                {
+                    Ignored = source.Ignored
+                };
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MapRequiredPropertyWhenIgnoreObsoleteTarget()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+                [MapProperty("Ignored", "Ignored")]
+                [MapperIgnoreObsoleteMembers(IgnoreObsoleteMembersStrategy.Target)]
+                partial B Map(A source);
+                """,
+            _classA,
+            """
+                class B
+                {
+                    public int Value { get; set; }
+
+                    [Obsolete]
+                    public required int Ignored { get; set; }
+                }
+                """
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B()
+                {
+                    Ignored = source.Ignored
+                };
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+}

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyInitPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyInitPropertyTest.cs
@@ -313,6 +313,66 @@ public class ObjectPropertyInitPropertyTest
     }
 
     [Fact]
+    public void IgnoredTargetRequiredPropertyWithConfiguration()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+                [MapProperty("StringValue", "StringValue")]
+                [MapperIgnoreTarget("StringValue")]
+                partial B Map(A source);
+                """,
+            "A",
+            "B",
+            "class A { public string StringValue { get; init; } public int IntValue { get; set; } }",
+            "class B { public required string StringValue { get; set; } public int IntValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B()
+                {
+                    StringValue = source.StringValue
+                };
+                target.IntValue = source.IntValue;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void IgnoredTargetInitPropertyWithConfiguration()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+                [MapProperty("StringValue", "StringValue")]
+                [MapperIgnoreTarget("StringValue")]
+                partial B Map(A source);
+                """,
+            "A",
+            "B",
+            "class A { public string StringValue { get; init; } public int IntValue { get; set; } }",
+            "class B { public string StringValue { get; init; } public int IntValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B()
+                {
+                    StringValue = source.StringValue
+                };
+                target.IntValue = source.IntValue;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public Task RequiredPropertySourceNotFoundShouldDiagnostic()
     {
         var source = TestSourceBuilder.Mapping(

--- a/test/Riok.Mapperly.Tests/TestSourceBuilder.cs
+++ b/test/Riok.Mapperly.Tests/TestSourceBuilder.cs
@@ -85,6 +85,7 @@ public partial class Mapper
             Attribute(options.PropertyNameMappingStrategy),
             Attribute(options.EnumMappingStrategy),
             Attribute(options.EnumMappingIgnoreCase),
+            Attribute(options.IgnoreObsoleteMembersStrategy),
         };
 
         return $"[Mapper({string.Join(", ", attrs)})]";

--- a/test/Riok.Mapperly.Tests/TestSourceBuilderOptions.cs
+++ b/test/Riok.Mapperly.Tests/TestSourceBuilderOptions.cs
@@ -11,12 +11,16 @@ public record TestSourceBuilderOptions(
     PropertyNameMappingStrategy PropertyNameMappingStrategy = PropertyNameMappingStrategy.CaseSensitive,
     MappingConversionType EnabledConversions = MappingConversionType.All,
     EnumMappingStrategy EnumMappingStrategy = EnumMappingStrategy.ByValue,
-    bool EnumMappingIgnoreCase = false
+    bool EnumMappingIgnoreCase = false,
+    IgnoreObsoleteMembersStrategy IgnoreObsoleteMembersStrategy = IgnoreObsoleteMembersStrategy.None
 )
 {
     public static readonly TestSourceBuilderOptions Default = new();
     public static readonly TestSourceBuilderOptions WithDeepCloning = new(UseDeepCloning: true);
     public static readonly TestSourceBuilderOptions WithReferenceHandling = new(UseReferenceHandling: true);
+
+    public static TestSourceBuilderOptions WithIgnoreObsolete(IgnoreObsoleteMembersStrategy ignoreObsoleteStrategy) =>
+        new(IgnoreObsoleteMembersStrategy: ignoreObsoleteStrategy);
 
     public static TestSourceBuilderOptions WithDisabledMappingConversion(params MappingConversionType[] conversionTypes)
     {


### PR DESCRIPTION
Resolves #284 and #450.

- Created `MapperIgnoreObsoleteMembersAttribute` and added `IgnoreObsoleteStrategy` to `MapperAttribute`. Updated `MembersMappingBuilderContext` to add the derecated members to there respective `Ignored*MemberNames`.
- Updated `FieldMember` and `PropertyMember` to expose the underlying symbol.
- Added unit tests
- Mapper attribute config is overriden by the method configuration.
- By default `IgnoreObsoleteStrategy` is none so deprecated members are treated as normal.
- The method attribute has a default parameters of `Both`  
```C#
[MapperIgnoreObsoleteMembers] partial B Map(A source);`
```

>  blanket ignore all obsolete members except when [MapProperty] is used?

Haven't done this yet, I'm not 100% sure how `MemberConfigsByRootTargetName` works to match the obsolete members to the respective explicitly mapped member.

I'll wait for #390 and then update the relevant logic.