### PR TITLE
fix: seal all configuration attributes

### DIFF
--- a/src/Riok.Mapperly.Abstractions/MapDerivedTypeAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapDerivedTypeAttribute.cs
@@ -8,7 +8,7 @@ namespace Riok.Mapperly.Abstractions;
 /// Each target type needs to extend or implement the return type of the mapping method.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-public class MapDerivedTypeAttribute : Attribute
+public sealed class MapDerivedTypeAttribute : Attribute
 {
     /// <summary>
     /// Registers a derived type mapping.

--- a/src/Riok.Mapperly.Abstractions/MapperConstructorAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperConstructorAttribute.cs
@@ -4,4 +4,4 @@ namespace Riok.Mapperly.Abstractions;
 /// Marks the constructor to be used when type gets activated by Mapperly.
 /// </summary>
 [AttributeUsage(AttributeTargets.Constructor)]
-public class MapperConstructorAttribute : Attribute { }
+public sealed class MapperConstructorAttribute : Attribute { }

--- a/src/Riok.Mapperly.Abstractions/MapperIgnoreAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperIgnoreAttribute.cs
@@ -9,7 +9,7 @@ namespace Riok.Mapperly.Abstractions;
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 [Obsolete("Renamed to " + nameof(MapperIgnoreTargetAttribute))]
-public class MapperIgnoreAttribute : Attribute
+public sealed class MapperIgnoreAttribute : Attribute
 {
     /// <summary>
     /// Ignores the specified target property from the mapping.

--- a/src/Riok.Mapperly.Abstractions/MapperIgnoreSourceAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperIgnoreSourceAttribute.cs
@@ -4,7 +4,7 @@ namespace Riok.Mapperly.Abstractions;
 /// Ignores a source property from the mapping.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-public class MapperIgnoreSourceAttribute : Attribute
+public sealed class MapperIgnoreSourceAttribute : Attribute
 {
     /// <summary>
     /// Ignores the specified source property from the mapping.

--- a/src/Riok.Mapperly.Abstractions/MapperIgnoreTargetAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperIgnoreTargetAttribute.cs
@@ -4,7 +4,7 @@ namespace Riok.Mapperly.Abstractions;
 /// Ignores a target property from the mapping.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-public class MapperIgnoreTargetAttribute : Attribute
+public sealed class MapperIgnoreTargetAttribute : Attribute
 {
     /// <summary>
     /// Ignores the specified target property from the mapping.


### PR DESCRIPTION
Seal all configuration attributes as Mapperly reads the configuration via the syntax/symbols which does not work if an attribute is inherited. This could be a breaking change if one extends such an attribute, however, since it never worked with Mapperly, it should still be safe.