### PR TITLE
feat: Multiple ignore properties with one attribute

### DIFF
--- a/src/Riok.Mapperly.Abstractions/MapperIgnoreSourcesAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperIgnoreSourcesAttribute.cs
@@ -1,15 +1,15 @@
 namespace Riok.Mapperly.Abstractions;
 
 /// <summary>
-/// Ignores a source property from the mapping.
+/// Ignores multiple source properties from the mapping.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 public sealed class MapperIgnoreSourcesAttribute : Attribute
 {
     /// <summary>
-    /// Ignores the specified source properties from the mapping.
+    /// Ignores multiple source properties from the mapping.
     /// </summary>
-    /// <param name="sources">Collection of the source property names to ignore. The use of `nameof()` is encouraged.</param>
+    /// <param name="sources">Source property names to ignore. The use of `nameof()` is encouraged.</param>
     public MapperIgnoreSourcesAttribute(params string[] sources)
     {
         Sources = sources;

--- a/src/Riok.Mapperly.Abstractions/MapperIgnoreSourcesAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperIgnoreSourcesAttribute.cs
@@ -1,0 +1,22 @@
+namespace Riok.Mapperly.Abstractions;
+
+/// <summary>
+/// Ignores a source property from the mapping.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+public sealed class MapperIgnoreSourcesAttribute : Attribute
+{
+    /// <summary>
+    /// Ignores the specified source properties from the mapping.
+    /// </summary>
+    /// <param name="sources">Collection of the source property names to ignore. The use of `nameof()` is encouraged.</param>
+    public MapperIgnoreSourcesAttribute(params string[] sources)
+    {
+        Sources = sources;
+    }
+
+    /// <summary>
+    /// Gets the names of source properties which should be ignored from the mapping.
+    /// </summary>
+    public IEnumerable<string> Sources { get; }
+}

--- a/src/Riok.Mapperly.Abstractions/MapperIgnoreTargetsAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperIgnoreTargetsAttribute.cs
@@ -9,7 +9,7 @@ public sealed class MapperIgnoreTargetsAttribute : Attribute
     /// <summary>
     /// Ignores multiple target properties from the mapping.
     /// </summary>
-    /// <param name="targets">Collection of the target property names to ignore. The use of `nameof()` is encouraged.</param>
+    /// <param name="targets">Target property names to ignore. The use of `nameof()` is encouraged.</param>
     public MapperIgnoreTargetsAttribute(params string[] targets)
     {
         Targets = targets;

--- a/src/Riok.Mapperly.Abstractions/MapperIgnoreTargetsAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperIgnoreTargetsAttribute.cs
@@ -1,0 +1,22 @@
+namespace Riok.Mapperly.Abstractions;
+
+/// <summary>
+/// Ignores multiple target properties from the mapping.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+public sealed class MapperIgnoreTargetsAttribute : Attribute
+{
+    /// <summary>
+    /// Ignores multiple target properties from the mapping.
+    /// </summary>
+    /// <param name="targets">Collection of the target property names to ignore. The use of `nameof()` is encouraged.</param>
+    public MapperIgnoreTargetsAttribute(params string[] targets)
+    {
+        Targets = targets;
+    }
+
+    /// <summary>
+    /// Gets the names of target properties which should be ignored from the mapping.
+    /// </summary>
+    public IEnumerable<string> Targets { get; }
+}

--- a/src/Riok.Mapperly.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Riok.Mapperly.Abstractions/PublicAPI.Shipped.txt
@@ -35,6 +35,12 @@ Riok.Mapperly.Abstractions.MapperIgnoreSourceAttribute.Source.get -> string!
 Riok.Mapperly.Abstractions.MapperIgnoreTargetAttribute
 Riok.Mapperly.Abstractions.MapperIgnoreTargetAttribute.MapperIgnoreTargetAttribute(string! target) -> void
 Riok.Mapperly.Abstractions.MapperIgnoreTargetAttribute.Target.get -> string!
+Riok.Mapperly.Abstractions.MapperIgnoreSourcesAttribute
+Riok.Mapperly.Abstractions.MapperIgnoreSourcesAttribute.MapperIgnoreSourcesAttribute(params string![]! sources) -> void
+Riok.Mapperly.Abstractions.MapperIgnoreSourcesAttribute.Sources.get -> System.Collections.Generic.IEnumerable<string!>!
+Riok.Mapperly.Abstractions.MapperIgnoreTargetsAttribute
+Riok.Mapperly.Abstractions.MapperIgnoreTargetsAttribute.MapperIgnoreTargetsAttribute(params string![]! targets) -> void
+Riok.Mapperly.Abstractions.MapperIgnoreTargetsAttribute.Targets.get -> System.Collections.Generic.IEnumerable<string!>!
 Riok.Mapperly.Abstractions.MapPropertyAttribute
 Riok.Mapperly.Abstractions.MapPropertyAttribute.MapPropertyAttribute(string! source, string! target) -> void
 Riok.Mapperly.Abstractions.MapPropertyAttribute.MapPropertyAttribute(string![]! source, string![]! target) -> void

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
@@ -69,6 +69,7 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
         return BuilderContext
             .ListConfiguration<MapperIgnoreTargetAttribute>()
             .Select(x => x.Target)
+            .Concat(BuilderContext.ListConfiguration<MapperIgnoreTargetsAttribute>().SelectMany(x => x.Targets))
             // deprecated MapperIgnoreAttribute, but it is still supported by Mapperly.
 #pragma warning disable CS0618
             .Concat(BuilderContext.ListConfiguration<MapperIgnoreAttribute>().Select(x => x.Target))
@@ -78,7 +79,11 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
 
     private HashSet<string> GetIgnoredSourceMembers()
     {
-        return BuilderContext.ListConfiguration<MapperIgnoreSourceAttribute>().Select(x => x.Source).ToHashSet();
+        return BuilderContext
+            .ListConfiguration<MapperIgnoreSourceAttribute>()
+            .Select(x => x.Source)
+            .Concat(BuilderContext.ListConfiguration<MapperIgnoreSourcesAttribute>().SelectMany(x => x.Sources))
+            .ToHashSet();
     }
 
     private HashSet<string> GetSourceMemberNames()

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyIgnoreTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyIgnoreTest.cs
@@ -27,6 +27,27 @@ public class ObjectPropertyIgnoreTest
     }
 
     [Fact]
+    public void WithIgnoredSourcesAndTargetsPropertyShouldIgnore()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapperIgnoreSources(nameof(A.IntValue), nameof(A.IntValue2))] [MapperIgnoreTargets(nameof(B.IntValue), nameof(B.IntValue2))] partial B Map(A source);",
+            "class A { public string StringValue { get; set; } public int IntValue { get; set; } public int IntValue2 { get; set; } }",
+            "class B { public string StringValue { get; set; }  public int IntValue { get; set; } public int IntValue2 { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.StringValue = source.StringValue;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public void ExistingTargetWithIgnoredSourceAndTargetPropertyShouldIgnore()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(


### PR DESCRIPTION
Support for ignoring multiple source and target properties with a single attribute has been added. The new `MapperIgnoreSourcesAttribute` and `MapperIgnoreTargetsAttribute` allow multiple properties to be specified for ignoring in a single attribute. This makes mapper classes cleaner when there are many repeated ignored properties, such as when many objects inherit from a class with properties that need to be ignored.”