### PR TITLE
fix: support queryable projection mappings for derived type mappings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# Mapperly PR
+# <Title>
 
 ## Description
 

--- a/src/Riok.Mapperly/Descriptors/Mappings/DerivedTypeIfExpressionMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/DerivedTypeIfExpressionMapping.cs
@@ -1,0 +1,49 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Riok.Mapperly.Emit.SyntaxFactoryHelper;
+
+namespace Riok.Mapperly.Descriptors.Mappings;
+
+/// <summary>
+/// A derived type mapping maps one base type or interface to another
+/// by implementing a if with instance checks over known types and performs the provided mapping for each type.
+/// </summary>
+public class DerivedTypeIfExpressionMapping : TypeMapping
+{
+    private readonly IReadOnlyCollection<ITypeMapping> _typeMappings;
+
+    public DerivedTypeIfExpressionMapping(ITypeSymbol sourceType, ITypeSymbol targetType, IReadOnlyCollection<ITypeMapping> typeMappings)
+        : base(sourceType, targetType)
+    {
+        _typeMappings = typeMappings;
+    }
+
+    public override ExpressionSyntax Build(TypeMappingBuildContext ctx)
+    {
+        // source is A x ? MapToA(x) : <other cases>
+        var typeExpressions = _typeMappings
+            .Reverse()
+            .Aggregate<ITypeMapping, ExpressionSyntax>(DefaultLiteral(), (aggregate, current) => BuildConditional(ctx, aggregate, current));
+
+        // cast to target type, to ensure the compiler picks the correct type
+        // (B)(<ifs...>
+        return CastExpression(FullyQualifiedIdentifier(TargetType), ParenthesizedExpression(typeExpressions));
+    }
+
+    private ConditionalExpressionSyntax BuildConditional(TypeMappingBuildContext ctx, ExpressionSyntax notMatched, ITypeMapping mapping)
+    {
+        // cannot use is pattern matching is operator due to expression limitations
+        // use is with a cast instead
+        // source is A ? MapToB((A)x) : <other cases>
+        var castedSourceContext = ctx.WithSource(
+            ParenthesizedExpression(CastExpression(FullyQualifiedIdentifier(mapping.SourceType), ctx.Source))
+        );
+        return ConditionalExpression(
+            BinaryExpression(SyntaxKind.IsExpression, ctx.Source, FullyQualifiedIdentifier(mapping.SourceType)),
+            mapping.Build(castedSourceContext),
+            notMatched
+        );
+    }
+}

--- a/src/Riok.Mapperly/Descriptors/Mappings/DerivedTypeSwitchMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/DerivedTypeSwitchMapping.cs
@@ -9,13 +9,13 @@ namespace Riok.Mapperly.Descriptors.Mappings;
 /// A derived type mapping maps one base type or interface to another
 /// by implementing a type switch over known types and performs the provided mapping for each type.
 /// </summary>
-public class DerivedTypeMapping : TypeMapping
+public class DerivedTypeSwitchMapping : TypeMapping
 {
     private const string GetTypeMethodName = "GetType";
 
-    private readonly IReadOnlyDictionary<ITypeSymbol, ITypeMapping> _typeMappings;
+    private readonly IReadOnlyCollection<ITypeMapping> _typeMappings;
 
-    public DerivedTypeMapping(ITypeSymbol sourceType, ITypeSymbol targetType, IReadOnlyDictionary<ITypeSymbol, ITypeMapping> typeMappings)
+    public DerivedTypeSwitchMapping(ITypeSymbol sourceType, ITypeSymbol targetType, IReadOnlyCollection<ITypeMapping> typeMappings)
         : base(sourceType, targetType)
     {
         _typeMappings = typeMappings;
@@ -35,7 +35,9 @@ public class DerivedTypeMapping : TypeMapping
 
         // source switch { A x => MapToA(x), B x => MapToB(x) }
         var (typeArmContext, typeArmVariableName) = ctx.WithNewSource();
-        var arms = _typeMappings.Select(x => BuildSwitchArm(typeArmVariableName, x.Key, x.Value.Build(typeArmContext))).Append(fallbackArm);
+        var arms = _typeMappings
+            .Select(x => BuildSwitchArm(typeArmVariableName, x.SourceType, x.Build(typeArmContext)))
+            .Append(fallbackArm);
         return SwitchExpression(ctx.Source).WithArms(CommaSeparatedList(arms, true));
     }
 

--- a/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDtoProjectionBaseType.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDtoProjectionBaseType.cs
@@ -1,0 +1,9 @@
+namespace Riok.Mapperly.IntegrationTests.Dto
+{
+    public abstract class TestObjectDtoProjectionBaseType
+    {
+        public int Id { get; set; }
+
+        public int BaseValue { get; set; }
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDtoProjectionTypeA.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDtoProjectionTypeA.cs
@@ -1,0 +1,7 @@
+namespace Riok.Mapperly.IntegrationTests.Dto
+{
+    public class TestObjectDtoProjectionTypeA : TestObjectDtoProjectionBaseType
+    {
+        public int ValueA { get; set; }
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDtoProjectionTypeB.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDtoProjectionTypeB.cs
@@ -1,0 +1,7 @@
+namespace Riok.Mapperly.IntegrationTests.Dto
+{
+    public class TestObjectDtoProjectionTypeB : TestObjectDtoProjectionBaseType
+    {
+        public int ValueB { get; set; }
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/ProjectionMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/ProjectionMapper.cs
@@ -10,6 +10,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
     {
         public static partial IQueryable<TestObjectDtoProjection> ProjectToDto(this IQueryable<TestObjectProjection> q);
 
+        public static partial IQueryable<TestObjectDtoProjectionBaseType> ProjectToDto(this IQueryable<TestObjectProjectionBaseType> q);
+
         // disable obsolete warning, as the obsolete attribute should still be tested.
 #pragma warning disable CS0618
         [MapperIgnore(nameof(TestObjectDtoProjection.IgnoredStringValue))]
@@ -23,5 +25,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         {
             return new TestObjectDtoManuallyMappedProjection(100) { StringValue = str, };
         }
+
+        [MapDerivedType(typeof(TestObjectProjectionTypeA), typeof(TestObjectDtoProjectionTypeA))]
+        [MapDerivedType(typeof(TestObjectProjectionTypeB), typeof(TestObjectDtoProjectionTypeB))]
+        private static partial TestObjectDtoProjectionBaseType MapDerived(TestObjectProjectionBaseType source);
     }
 }

--- a/test/Riok.Mapperly.IntegrationTests/Models/TestObjectProjectionBaseType.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Models/TestObjectProjectionBaseType.cs
@@ -1,0 +1,9 @@
+namespace Riok.Mapperly.IntegrationTests.Models
+{
+    public abstract class TestObjectProjectionBaseType
+    {
+        public int Id { get; set; }
+
+        public int BaseValue { get; set; }
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/Models/TestObjectProjectionTypeA.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Models/TestObjectProjectionTypeA.cs
@@ -1,0 +1,7 @@
+namespace Riok.Mapperly.IntegrationTests.Models
+{
+    public class TestObjectProjectionTypeA : TestObjectProjectionBaseType
+    {
+        public int ValueA { get; set; }
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/Models/TestObjectProjectionTypeB.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Models/TestObjectProjectionTypeB.cs
@@ -1,0 +1,7 @@
+namespace Riok.Mapperly.IntegrationTests.Models
+{
+    public class TestObjectProjectionTypeB : TestObjectProjectionBaseType
+    {
+        public int ValueB { get; set; }
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/ProjectionMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/ProjectionMapperTest.SnapshotGeneratedSource.verified.cs
@@ -10,6 +10,13 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
 #nullable enable
         }
 
+        public static partial global::System.Linq.IQueryable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType> ProjectToDto(this global::System.Linq.IQueryable<global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionBaseType> q)
+        {
+#nullable disable
+            return System.Linq.Queryable.Select(q, x => (global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType)(x is global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeA() { ValueA = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).ValueA, Id = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).Id, BaseValue = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).BaseValue } : x is global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeB() { ValueB = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).ValueB, Id = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).Id, BaseValue = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).BaseValue } : default));
+#nullable enable
+        }
+
         private static partial global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjection ProjectToDto(this global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjection testObject)
         {
             var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjection(testObject.CtorValue)
@@ -57,6 +64,34 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.DateTimeValueTargetDateOnly = global::System.DateOnly.FromDateTime(testObject.DateTimeValueTargetDateOnly);
             target.DateTimeValueTargetTimeOnly = global::System.TimeOnly.FromDateTime(testObject.DateTimeValueTargetTimeOnly);
             target.ManuallyMapped = MapManual(testObject.ManuallyMapped);
+            return target;
+        }
+
+        private static partial global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType MapDerived(global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionBaseType source)
+        {
+            return source switch
+            {
+                global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA x => MapToTestObjectDtoProjectionTypeA(x),
+                global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB x => MapToTestObjectDtoProjectionTypeB(x),
+                _ => throw new System.ArgumentException($"Cannot map {source.GetType()} to Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType as there is no known derived type mapping", nameof(source)),
+            };
+        }
+
+        private static global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeA MapToTestObjectDtoProjectionTypeA(global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA source)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeA();
+            target.ValueA = source.ValueA;
+            target.Id = source.Id;
+            target.BaseValue = source.BaseValue;
+            return target;
+        }
+
+        private static global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeB MapToTestObjectDtoProjectionTypeB(global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB source)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeB();
+            target.ValueB = source.ValueB;
+            target.Id = source.Id;
+            target.BaseValue = source.BaseValue;
             return target;
         }
 

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/ProjectionMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/ProjectionMapperTest.SnapshotGeneratedSource.verified.cs
@@ -15,6 +15,15 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
 #nullable enable
         }
 
+        public static partial global::System.Linq.IQueryable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType> ProjectToDto(this global::System.Linq.IQueryable<global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionBaseType> q)
+        {
+#nullable disable
+            return System.Linq.Queryable.Select(q, x => (global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType)(x is global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeA()
+            {ValueA = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).ValueA, Id = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).Id, BaseValue = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).BaseValue} : x is global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeB()
+            {ValueB = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).ValueB, Id = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).Id, BaseValue = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).BaseValue} : default));
+#nullable enable
+        }
+
         private static partial global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjection ProjectToDto(this global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjection testObject)
         {
             var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjection(testObject.CtorValue)
@@ -59,6 +68,34 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.DateTimeValueTargetDateOnly = global::System.DateOnly.FromDateTime(testObject.DateTimeValueTargetDateOnly);
             target.DateTimeValueTargetTimeOnly = global::System.TimeOnly.FromDateTime(testObject.DateTimeValueTargetTimeOnly);
             target.ManuallyMapped = MapManual(testObject.ManuallyMapped);
+            return target;
+        }
+
+        private static partial global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType MapDerived(global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionBaseType source)
+        {
+            return source switch
+            {
+                global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA x => MapToTestObjectDtoProjectionTypeA(x),
+                global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB x => MapToTestObjectDtoProjectionTypeB(x),
+                _ => throw new System.ArgumentException($"Cannot map {source.GetType()} to Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType as there is no known derived type mapping", nameof(source)),
+            };
+        }
+
+        private static global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeA MapToTestObjectDtoProjectionTypeA(global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA source)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeA();
+            target.ValueA = source.ValueA;
+            target.Id = source.Id;
+            target.BaseValue = source.BaseValue;
+            return target;
+        }
+
+        private static global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeB MapToTestObjectDtoProjectionTypeB(global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB source)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeB();
+            target.ValueB = source.ValueB;
+            target.Id = source.Id;
+            target.BaseValue = source.BaseValue;
             return target;
         }
 

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/ProjectionMapperTest.DerivedTypesProjectionShouldTranslateToQuery_query.verified.sql
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/ProjectionMapperTest.DerivedTypesProjectionShouldTranslateToQuery_query.verified.sql
@@ -1,0 +1,3 @@
+SELECT "b"."type" = 'A', "b"."ValueA", "b"."Id", "b"."BaseValue", "b"."type" = 'B', "b"."ValueB"
+FROM "BaseTypeObjects" AS "b"
+ORDER BY "b"."BaseValue"

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/ProjectionMapperTest.DerivedTypesProjectionShouldTranslateToQuery_result.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/ProjectionMapperTest.DerivedTypesProjectionShouldTranslateToQuery_result.verified.txt
@@ -1,0 +1,12 @@
+﻿[
+  {
+    ValueA: 10,
+    Id: 1,
+    BaseValue: 10
+  },
+  {
+    ValueB: 20,
+    Id: 2,
+    BaseValue: 20
+  }
+]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/ProjectionMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/ProjectionMapperTest.SnapshotGeneratedSource.verified.cs
@@ -10,6 +10,13 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
 #nullable enable
         }
 
+        public static partial global::System.Linq.IQueryable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType> ProjectToDto(this global::System.Linq.IQueryable<global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionBaseType> q)
+        {
+#nullable disable
+            return System.Linq.Queryable.Select(q, x => (global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType)(x is global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeA() { ValueA = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).ValueA, Id = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).Id, BaseValue = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).BaseValue } : x is global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeB() { ValueB = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).ValueB, Id = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).Id, BaseValue = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).BaseValue } : default));
+#nullable enable
+        }
+
         private static partial global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjection ProjectToDto(this global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjection testObject)
         {
             var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjection(testObject.CtorValue)
@@ -57,6 +64,34 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.DateTimeValueTargetDateOnly = global::System.DateOnly.FromDateTime(testObject.DateTimeValueTargetDateOnly);
             target.DateTimeValueTargetTimeOnly = global::System.TimeOnly.FromDateTime(testObject.DateTimeValueTargetTimeOnly);
             target.ManuallyMapped = MapManual(testObject.ManuallyMapped);
+            return target;
+        }
+
+        private static partial global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType MapDerived(global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionBaseType source)
+        {
+            return source switch
+            {
+                global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA x => MapToTestObjectDtoProjectionTypeA(x),
+                global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB x => MapToTestObjectDtoProjectionTypeB(x),
+                _ => throw new System.ArgumentException($"Cannot map {source.GetType()} to Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType as there is no known derived type mapping", nameof(source)),
+            };
+        }
+
+        private static global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeA MapToTestObjectDtoProjectionTypeA(global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA source)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeA();
+            target.ValueA = source.ValueA;
+            target.Id = source.Id;
+            target.BaseValue = source.BaseValue;
+            return target;
+        }
+
+        private static global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeB MapToTestObjectDtoProjectionTypeB(global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB source)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeB();
+            target.ValueB = source.ValueB;
+            target.Id = source.Id;
+            target.BaseValue = source.BaseValue;
             return target;
         }
 

--- a/test/Riok.Mapperly.Tests/Mapping/QueryableProjectionDerivedTypeTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/QueryableProjectionDerivedTypeTest.cs
@@ -1,0 +1,29 @@
+namespace Riok.Mapperly.Tests.Mapping;
+
+[UsesVerify]
+public class QueryableProjectionDerivedTypeTest
+{
+    [Fact]
+    public Task AbstractBaseClassDerivedTypesShouldWork()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            partial System.Linq.IQueryable<B> Map(System.Linq.IQueryable<A> source);
+
+            [MapDerivedType<ASubType1, BSubType1>]
+            [MapDerivedType<ASubType2, BSubType2>]
+            partial B Map(A src);
+            """,
+            "abstract class A { public string BaseValue { get; set; } }",
+            "abstract class B { public string BaseValue { get; set; } }",
+            "class ASubType1 : A { public string Value1 { get; set; } }",
+            "class ASubType2 : A { public string Value2 { get; set; } }",
+            "class BSubType1 : B { public string Value1 { get; set; } }",
+            "class BSubType2 : B { public string Value2 { get; set; } }",
+            "class A { public string StringValue { get; set; } }",
+            "class B { public string StringValue { get; set; } }"
+        );
+
+        return TestHelper.VerifyGenerator(source);
+    }
+}

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionDerivedTypeTest.AbstractBaseClassDerivedTypesShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionDerivedTypeTest.AbstractBaseClassDerivedTypesShouldWork#Mapper.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: Mapper.g.cs
+#nullable enable
+public partial class Mapper
+{
+    private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
+    {
+#nullable disable
+        return System.Linq.Queryable.Select(source, x => (global::B)(x is global::ASubType1 ? new global::BSubType1() { Value1 = ((global::ASubType1)x).Value1, BaseValue = ((global::ASubType1)x).BaseValue, StringValue = ((global::ASubType1)x).StringValue } : x is global::ASubType2 ? new global::BSubType2() { Value2 = ((global::ASubType2)x).Value2, BaseValue = ((global::ASubType2)x).BaseValue, StringValue = ((global::ASubType2)x).StringValue } : default));
+#nullable enable
+    }
+
+    private partial global::B Map(global::A src)
+    {
+        return src switch
+        {
+            global::ASubType1 x => MapToBSubType1(x),
+            global::ASubType2 x => MapToBSubType2(x),
+            _ => throw new System.ArgumentException($"Cannot map {src.GetType()} to B as there is no known derived type mapping", nameof(src)),
+        };
+    }
+
+    private global::BSubType1 MapToBSubType1(global::ASubType1 source)
+    {
+        var target = new global::BSubType1();
+        target.Value1 = source.Value1;
+        target.BaseValue = source.BaseValue;
+        target.StringValue = source.StringValue;
+        return target;
+    }
+
+    private global::BSubType2 MapToBSubType2(global::ASubType2 source)
+    {
+        var target = new global::BSubType2();
+        target.Value2 = source.Value2;
+        target.BaseValue = source.BaseValue;
+        target.StringValue = source.StringValue;
+        return target;
+    }
+}


### PR DESCRIPTION
Adds a new if + is expression save derived type mapping to add support for derived type mappings in expressions.
Closes https://github.com/riok/mapperly/issues/409