### PR TITLE
fix: throw NullReferenceException for element access

### DIFF
--- a/src/Riok.Mapperly/Emit/SyntaxFactoryHelper.cs
+++ b/src/Riok.Mapperly/Emit/SyntaxFactoryHelper.cs
@@ -77,6 +77,12 @@ public static class SyntaxFactoryHelper
             NullFallbackValue.Default => DefaultLiteral(),
             NullFallbackValue.EmptyString => StringLiteral(string.Empty),
             NullFallbackValue.CreateInstance => CreateInstance(t),
+            _ when argument is ElementAccessExpressionSyntax memberAccess
+                => ThrowNullReferenceException(
+                    InterpolatedString(
+                        $"Sequence {NameOf(memberAccess.Expression)}, contained a null value at index {memberAccess.ArgumentList.Arguments[0].Expression}."
+                    )
+                ),
             _ => ThrowArgumentNullException(argument),
         };
     }
@@ -162,6 +168,13 @@ public static class SyntaxFactoryHelper
     {
         return ThrowExpression(
             ObjectCreationExpression(IdentifierName(NullReferenceExceptionClassName)).WithArgumentList(ArgumentList(StringLiteral(message)))
+        );
+    }
+
+    public static ThrowExpressionSyntax ThrowNullReferenceException(ExpressionSyntax arg)
+    {
+        return ThrowExpression(
+            ObjectCreationExpression(IdentifierName(NullReferenceExceptionClassName)).WithArgumentList(ArgumentList(arg))
         );
     }
 

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
@@ -35,7 +35,7 @@ public class EnumerableTest
                 var target = new int[source.Length];
                 for (var i = 0; i < source.Length; i++)
                 {
-                    target[i] = source[i] == null ? throw new System.ArgumentNullException(nameof(source[i])) : source[i].Value;
+                    target[i] = source[i] == null ? throw new System.NullReferenceException($"Sequence {nameof(source)}, contained a null value at index {i}.") : source[i].Value;
                 }
 
                 return target;
@@ -82,7 +82,7 @@ public class EnumerableTest
                 var target = new int[source.Length];
                 for (var i = 0; i < source.Length; i++)
                 {
-                    target[i] = source[i] == null ? throw new System.ArgumentNullException(nameof(source[i])) : source[i].Value;
+                    target[i] = source[i] == null ? throw new System.NullReferenceException($"Sequence {nameof(source)}, contained a null value at index {i}.") : source[i].Value;
                 }
 
                 return target;
@@ -129,7 +129,7 @@ public class EnumerableTest
                 var target = new global::B[source.Length];
                 for (var i = 0; i < source.Length; i++)
                 {
-                    target[i] = source[i] == null ? throw new System.ArgumentNullException(nameof(source[i])) : source[i];
+                    target[i] = source[i] == null ? throw new System.NullReferenceException($"Sequence {nameof(source)}, contained a null value at index {i}.") : source[i];
                 }
 
                 return target;


### PR DESCRIPTION
### Description

Added a `NullReferenceException` with the message `"Sequence {nameof(source)}, contained a null value"` arm to `NullSubstitute` for element accessors. 
The error message could be improved, I considered `"Null value found inside sequence {nameof(source)}"`.

Fixes #413.


