### PR TITLE
fix: prevent `throw throw` being generated.

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Mappings/UserDefinedNewInstanceMethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserDefinedNewInstanceMethodMapping.cs
@@ -46,7 +46,7 @@ public class UserDefinedNewInstanceMethodMapping : MethodMapping, IUserMapping
     {
         if (_delegateMapping == null)
         {
-            return new[] { ThrowStatement(ThrowNotImplementedException()).WithLeadingTrivia(TriviaList(Comment(NoMappingComment))), };
+            return new[] { ExpressionStatement(ThrowNotImplementedException()).WithLeadingTrivia(TriviaList(Comment(NoMappingComment))), };
         }
 
         // if reference handling is enabled and no reference handler parameter is declared

--- a/test/Riok.Mapperly.Tests/_snapshots/DictionaryTest.DictionaryToCustomDictionaryWithPrivateCtorShouldDiagnostic#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/DictionaryTest.DictionaryToCustomDictionaryWithPrivateCtorShouldDiagnostic#Mapper.g.verified.cs
@@ -5,6 +5,6 @@ public partial class Mapper
     private partial global::A Map(global::System.Collections.Generic.IDictionary<string, int> source)
     {
         // Could not generate mapping
-        throw throw new System.NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyConstructorResolverTest.ClassToClassPrivateCtorShouldDiagnostic#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyConstructorResolverTest.ClassToClassPrivateCtorShouldDiagnostic#Mapper.g.verified.cs
@@ -5,6 +5,6 @@ public partial class Mapper
     private partial global::B Map(global::A source)
     {
         // Could not generate mapping
-        throw throw new System.NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }


### PR DESCRIPTION
### Fix bug where `throw throw` is generated.

#### Description
When `UserDefinedNewInstanceMethodMapping` cannot create an instance it generates an invalid throw throw statement. By replacing the enclosing `ThrowStatement` a normal throw statement is generated.