### PR TITLE
Prevent mapping to inaccessible construtors

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/CtorMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/CtorMappingBuilder.cs
@@ -16,12 +16,14 @@ public static class CtorMappingBuilder
             return null;
 
         // resolve ctors which have the source as single argument
-        var ctorMethod = namedTarget.InstanceConstructors.FirstOrDefault(
-            m =>
-                m.Parameters.Length == 1
-                && SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, ctx.Source)
-                && ctx.Source.HasSameOrStricterNullability(m.Parameters[0].Type)
-        );
+        var ctorMethod = namedTarget.InstanceConstructors
+            .Where(x => x.IsAccessible())
+            .FirstOrDefault(
+                m =>
+                    m.Parameters.Length == 1
+                    && SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, ctx.Source)
+                    && ctx.Source.HasSameOrStricterNullability(m.Parameters[0].Type)
+            );
 
         return ctorMethod == null ? null : new CtorMapping(ctx.Source, ctx.Target);
     }

--- a/test/Riok.Mapperly.Tests/Mapping/CtorTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/CtorTest.cs
@@ -33,4 +33,25 @@ public class CtorTest
             .Should()
             .HaveDiagnostic(new(DiagnosticDescriptors.CouldNotCreateMapping));
     }
+
+    [Fact]
+    public void DeepCloneRecordShouldNotUseCtorMapping()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "A",
+            TestSourceBuilderOptions.WithDeepCloning,
+            "record A { public int Value { get; set; } }"
+        );
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+            var target = new global::A();
+            target.Value = source.Value;
+            return target;
+            """
+            );
+    }
 }


### PR DESCRIPTION
### Stop `CtorMapping` from mapping to inaccessible constructors

**Description**
`CtorMapping` will try to construct an object from itself using inaccessible constructors. This usually occurs with records because they all have protected constructors.
```C#
[Mapper(UseDeepCloning = true)]
public static partial class Mapper
{
    public static partial MyRecord Map(MyRecord src);
    public static partial MyClass Map(MyClass src);
}
public class MyClass
{
    protected MyClass(MyClass myClass)
    {
    }
}
public record MyRecord
{
    public int Value { get; set; }
}
```
```C#
// Generates
public static partial global::Riok.Mapperly.Sample.MyRecord Map(global::Riok.Mapperly.Sample.MyRecord src)
{
    return new global::Riok.Mapperly.Sample.MyRecord(src); // invalid can't access constructor
}

public static partial global::Riok.Mapperly.Sample.MyClass Map(global::Riok.Mapperly.Sample.MyClass src)
{
    return new global::Riok.Mapperly.Sample.MyClass(src); // invalid can't access constructor
}
```

- Added accessibility check to `CtorMapping`
- Added unit test
