### PR TITLE
fix: only use instance constructors to create new object instances

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
@@ -179,7 +179,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
         // parameterless ctor is prio 2
         // then by descending parameter count
         // ctors annotated with [Obsolete] are considered last unless they have a MapperConstructor attribute set
-        var ctorCandidates = namedTargetType.Constructors
+        var ctorCandidates = namedTargetType.InstanceConstructors
             .Where(ctor => ctor.IsAccessible())
             .OrderByDescending(x => x.HasAttribute(ctx.BuilderContext.Types.MapperConstructorAttribute))
             .ThenBy(x => x.HasAttribute(ctx.BuilderContext.Types.ObsoleteAttribute))

--- a/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
+++ b/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
@@ -32,7 +32,7 @@ internal static class SymbolExtensions
 
     internal static bool HasAccessibleParameterlessConstructor(this ITypeSymbol symbol, bool allowProtected = false) =>
         symbol is INamedTypeSymbol { IsAbstract: false } namedTypeSymbol
-        && namedTypeSymbol.Constructors.Any(c => c.Parameters.IsDefaultOrEmpty && c.IsAccessible(allowProtected));
+        && namedTypeSymbol.InstanceConstructors.Any(c => c.Parameters.IsDefaultOrEmpty && c.IsAccessible(allowProtected));
 
     internal static int GetInheritanceLevel(this ITypeSymbol symbol)
     {

--- a/test/Riok.Mapperly.Tests/Mapping/CtorTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/CtorTest.cs
@@ -48,10 +48,10 @@ public class CtorTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new global::A();
-            target.Value = source.Value;
-            return target;
-            """
+                var target = new global::A();
+                target.Value = source.Value;
+                return target;
+                """
             );
     }
 }

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
@@ -405,4 +405,20 @@ public class ObjectPropertyTest
                 """
             );
     }
+
+    [Fact]
+    public void ShouldIgnoreStaticConstructorAndDiagnostic()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            "class A { public string StringValue { get; set; } }",
+            "class B { static B() {} private B() {} public string StringValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowAllDiagnostics)
+            .Should()
+            .HaveDiagnostic(new(DiagnosticDescriptors.CouldNotCreateMapping));
+    }
 }


### PR DESCRIPTION
Exclude static constructors and only consider instance constructors to create new objects.