### PR TITLE
fix: existing dictionary and enumerable mapping should respect enabled conversion types

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/DictionaryMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/DictionaryMappingBuilder.cs
@@ -81,6 +81,9 @@ public static class DictionaryMappingBuilder
 
     public static IExistingTargetMapping? TryBuildExistingTargetMapping(MappingBuilderContext ctx)
     {
+        if (!ctx.IsConversionEnabled(MappingConversionType.Dictionary))
+            return null;
+
         if (!ctx.Target.ImplementsGeneric(ctx.Types.IDictionaryT, out _))
             return null;
 

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
@@ -74,6 +74,9 @@ public static class EnumerableMappingBuilder
 
     public static IExistingTargetMapping? TryBuildExistingTargetMapping(MappingBuilderContext ctx)
     {
+        if (!ctx.IsConversionEnabled(MappingConversionType.Enumerable))
+            return null;
+
         if (BuildElementMapping(ctx) is not { } elementMapping)
             return null;
 

--- a/test/Riok.Mapperly.Tests/Mapping/DictionaryTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/DictionaryTest.cs
@@ -521,4 +521,25 @@ public class DictionaryTest
         );
         TestHelper.GenerateMapper(source, TestHelperOptions.AllowDiagnostics).Should().HaveDiagnostics();
     }
+
+    [Fact]
+    public void DictionaryMappingExistingTargetDisabledShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithDisabledMappingConversion(MappingConversionType.Dictionary),
+            "class A { public Dictionary<long, long> Value { get; } }",
+            "class B { public Dictionary<int, int> Value { get; } }"
+        );
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
 }

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
@@ -634,6 +634,27 @@ public class EnumerableTest
     }
 
     [Fact]
+    public void EnumerableMappingExistingTargetDisabledShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithDisabledMappingConversion(MappingConversionType.Enumerable),
+            "class A { public IEnumerable<int> Value { get; } }",
+            "class B { public IReadOnlyCollection<int> Value { get; } }"
+        );
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public void EnumerableToReadOnlyArrayPropertyShouldDiagnostic()
     {
         // should not create a mapping that maps to an array by adding to it in a foreach loop


### PR DESCRIPTION
Closes #443 