### PR TITLE
feat: cache attribute symbols

### DIFF
--- a/src/Riok.Mapperly/Configuration/AttributeDataAccessor.cs
+++ b/src/Riok.Mapperly/Configuration/AttributeDataAccessor.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Microsoft.CodeAnalysis;
+using Riok.Mapperly.Descriptors;
 
 namespace Riok.Mapperly.Configuration;
 
@@ -8,27 +9,25 @@ namespace Riok.Mapperly.Configuration;
 /// </summary>
 internal static class AttributeDataAccessor
 {
-    public static T? AccessFirstOrDefault<T>(Compilation compilation, ISymbol symbol)
-        where T : Attribute => Access<T, T>(compilation, symbol).FirstOrDefault();
+    public static T? AccessFirstOrDefault<T>(WellKnownTypes knownTypes, ISymbol symbol)
+        where T : Attribute => Access<T, T>(knownTypes, symbol).FirstOrDefault();
 
     /// <summary>
     /// Reads the attribute data and sets it on a newly created instance of <see cref="TData"/>.
     /// If <see cref="TAttribute"/> has n type parameters,
     /// <see cref="TData"/> needs to have an accessible ctor with the parameters 0 to n-1 to be of type <see cref="ITypeSymbol"/>.
     /// </summary>
-    /// <param name="compilation">The compilation.</param>
+    /// <param name="knownTypes">The knownTypes used to get the type symbol.</param>
     /// <param name="symbol">The symbol on which the attributes should be read.</param>
     /// <typeparam name="TAttribute">The type of the attribute.</typeparam>
     /// <typeparam name="TData">The type of the data class. If no type parameters are involved, this is usually the same as <see cref="TAttribute"/>.</typeparam>
     /// <returns>The attribute data.</returns>
     /// <exception cref="InvalidOperationException">If a property or ctor argument of <see cref="TData"/> could not be read on the attribute.</exception>
-    public static IEnumerable<TData> Access<TAttribute, TData>(Compilation compilation, ISymbol symbol)
+    public static IEnumerable<TData> Access<TAttribute, TData>(WellKnownTypes knownTypes, ISymbol symbol)
         where TAttribute : Attribute
     {
         var attrType = typeof(TAttribute);
-        var attrSymbol = compilation.GetTypeByMetadataName($"{attrType.Namespace}.{attrType.Name}");
-        if (attrSymbol == null)
-            yield break;
+        var attrSymbol = knownTypes.Get($"{attrType.Namespace}.{attrType.Name}");
 
         var attrDatas = symbol
             .GetAttributes()

--- a/src/Riok.Mapperly/Descriptors/Configuration.cs
+++ b/src/Riok.Mapperly/Descriptors/Configuration.cs
@@ -14,12 +14,12 @@ public class Configuration
     /// </summary>
     private readonly Dictionary<Type, object> _defaultConfigurations = new();
 
-    private readonly Compilation _compilation;
+    private readonly WellKnownTypes _knownTypes;
 
-    public Configuration(Compilation compilation, INamedTypeSymbol mapperSymbol)
+    public Configuration(WellKnownTypes knownTypes, INamedTypeSymbol mapperSymbol)
     {
-        _compilation = compilation;
-        Mapper = AttributeDataAccessor.AccessFirstOrDefault<MapperAttribute>(compilation, mapperSymbol) ?? new();
+        _knownTypes = knownTypes;
+        Mapper = AttributeDataAccessor.AccessFirstOrDefault<MapperAttribute>(knownTypes, mapperSymbol) ?? new();
         InitDefaultConfigurations();
     }
 
@@ -34,7 +34,7 @@ public class Configuration
     public IEnumerable<TData> ListConfiguration<T, TData>(IMethodSymbol? userSymbol)
         where T : Attribute
     {
-        return userSymbol == null ? Enumerable.Empty<TData>() : AttributeDataAccessor.Access<T, TData>(_compilation, userSymbol);
+        return userSymbol == null ? Enumerable.Empty<TData>() : AttributeDataAccessor.Access<T, TData>(_knownTypes, userSymbol);
     }
 
     private void InitDefaultConfigurations()

--- a/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Abstractions.ReferenceHandling;
 using Riok.Mapperly.Descriptors.MappingBodyBuilders;
 using Riok.Mapperly.Descriptors.MappingBuilders;
 using Riok.Mapperly.Descriptors.ObjectFactories;
@@ -22,15 +23,16 @@ public class DescriptorBuilder
         SourceProductionContext sourceContext,
         Compilation compilation,
         ClassDeclarationSyntax mapperSyntax,
-        INamedTypeSymbol mapperSymbol
+        INamedTypeSymbol mapperSymbol,
+        WellKnownTypes wellKnownTypes
     )
     {
         _mapperDescriptor = new MapperDescriptor(mapperSyntax, mapperSymbol, _methodNameBuilder);
         _mappingBodyBuilder = new MappingBodyBuilder(_mappings);
         _builderContext = new SimpleMappingBuilderContext(
             compilation,
-            new Configuration(compilation, mapperSymbol),
-            new WellKnownTypes(compilation),
+            new Configuration(wellKnownTypes, mapperSymbol),
+            wellKnownTypes,
             _mapperDescriptor,
             sourceContext,
             new MappingBuilder(_mappings),
@@ -95,7 +97,7 @@ public class DescriptorBuilder
 
         foreach (var methodMapping in _mappings.MethodMappings)
         {
-            methodMapping.EnableReferenceHandling(_builderContext.Types.IReferenceHandler);
+            methodMapping.EnableReferenceHandling(_builderContext.Types.Get<IReferenceHandler>());
         }
     }
 

--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityBuilder.cs
@@ -33,9 +33,10 @@ public static class EnsureCapacityBuilder
         if (TryGetNonEnumeratedCount(sourceType, types, out var sourceSizeProperty))
             return new EnsureCapacityMember(targetSizeProperty, sourceSizeProperty);
 
-        sourceType.ImplementsGeneric(types.IEnumerableT, out var iEnumerable);
+        sourceType.ImplementsGeneric(types.Get(typeof(IEnumerable<>)), out var iEnumerable);
 
-        var nonEnumeratedCountMethod = types.Enumerable
+        var nonEnumeratedCountMethod = types
+            .Get(typeof(Enumerable))
             .GetMembers(TryGetNonEnumeratedCountMethodName)
             .OfType<IMethodSymbol>()
             .FirstOrDefault(
@@ -59,13 +60,19 @@ public static class EnsureCapacityBuilder
             return true;
         }
 
-        if (value.ImplementsGeneric(types.ICollectionT, CountPropertyName, out _, out var hasCollectionCount) && !hasCollectionCount)
+        if (
+            value.ImplementsGeneric(types.Get(typeof(ICollection<>)), CountPropertyName, out _, out var hasCollectionCount)
+            && !hasCollectionCount
+        )
         {
             expression = CountPropertyName;
             return true;
         }
 
-        if (value.ImplementsGeneric(types.IReadOnlyCollectionT, CountPropertyName, out _, out var hasReadOnlyCount) && !hasReadOnlyCount)
+        if (
+            value.ImplementsGeneric(types.Get(typeof(IReadOnlyCollection<>)), CountPropertyName, out _, out var hasReadOnlyCount)
+            && !hasReadOnlyCount
+        )
         {
             expression = CountPropertyName;
             return true;

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
@@ -181,15 +181,15 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
         // ctors annotated with [Obsolete] are considered last unless they have a MapperConstructor attribute set
         var ctorCandidates = namedTargetType.InstanceConstructors
             .Where(ctor => ctor.IsAccessible())
-            .OrderByDescending(x => x.HasAttribute(ctx.BuilderContext.Types.MapperConstructorAttribute))
-            .ThenBy(x => x.HasAttribute(ctx.BuilderContext.Types.ObsoleteAttribute))
+            .OrderByDescending(x => x.HasAttribute(ctx.BuilderContext.Types.Get<MapperConstructorAttribute>()))
+            .ThenBy(x => x.HasAttribute(ctx.BuilderContext.Types.Get<ObsoleteAttribute>()))
             .ThenByDescending(x => x.Parameters.Length == 0)
             .ThenByDescending(x => x.Parameters.Length);
         foreach (var ctorCandidate in ctorCandidates)
         {
             if (!TryBuildConstructorMapping(ctx, ctorCandidate, out var mappedTargetMemberNames, out var constructorParameterMappings))
             {
-                if (ctorCandidate.HasAttribute(ctx.BuilderContext.Types.MapperConstructorAttribute))
+                if (ctorCandidate.HasAttribute(ctx.BuilderContext.Types.Get<MapperConstructorAttribute>()))
                 {
                     ctx.BuilderContext.ReportDiagnostic(
                         DiagnosticDescriptors.CannotMapToConfiguredConstructor,

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/QueryableMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/QueryableMappingBuilder.cs
@@ -12,10 +12,10 @@ public static class QueryableMappingBuilder
         if (!ctx.IsConversionEnabled(MappingConversionType.Queryable))
             return null;
 
-        if (!ctx.Source.ImplementsGeneric(ctx.Types.IQueryableT, out var sourceQueryable))
+        if (!ctx.Source.ImplementsGeneric(ctx.Types.Get(typeof(IQueryable<>)), out var sourceQueryable))
             return null;
 
-        if (!ctx.Target.ImplementsGeneric(ctx.Types.IQueryableT, out var targetQueryable))
+        if (!ctx.Target.ImplementsGeneric(ctx.Types.Get(typeof(IQueryable<>)), out var targetQueryable))
             return null;
 
         var sourceType = sourceQueryable.TypeArguments[0];

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/StringToEnumMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/StringToEnumMappingBuilder.cs
@@ -15,7 +15,8 @@ public static class StringToEnumMappingBuilder
         if (ctx.Source.SpecialType != SpecialType.System_String || !ctx.Target.IsEnum())
             return null;
 
-        var genericEnumParseMethodSupported = ctx.Types.Enum
+        var genericEnumParseMethodSupported = ctx.Types
+            .Get<Enum>()
             .GetMembers(nameof(Enum.Parse))
             .OfType<IMethodSymbol>()
             .Any(x => x.IsGenericMethod);

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/ObjectFactoryBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/ObjectFactoryBuilder.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.Diagnostics;
 using Riok.Mapperly.Helpers;
 
@@ -11,7 +12,7 @@ public static class ObjectFactoryBuilder
         var objectFactories = mapperSymbol
             .GetMembers()
             .OfType<IMethodSymbol>()
-            .Where(m => m.HasAttribute(ctx.Types.ObjectFactoryAttribute))
+            .Where(m => m.HasAttribute(ctx.Types.Get<ObjectFactoryAttribute>()))
             .Select(x => BuildObjectFactory(ctx, x))
             .WhereNotNull()
             .ToList();

--- a/src/Riok.Mapperly/Descriptors/UserMethodMappingExtractor.cs
+++ b/src/Riok.Mapperly/Descriptors/UserMethodMappingExtractor.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
+using Riok.Mapperly.Abstractions.ReferenceHandling;
+using Riok.Mapperly.Abstractions.ReferenceHandling.Internal;
 using Riok.Mapperly.Descriptors.Mappings;
 using Riok.Mapperly.Descriptors.Mappings.UserMappings;
 using Riok.Mapperly.Diagnostics;
@@ -97,7 +99,7 @@ public static class UserMethodMappingExtractor
                 methodSymbol,
                 runtimeTargetTypeParams,
                 ctx.MapperConfiguration.UseReferenceHandling,
-                ctx.Types.PreserveReferenceHandler,
+                ctx.Types.Get<PreserveReferenceHandler>(),
                 GetTypeSwitchNullArm(methodSymbol, runtimeTargetTypeParams, null),
                 ctx.Compilation.ObjectType
             );
@@ -116,7 +118,7 @@ public static class UserMethodMappingExtractor
                 typeParameters.Value,
                 parameters,
                 ctx.MapperConfiguration.UseReferenceHandling,
-                ctx.Types.PreserveReferenceHandler,
+                ctx.Types.Get<PreserveReferenceHandler>(),
                 GetTypeSwitchNullArm(methodSymbol, parameters, typeParameters),
                 ctx.Compilation.ObjectType
             );
@@ -136,7 +138,7 @@ public static class UserMethodMappingExtractor
                 parameters.Target.Value,
                 parameters.ReferenceHandler,
                 ctx.MapperConfiguration.UseReferenceHandling,
-                ctx.Types.PreserveReferenceHandler
+                ctx.Types.Get<PreserveReferenceHandler>()
             );
         }
 
@@ -145,7 +147,7 @@ public static class UserMethodMappingExtractor
             parameters.Source,
             parameters.ReferenceHandler,
             ctx.MapperConfiguration.UseReferenceHandling,
-            ctx.Types.PreserveReferenceHandler
+            ctx.Types.Get<PreserveReferenceHandler>()
         );
     }
 
@@ -223,7 +225,7 @@ public static class UserMethodMappingExtractor
             method.Parameters.FirstOrDefault(p => p.Ordinal != sourceParameter.Value.Ordinal && p.Ordinal != refHandlerParameterOrdinal)
         );
         expectedParametersCount++;
-        if (targetTypeParameter == null || !SymbolEqualityComparer.Default.Equals(targetTypeParameter.Value.Type, ctx.Types.Type))
+        if (targetTypeParameter == null || !SymbolEqualityComparer.Default.Equals(targetTypeParameter.Value.Type, ctx.Types.Get<Type>()))
         {
             parameters = null;
             return false;
@@ -292,19 +294,19 @@ public static class UserMethodMappingExtractor
 
     private static MethodParameter? BuildReferenceHandlerParameter(SimpleMappingBuilderContext ctx, IMethodSymbol method)
     {
-        var refHandlerParameterSymbol = method.Parameters.FirstOrDefault(p => p.HasAttribute(ctx.Types.ReferenceHandlerAttribute));
+        var refHandlerParameterSymbol = method.Parameters.FirstOrDefault(p => p.HasAttribute(ctx.Types.Get<ReferenceHandlerAttribute>()));
         if (refHandlerParameterSymbol == null)
             return null;
 
         var refHandlerParameter = new MethodParameter(refHandlerParameterSymbol);
-        if (!SymbolEqualityComparer.Default.Equals(ctx.Types.IReferenceHandler, refHandlerParameter.Type))
+        if (!SymbolEqualityComparer.Default.Equals(ctx.Types.Get<IReferenceHandler>(), refHandlerParameter.Type))
         {
             ctx.ReportDiagnostic(
                 DiagnosticDescriptors.ReferenceHandlerParameterWrongType,
                 refHandlerParameterSymbol,
                 method.ContainingType.ToDisplayString(),
                 method.Name,
-                ctx.Types.IReferenceHandler.ToDisplayString(),
+                ctx.Types.Get<IReferenceHandler>().ToDisplayString(),
                 refHandlerParameterSymbol.Type.ToDisplayString()
             );
         }

--- a/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
+++ b/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
@@ -1,127 +1,40 @@
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
-using Riok.Mapperly.Abstractions;
-using Riok.Mapperly.Abstractions.ReferenceHandling;
-using Riok.Mapperly.Abstractions.ReferenceHandling.Internal;
 
 namespace Riok.Mapperly.Descriptors;
 
 public class WellKnownTypes
 {
     private readonly Compilation _compilation;
-
-    private INamedTypeSymbol? _referenceHandlerAttribute;
-    private INamedTypeSymbol? _objectFactoryAttribute;
-    private INamedTypeSymbol? _mapperConstructorAttribute;
-
-    private INamedTypeSymbol? _obsoleteAttribute;
-
-    private INamedTypeSymbol? _iReferenceHandler;
-    private INamedTypeSymbol? _preserveReferenceHandler;
-
-    private INamedTypeSymbol? _iDictionaryT;
-    private INamedTypeSymbol? _iReadOnlyDictionaryT;
-    private INamedTypeSymbol? _iEnumerableT;
-    private INamedTypeSymbol? _enumerable;
-    private INamedTypeSymbol? _iCollectionT;
-    private INamedTypeSymbol? _iReadOnlyCollectionT;
-    private INamedTypeSymbol? _iListT;
-    private INamedTypeSymbol? _listT;
-    private INamedTypeSymbol? _stackT;
-    private INamedTypeSymbol? _queueT;
-    private INamedTypeSymbol? _iReadOnlyListT;
-    private INamedTypeSymbol? _keyValuePairT;
-    private INamedTypeSymbol? _dictionaryT;
-    private INamedTypeSymbol? _enum;
-    private INamedTypeSymbol? _type;
-
-    private INamedTypeSymbol? _immutableArray;
-    private INamedTypeSymbol? _immutableArrayT;
-    private INamedTypeSymbol? _immutableList;
-    private INamedTypeSymbol? _immutableListT;
-    private INamedTypeSymbol? _iImmutableListT;
-    private INamedTypeSymbol? _immutableHashSet;
-    private INamedTypeSymbol? _immutableHashSetT;
-    private INamedTypeSymbol? _iImmutableSetT;
-    private INamedTypeSymbol? _immutableQueue;
-    private INamedTypeSymbol? _immutableQueueT;
-    private INamedTypeSymbol? _iImmutableQueueT;
-    private INamedTypeSymbol? _immutableStack;
-    private INamedTypeSymbol? _immutableStackT;
-    private INamedTypeSymbol? _iImmutableStackT;
-    private INamedTypeSymbol? _immutableSortedSet;
-    private INamedTypeSymbol? _immutableSortedSetT;
-    private INamedTypeSymbol? _immutableDictionary;
-    private INamedTypeSymbol? _immutableDictionaryT;
-    private INamedTypeSymbol? _iImmutableDictionaryT;
-    private INamedTypeSymbol? _immutableSortedDictionary;
-    private INamedTypeSymbol? _immutableSortedDictionaryT;
-
-    private INamedTypeSymbol? _iQueryableT;
-
-    private INamedTypeSymbol? _dateOnly;
-    private INamedTypeSymbol? _timeOnly;
+    private readonly Dictionary<string, INamedTypeSymbol?> _cachedTypes = new();
 
     internal WellKnownTypes(Compilation compilation)
     {
         _compilation = compilation;
     }
 
-    public INamedTypeSymbol ReferenceHandlerAttribute => _referenceHandlerAttribute ??= GetTypeSymbol(typeof(ReferenceHandlerAttribute));
-    public INamedTypeSymbol ObjectFactoryAttribute => _objectFactoryAttribute ??= GetTypeSymbol(typeof(ObjectFactoryAttribute));
-    public INamedTypeSymbol MapperConstructorAttribute => _mapperConstructorAttribute ??= GetTypeSymbol(typeof(MapperConstructorAttribute));
-    public INamedTypeSymbol ObsoleteAttribute => _obsoleteAttribute ??= GetTypeSymbol(typeof(ObsoleteAttribute));
-    public INamedTypeSymbol IReferenceHandler => _iReferenceHandler ??= GetTypeSymbol(typeof(IReferenceHandler));
-    public INamedTypeSymbol PreserveReferenceHandler => _preserveReferenceHandler ??= GetTypeSymbol(typeof(PreserveReferenceHandler));
-    public INamedTypeSymbol IDictionaryT => _iDictionaryT ??= GetTypeSymbol(typeof(IDictionary<,>));
-    public INamedTypeSymbol IReadOnlyDictionaryT => _iReadOnlyDictionaryT ??= GetTypeSymbol(typeof(IReadOnlyDictionary<,>));
-    public INamedTypeSymbol IEnumerableT => _iEnumerableT ??= GetTypeSymbol(typeof(IEnumerable<>));
-    public INamedTypeSymbol Enumerable => _enumerable ??= GetTypeSymbol(typeof(Enumerable));
-    public INamedTypeSymbol ICollectionT => _iCollectionT ??= GetTypeSymbol(typeof(ICollection<>));
-    public INamedTypeSymbol IReadOnlyCollectionT => _iReadOnlyCollectionT ??= GetTypeSymbol(typeof(IReadOnlyCollection<>));
-    public INamedTypeSymbol IListT => _iListT ??= GetTypeSymbol(typeof(IList<>));
-    public INamedTypeSymbol ListT => _listT ??= GetTypeSymbol(typeof(List<>));
-    public INamedTypeSymbol StackT => _stackT ??= GetTypeSymbol(typeof(Stack<>));
-    public INamedTypeSymbol QueueT => _queueT ??= GetTypeSymbol(typeof(Queue<>));
-    public INamedTypeSymbol IReadOnlyListT => _iReadOnlyListT ??= GetTypeSymbol(typeof(IReadOnlyList<>));
-    public INamedTypeSymbol KeyValuePairT => _keyValuePairT ??= GetTypeSymbol(typeof(KeyValuePair<,>));
-    public INamedTypeSymbol DictionaryT => _dictionaryT ??= GetTypeSymbol(typeof(Dictionary<,>));
-    public INamedTypeSymbol Enum => _enum ??= GetTypeSymbol(typeof(Enum));
-    public INamedTypeSymbol Type => _type ??= GetTypeSymbol(typeof(Type));
-    public INamedTypeSymbol IQueryableT => _iQueryableT ??= GetTypeSymbol(typeof(IQueryable<>));
-
-    public INamedTypeSymbol ImmutableArray => _immutableArray ??= GetTypeSymbol(typeof(ImmutableArray));
-    public INamedTypeSymbol ImmutableArrayT => _immutableArrayT ??= GetTypeSymbol(typeof(ImmutableArray<>));
-    public INamedTypeSymbol ImmutableList => _immutableList ??= GetTypeSymbol(typeof(ImmutableList));
-    public INamedTypeSymbol ImmutableListT => _immutableListT ??= GetTypeSymbol(typeof(ImmutableList<>));
-    public INamedTypeSymbol IImmutableListT => _iImmutableListT ??= GetTypeSymbol(typeof(IImmutableList<>));
-    public INamedTypeSymbol ImmutableHashSet => _immutableHashSet ??= GetTypeSymbol(typeof(ImmutableHashSet));
-    public INamedTypeSymbol ImmutableHashSetT => _immutableHashSetT ??= GetTypeSymbol(typeof(ImmutableHashSet<>));
-    public INamedTypeSymbol IImmutableSetT => _iImmutableSetT ??= GetTypeSymbol(typeof(IImmutableSet<>));
-    public INamedTypeSymbol ImmutableQueue => _immutableQueue ??= GetTypeSymbol(typeof(ImmutableQueue));
-    public INamedTypeSymbol ImmutableQueueT => _immutableQueueT ??= GetTypeSymbol(typeof(ImmutableQueue<>));
-    public INamedTypeSymbol IImmutableQueueT => _iImmutableQueueT ??= GetTypeSymbol(typeof(IImmutableQueue<>));
-    public INamedTypeSymbol ImmutableStack => _immutableStack ??= GetTypeSymbol(typeof(ImmutableStack));
-    public INamedTypeSymbol ImmutableStackT => _immutableStackT ??= GetTypeSymbol(typeof(ImmutableStack<>));
-    public INamedTypeSymbol IImmutableStackT => _iImmutableStackT ??= GetTypeSymbol(typeof(IImmutableStack<>));
-    public INamedTypeSymbol ImmutableSortedSet => _immutableSortedSet ??= GetTypeSymbol(typeof(ImmutableSortedSet));
-    public INamedTypeSymbol ImmutableSortedSetT => _immutableSortedSetT ??= GetTypeSymbol(typeof(ImmutableSortedSet<>));
-    public INamedTypeSymbol ImmutableDictionary => _immutableDictionary ??= GetTypeSymbol(typeof(ImmutableDictionary));
-    public INamedTypeSymbol IImmutableDictionaryT => _iImmutableDictionaryT ??= GetTypeSymbol(typeof(IImmutableDictionary<,>));
-    public INamedTypeSymbol ImmutableDictionaryT => _immutableDictionaryT ??= GetTypeSymbol(typeof(ImmutableDictionary<,>));
-
-    public INamedTypeSymbol ImmutableSortedDictionary => _immutableSortedDictionary ??= GetTypeSymbol(typeof(ImmutableSortedDictionary));
-    public INamedTypeSymbol ImmutableSortedDictionaryT =>
-        _immutableSortedDictionaryT ??= GetTypeSymbol(typeof(ImmutableSortedDictionary<,>));
-
     // use string type name as they are not available in netstandard2.0
-    public INamedTypeSymbol? DateOnly => _dateOnly ??= GetTypeSymbol("System.DateOnly");
+    public INamedTypeSymbol? DateOnly => TryGet("System.DateOnly");
 
-    public INamedTypeSymbol? TimeOnly => _timeOnly ??= GetTypeSymbol("System.TimeOnly");
+    public INamedTypeSymbol? TimeOnly => TryGet("System.TimeOnly");
 
-    private INamedTypeSymbol GetTypeSymbol(Type type) =>
-        _compilation.GetTypeByMetadataName(type.FullName ?? throw new InvalidOperationException("Could not get name of type " + type))
-        ?? throw new InvalidOperationException("Could not get type " + type.FullName);
+    public INamedTypeSymbol Get<T>() => Get(typeof(T).FullName);
 
-    private INamedTypeSymbol? GetTypeSymbol(string typeFullName) => _compilation.GetTypeByMetadataName(typeFullName);
+    public INamedTypeSymbol Get(Type type) =>
+        Get(type.FullName ?? throw new InvalidOperationException("Could not get name of type " + type));
+
+    public INamedTypeSymbol Get(string typeFullName) =>
+        TryGet(typeFullName) ?? throw new InvalidOperationException("Could not get type " + typeFullName);
+
+    private INamedTypeSymbol? TryGet(string typeFullName)
+    {
+        if (_cachedTypes.TryGetValue(typeFullName, out var typeSymbol))
+        {
+            return typeSymbol;
+        }
+
+        typeSymbol = _compilation.GetTypeByMetadataName(typeFullName);
+        _cachedTypes.Add(typeFullName, typeSymbol);
+
+        return typeSymbol;
+    }
 }

--- a/src/Riok.Mapperly/MapperGenerator.cs
+++ b/src/Riok.Mapperly/MapperGenerator.cs
@@ -37,6 +37,7 @@ public class MapperGenerator : IIncrementalGenerator
         if (mapperAttributeSymbol == null)
             return;
 
+        var wellKnownTypes = new WellKnownTypes(compilation);
         var uniqueNameBuilder = new UniqueNameBuilder();
         foreach (var mapperSyntax in mappers.Distinct())
         {
@@ -47,7 +48,7 @@ public class MapperGenerator : IIncrementalGenerator
             if (!mapperSymbol.HasAttribute(mapperAttributeSymbol))
                 continue;
 
-            var builder = new DescriptorBuilder(ctx, compilation, mapperSyntax, mapperSymbol);
+            var builder = new DescriptorBuilder(ctx, compilation, mapperSyntax, mapperSymbol, wellKnownTypes);
             var descriptor = builder.Build();
 
             ctx.AddSource(


### PR DESCRIPTION
**Description**
See #475

Add a `Dictionary<Type, INamedTypeSymbol?>` cache to `WellKnownTypes` to optimize `AttributeDataAccessor`.

**Benchmarks**
Benefits mappers with many mapping methods, saves 8ms for `LargeCompile` and saved 300 KB of memory. Doesn't look like `Compile` is effected.

**Old:**

|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.563 ms | 0.0261 ms | 0.0244 ms |   82.0313 |  19.5313 |  169.32 KB |
| LargeCompile | 59.450 ms | 1.1351 ms | 1.1148 ms | 1428.5714 | 285.7143 | 9280.05 KB |

|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.536 ms | 0.0238 ms | 0.0211 ms |   82.0313 |  19.5313 |  170.23 KB |
| LargeCompile | 57.525 ms | 0.5249 ms | 0.5155 ms | 1428.5714 | 285.7143 | 9276.68 KB |

|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.571 ms | 0.0240 ms | 0.0225 ms |   78.1250 |  15.6250 |  169.85 KB |
| LargeCompile | 58.310 ms | 0.9858 ms | 1.2819 ms | 1428.5714 | 285.7143 | 9272.75 KB |


**New:**


|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.594 ms | 0.0303 ms | 0.0384 ms |   78.1250 |  15.6250 |  168.44 KB |
| LargeCompile | 51.705 ms | 0.8099 ms | 1.1616 ms | 1375.0000 | 375.0000 | 8934.55 KB |

|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.575 ms | 0.0284 ms | 0.0304 ms |   89.8438 |  23.4375 |  168.49 KB |
| LargeCompile | 51.513 ms | 0.7022 ms | 1.1924 ms | 1333.3333 | 333.3333 | 8965.35 KB |

|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 | Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|----------:|
|      Compile |  1.559 ms | 0.0296 ms | 0.0277 ms |   78.1250 |  19.5313 | 169.52 KB |
| LargeCompile | 51.809 ms | 0.9939 ms | 1.0207 ms | 1375.0000 | 375.0000 | 8925.2 KB |
