### PR TITLE
WIP: refactor `MemberPath`

### DIFF
--- a/benchmarks/Riok.Mapperly.Benchmarks/Program.cs
+++ b/benchmarks/Riok.Mapperly.Benchmarks/Program.cs
@@ -1,3 +1,14 @@
 ﻿using BenchmarkDotNet.Running;
+using Riok.Mapperly.Benchmarks;
 
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+// var source =new SourceGeneratorBenchmarks();
+// source.SetupLargeCompile();
+// source.LargeCompile();
+//
+// Span<int> s = stackalloc int[4];
+// var r = Do(s);
+// static Span<int> Do(Span<int> src)
+// {
+//     return src.Slice(2);
+// }

--- a/benchmarks/Riok.Mapperly.Benchmarks/Program.cs
+++ b/benchmarks/Riok.Mapperly.Benchmarks/Program.cs
@@ -1,5 +1,6 @@
 ﻿using BenchmarkDotNet.Running;
-using Riok.Mapperly.Benchmarks;
+
+// using Riok.Mapperly.Benchmarks;
 
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 // var source =new SourceGeneratorBenchmarks();

--- a/samples/Riok.Mapperly.Sample/CarDto.cs
+++ b/samples/Riok.Mapperly.Sample/CarDto.cs
@@ -11,7 +11,7 @@ public class CarDto
     public ProducerDto? Producer { get; set; }
 
     public List<TireDto>? Tires { get; set; }
-    // public int ABCDEFGHIJKLM { get; set; }
+    public int ABCDEFGHIJKLM { get; set; }
 }
 
 // Intentionally use different numeric values for demonstration purposes

--- a/samples/Riok.Mapperly.Sample/CarDto.cs
+++ b/samples/Riok.Mapperly.Sample/CarDto.cs
@@ -11,6 +11,7 @@ public class CarDto
     public ProducerDto? Producer { get; set; }
 
     public List<TireDto>? Tires { get; set; }
+    // public int ABCDEFGHIJKLM { get; set; }
 }
 
 // Intentionally use different numeric values for demonstration purposes

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
@@ -46,14 +46,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
                 continue;
             }
 
-            if (
-                !MemberPath.TryFind(
-                    ctx.Mapping.SourceType,
-                    MemberPathCandidateBuilder.BuildMemberPathCandidates(targetMember.Name),
-                    ctx.IgnoredSourceMemberNames,
-                    out var sourceMemberPath
-                )
-            )
+            if (!MemberPath.TryFind(ctx.Mapping.SourceType, targetMember.Name, ctx.IgnoredSourceMemberNames, out var sourceMemberPath))
             {
                 ctx.BuilderContext.ReportDiagnostic(
                     targetMember.IsRequired ? DiagnosticDescriptors.RequiredMemberNotMapped : DiagnosticDescriptors.SourceMemberNotFound,
@@ -289,9 +282,9 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
         {
             return MemberPath.TryFind(
                 ctx.Mapping.SourceType,
-                MemberPathCandidateBuilder.BuildMemberPathCandidates(parameter.Name),
+                parameter.Name,
                 ctx.IgnoredSourceMemberNames,
-                StringComparer.OrdinalIgnoreCase,
+                StringComparison.OrdinalIgnoreCase,
                 out sourcePath
             );
         }

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
@@ -46,7 +46,15 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
                 continue;
             }
 
-            if (!MemberPath.TryFind(ctx.Mapping.SourceType, targetMember.Name, ctx.IgnoredSourceMemberNames, out var sourceMemberPath))
+            if (
+                !MemberPath.TryFind(
+                    ctx.Mapping.SourceType,
+                    targetMember.Name,
+                    ctx.IgnoredSourceMemberNames,
+                    ctx.BuilderContext.Types,
+                    out var sourceMemberPath
+                )
+            )
             {
                 ctx.BuilderContext.ReportDiagnostic(
                     targetMember.IsRequired ? DiagnosticDescriptors.RequiredMemberNotMapped : DiagnosticDescriptors.SourceMemberNotFound,
@@ -285,6 +293,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
                 parameter.Name,
                 ctx.IgnoredSourceMemberNames,
                 StringComparison.OrdinalIgnoreCase,
+                ctx.BuilderContext.Types,
                 out sourcePath
             );
         }

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
@@ -23,8 +23,8 @@ public static class ObjectMemberMappingBodyBuilder
     {
         var memberNameComparer =
             ctx.BuilderContext.MapperConfiguration.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseSensitive
-                ? StringComparer.Ordinal
-                : StringComparer.OrdinalIgnoreCase;
+                ? StringComparison.Ordinal
+                : StringComparison.OrdinalIgnoreCase;
 
         foreach (var targetMember in ctx.TargetMembers.Values)
         {
@@ -44,7 +44,7 @@ public static class ObjectMemberMappingBodyBuilder
             if (
                 MemberPath.TryFind(
                     ctx.Mapping.SourceType,
-                    MemberPathCandidateBuilder.BuildMemberPathCandidates(targetMember.Name),
+                    targetMember.Name,
                     ctx.IgnoredSourceMemberNames,
                     memberNameComparer,
                     out var sourceMemberPath

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
@@ -47,6 +47,7 @@ public static class ObjectMemberMappingBodyBuilder
                     targetMember.Name,
                     ctx.IgnoredSourceMemberNames,
                     memberNameComparer,
+                    ctx.BuilderContext.Types,
                     out var sourceMemberPath
                 )
             )

--- a/src/Riok.Mapperly/Descriptors/MemberPathCandidateBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MemberPathCandidateBuilder.cs
@@ -26,7 +26,7 @@ public static class MemberPathCandidateBuilder
         }
     }
 
-    private static IEnumerable<string> BuildName(string source, int[] splitIndices, int enabledSplitPositions)
+    public static IEnumerable<string> BuildName(string source, int[] splitIndices, int enabledSplitPositions)
     {
         var lastSplitIndex = 0;
         var currentSplitPosition = 1;
@@ -45,7 +45,7 @@ public static class MemberPathCandidateBuilder
             yield return source.Substring(lastSplitIndex);
     }
 
-    private static IEnumerable<int> GetPascalCaseSplitIndices(string str)
+    public static IEnumerable<int> GetPascalCaseSplitIndices(string str)
     {
         for (var i = 1; i < str.Length; i++)
         {

--- a/src/Riok.Mapperly/Descriptors/MemberPathCandidateBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MemberPathCandidateBuilder.cs
@@ -8,23 +8,23 @@ public static class MemberPathCandidateBuilder
     /// </summary>
     /// <param name="name">The name to build candidates from.</param>
     /// <returns>The joined member path groups.</returns>
-    internal static IEnumerable<IEnumerable<string>> BuildMemberPathCandidates(string name)
-    {
-        if (name.Length == 0)
-            yield break;
-
-        // yield full string
-        yield return new[] { name };
-
-        var indices = GetPascalCaseSplitIndices(name).ToArray();
-
-        // try all permutations, skipping the first because the full string is already yielded
-        var permutationsCount = 1 << indices.Length;
-        for (var i = 1; i < permutationsCount; i++)
-        {
-            yield return BuildName(name, indices, i);
-        }
-    }
+    // internal static IEnumerable<IEnumerable<string>> BuildMemberPathCandidates(string name)
+    // {
+    //     if (name.Length == 0)
+    //         yield break;
+    //
+    //     // yield full string
+    //     yield return new[] { name };
+    //
+    //     var indices = GetPascalCaseSplitIndices(name).ToArray();
+    //
+    //     // try all permutations, skipping the first because the full string is already yielded
+    //     var permutationsCount = 1 << indices.Length;
+    //     for (var i = 1; i < permutationsCount; i++)
+    //     {
+    //         yield return BuildName(name, indices, i);
+    //     }
+    // }
 
     public static IEnumerable<string> BuildName(string source, int[] splitIndices, int enabledSplitPositions)
     {
@@ -45,12 +45,18 @@ public static class MemberPathCandidateBuilder
             yield return source.Substring(lastSplitIndex);
     }
 
-    public static IEnumerable<int> GetPascalCaseSplitIndices(string str)
+    public static Span<int> GetPascalCaseSplitIndices(string str, Span<int> input)
     {
+        var j = 0;
         for (var i = 1; i < str.Length; i++)
         {
             if (char.IsUpper(str[i]))
-                yield return i;
+            {
+                input[j] = i;
+                j++;
+            }
         }
+
+        return input.Slice(0, j);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
+++ b/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
@@ -39,9 +39,9 @@ public class WellKnownTypes
         return typeSymbol;
     }
 
-    private readonly Dictionary<ITypeSymbol, ISymbol[]> _cachedSymbols = new();
+    private readonly Dictionary<ITypeSymbol, ISymbol[]> _cachedSymbols = new(SymbolEqualityComparer.Default);
 
-    public IEnumerable<ISymbol> GetMembers(ITypeSymbol symbol)
+    public ISymbol[] GetMembers(ITypeSymbol symbol)
     {
         if (_cachedSymbols.TryGetValue(symbol, out var members))
             return members;

--- a/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
+++ b/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Riok.Mapperly.Helpers;
 
 namespace Riok.Mapperly.Descriptors;
 
@@ -36,5 +37,17 @@ public class WellKnownTypes
         _cachedTypes.Add(typeFullName, typeSymbol);
 
         return typeSymbol;
+    }
+
+    private readonly Dictionary<ITypeSymbol, ISymbol[]> _cachedSymbols = new();
+
+    public IEnumerable<ISymbol> GetMembers(ITypeSymbol symbol)
+    {
+        if (_cachedSymbols.TryGetValue(symbol, out var members))
+            return members;
+
+        var symbolsMembers = symbol.GetAllMembers().Where(x => !x.IsStatic).ToArray();
+        _cachedSymbols.Add(symbol, symbolsMembers);
+        return symbolsMembers;
     }
 }

--- a/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
+++ b/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
@@ -86,9 +86,13 @@ internal static class SymbolExtensions
         return symbol.GetAllMembers().Where(x => !x.IsStatic && comparer.Equals(name, x.Name)).Select(MappableMember.Create).WhereNotNull();
     }
 
-    internal static IMappableMember? GetMappableMembers(this ITypeSymbol symbol, ReadOnlySpan<char> name, StringComparison comparer)
+    internal static IMappableMember? GetMappableMembers(
+        this IEnumerable<ISymbol> symbol,
+        ReadOnlySpan<char> name,
+        StringComparison comparer
+    )
     {
-        foreach (var x in symbol.GetAllMembers().Where(x => !x.IsStatic))
+        foreach (var x in symbol)
         {
             if (MemoryExtensions.Equals(name, x.Name.AsSpan(), comparer))
             {

--- a/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
+++ b/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
@@ -86,6 +86,22 @@ internal static class SymbolExtensions
         return symbol.GetAllMembers().Where(x => !x.IsStatic && comparer.Equals(name, x.Name)).Select(MappableMember.Create).WhereNotNull();
     }
 
+    internal static IMappableMember? GetMappableMembers(this ITypeSymbol symbol, ReadOnlySpan<char> name, StringComparison comparer)
+    {
+        foreach (var x in symbol.GetAllMembers().Where(x => !x.IsStatic))
+        {
+            if (MemoryExtensions.Equals(name, x.Name.AsSpan(), comparer))
+            {
+                if (MappableMember.Create(x) is { } mappableMember)
+                {
+                    return mappableMember;
+                }
+            }
+        }
+
+        return null;
+    }
+
     internal static IEnumerable<IMappableMember> GetAccessibleMappableMembers(this ITypeSymbol symbol)
     {
         return symbol

--- a/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
+++ b/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
@@ -86,15 +86,11 @@ internal static class SymbolExtensions
         return symbol.GetAllMembers().Where(x => !x.IsStatic && comparer.Equals(name, x.Name)).Select(MappableMember.Create).WhereNotNull();
     }
 
-    internal static IMappableMember? GetMappableMembers(
-        this IEnumerable<ISymbol> symbol,
-        ReadOnlySpan<char> name,
-        StringComparison comparer
-    )
+    internal static IMappableMember? GetMappableMembers(this ISymbol[] symbol, ReadOnlySpan<char> name, StringComparison comparer)
     {
         foreach (var x in symbol)
         {
-            if (MemoryExtensions.Equals(name, x.Name.AsSpan(), comparer))
+            if (name.Equals(x.Name.AsSpan(), comparer))
             {
                 if (MappableMember.Create(x) is { } mappableMember)
                 {

--- a/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDto.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDto.cs
@@ -13,7 +13,7 @@ namespace Riok.Mapperly.IntegrationTests.Dto
             CtorValue2 = ctorValue2;
         }
 
-        // public int ABCDEFGHIJKLM { get; set; }
+        public int ABCDEFGHIJKLM { get; set; }
         public int CtorValue { get; set; }
 
         public int CtorValue2 { get; set; }

--- a/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDto.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Dto/TestObjectDto.cs
@@ -13,6 +13,7 @@ namespace Riok.Mapperly.IntegrationTests.Dto
             CtorValue2 = ctorValue2;
         }
 
+        // public int ABCDEFGHIJKLM { get; set; }
         public int CtorValue { get; set; }
 
         public int CtorValue2 { get; set; }

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/TestMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/TestMapper.cs
@@ -62,9 +62,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         [MapEnum(EnumMappingStrategy.ByName)]
         public partial TestEnumDtoByName MapToEnumDtoByName(TestEnum v);
 
-        [MapEnum(EnumMappingStrategy.ByName)]
-        [MapEnumValue(TestEnumDtoExplicitLarger.Value40, TestEnum.Value30)]
-        public partial TestEnum MapToEnumDtoByNameWithExplicit(TestEnumDtoExplicitLarger v);
+        // [MapEnum(EnumMappingStrategy.ByName)]
+        // [MapEnumValue(TestEnumDtoExplicitLarger.Value40, TestEnum.Value30)]
+        // public partial TestEnum MapToEnumDtoByNameWithExplicit(TestEnumDtoExplicitLarger v);
 
         [MapperIgnoreTarget(nameof(TestObjectDto.IgnoredIntValue))]
         [MapperIgnoreSource(nameof(TestObject.IgnoredStringValue))]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/MapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/MapperTest.SnapshotGeneratedSource.verified.cs
@@ -185,17 +185,6 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             };
         }
 
-        public partial global::Riok.Mapperly.IntegrationTests.Models.TestEnum MapToEnumDtoByNameWithExplicit(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoExplicitLarger v)
-        {
-            return v switch
-            {
-                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoExplicitLarger.Value10 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value10,
-                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoExplicitLarger.Value20 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value20,
-                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoExplicitLarger.Value30 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
-                _ => throw new System.ArgumentOutOfRangeException(nameof(v), v, "The value of enum TestEnumDtoExplicitLarger is not supported"),
-            };
-        }
-
         public partial void UpdateDto(global::Riok.Mapperly.IntegrationTests.Models.TestObject source, global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto target)
         {
             if (source.NullableFlattening != null)

--- a/test/Riok.Mapperly.Tests/Descriptors/MemberPathCandidateBuilderTest.cs
+++ b/test/Riok.Mapperly.Tests/Descriptors/MemberPathCandidateBuilderTest.cs
@@ -1,4 +1,4 @@
-using Riok.Mapperly.Descriptors;
+// using Riok.Mapperly.Descriptors;
 
 namespace Riok.Mapperly.Tests.Descriptors;
 

--- a/test/Riok.Mapperly.Tests/Descriptors/MemberPathCandidateBuilderTest.cs
+++ b/test/Riok.Mapperly.Tests/Descriptors/MemberPathCandidateBuilderTest.cs
@@ -4,35 +4,35 @@ namespace Riok.Mapperly.Tests.Descriptors;
 
 public class MemberPathCandidateBuilderTest
 {
-    [Theory]
-    [InlineData("", new string[] { })]
-    [InlineData("a", new[] { "a" })]
-    [InlineData("A", new[] { "A" })]
-    [InlineData("aA", new[] { "aA", "a.A" })]
-    [InlineData("AB", new[] { "AB", "A.B" })]
-    [InlineData("Value", new[] { "Value" })]
-    [InlineData("MyValue", new[] { "MyValue", "My.Value" })]
-    [InlineData("MyValueId", new[] { "MyValueId", "My.ValueId", "MyValue.Id", "My.Value.Id" })]
-    [InlineData(
-        "MyValueIdNum",
-        new[]
-        {
-            "MyValueIdNum",
-            "My.ValueIdNum",
-            "MyValue.IdNum",
-            "My.Value.IdNum",
-            "MyValueId.Num",
-            "My.ValueId.Num",
-            "MyValue.Id.Num",
-            "My.Value.Id.Num"
-        }
-    )]
-    public void BuildMemberPathCandidatesShouldWork(string name, string[] chunks)
-    {
-        MemberPathCandidateBuilder
-            .BuildMemberPathCandidates(name)
-            .Select(x => string.Join(".", x))
-            .Should()
-            .BeEquivalentTo(chunks, o => o.WithStrictOrdering());
-    }
+    // [Theory]
+    // [InlineData("", new string[] { })]
+    // [InlineData("a", new[] { "a" })]
+    // [InlineData("A", new[] { "A" })]
+    // [InlineData("aA", new[] { "aA", "a.A" })]
+    // [InlineData("AB", new[] { "AB", "A.B" })]
+    // [InlineData("Value", new[] { "Value" })]
+    // [InlineData("MyValue", new[] { "MyValue", "My.Value" })]
+    // [InlineData("MyValueId", new[] { "MyValueId", "My.ValueId", "MyValue.Id", "My.Value.Id" })]
+    // [InlineData(
+    //     "MyValueIdNum",
+    //     new[]
+    //     {
+    //         "MyValueIdNum",
+    //         "My.ValueIdNum",
+    //         "MyValue.IdNum",
+    //         "My.Value.IdNum",
+    //         "MyValueId.Num",
+    //         "My.ValueId.Num",
+    //         "MyValue.Id.Num",
+    //         "My.Value.Id.Num"
+    //     }
+    // )]
+    // public void BuildMemberPathCandidatesShouldWork(string name, string[] chunks)
+    // {
+    //     MemberPathCandidateBuilder
+    //         .BuildMemberPathCandidates(name)
+    //         .Select(x => string.Join(".", x))
+    //         .Should()
+    //         .BeEquivalentTo(chunks, o => o.WithStrictOrdering());
+    // }
 }


### PR DESCRIPTION
Playing around with refactoring `MemberPath` to use `ReadOnlySpan<char>` this PR is not complete. I'm using the CI pipeline to check it works for framework.

#### Unchanged
##### Normal
|       Method |      Mean |     Error |    StdDev |    Median |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.559 ms | 0.0305 ms | 0.0363 ms |  1.561 ms |   70.3125 |  15.6250 |  164.08 KB |
| LargeCompile | 49.250 ms | 0.9972 ms | 2.6961 ms | 48.082 ms | 1222.2222 | 333.3333 | 7959.24 KB |

##### Big
|       Method |      Mean |    Error |   StdDev |       Gen0 |      Gen1 | Allocated |
|------------- |----------:|---------:|---------:|-----------:|----------:|----------:|
|      Compile |  17.23 ms | 0.223 ms | 0.186 ms |  3687.5000 |   62.5000 |   5.55 MB |
| LargeCompile | 183.90 ms | 2.656 ms | 2.218 ms | 17666.6667 | 1000.0000 |  34.65 MB |


#### Cached symbols, use `Span`, inlined indices and removed iterator.
##### Normal
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 | Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|----------:|
|      Compile |  1.549 ms | 0.0201 ms | 0.0179 ms |   70.3125 |  15.6250 | 164.19 KB |
| LargeCompile | 43.796 ms | 0.8133 ms | 0.7988 ms | 1100.0000 | 200.0000 | 7320.2 KB |

###### Big
|       Method |       Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |-----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |   4.543 ms | 0.0886 ms | 0.1829 ms |  171.8750 |  39.0625 |   300.9 KB |
| LargeCompile | 115.573 ms | 2.3086 ms | 2.2674 ms | 1250.0000 | 250.0000 | 7980.59 KB |


#### Removed IEnumerable<ISymbol> boxing
##### Normal
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.555 ms | 0.0265 ms | 0.0363 ms |   62.5000 |  15.6250 |  164.78 KB |
| LargeCompile | 43.291 ms | 0.7989 ms | 0.7846 ms | 1100.0000 | 200.0000 | 7306.75 KB |

##### Big
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  2.934 ms | 0.0545 ms | 0.0483 ms |   70.3125 |  15.6250 |   167.9 KB |
| LargeCompile | 78.747 ms | 1.3655 ms | 1.0661 ms | 1166.6667 | 333.3333 | 7325.02 KB |
