### PR TITLE
feat: refactored `UniqueNameBuilder`

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityNonEnumerated.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityNonEnumerated.cs
@@ -20,6 +20,7 @@ namespace Riok.Mapperly.Descriptors.Enumerables.EnsureCapacity;
 /// </remarks>
 public class EnsureCapacityNonEnumerated : EnsureCapacity
 {
+    private const string SourceCountVariableName = "sourceCount";
     private readonly string _targetAccessor;
     private readonly IMethodSymbol _getNonEnumeratedMethod;
 
@@ -33,7 +34,7 @@ public class EnsureCapacityNonEnumerated : EnsureCapacity
     {
         var targetCount = MemberAccess(target, _targetAccessor);
 
-        var countIdentifier = Identifier(ctx.NameBuilder.New("sourceCount"));
+        var countIdentifier = Identifier(ctx.NameBuilder.New(SourceCountVariableName));
         var countIdentifierName = IdentifierName(countIdentifier);
 
         var enumerableArgument = Argument(ctx.Source);

--- a/src/Riok.Mapperly/Helpers/UniqueNameBuilder.cs
+++ b/src/Riok.Mapperly/Helpers/UniqueNameBuilder.cs
@@ -3,31 +3,46 @@ namespace Riok.Mapperly.Helpers;
 public class UniqueNameBuilder
 {
     private readonly HashSet<string> _usedNames;
+    private readonly UniqueNameBuilder? _parentScope;
 
     public UniqueNameBuilder()
     {
         _usedNames = new HashSet<string>();
     }
 
-    private UniqueNameBuilder(IEnumerable<string> usedNames)
+    private UniqueNameBuilder(UniqueNameBuilder parentScope)
     {
-        _usedNames = new HashSet<string>(usedNames);
+        _usedNames = new HashSet<string>();
+        _parentScope = parentScope;
     }
 
     public void Reserve(string name) => _usedNames.Add(name);
 
-    public UniqueNameBuilder NewScope() => new(_usedNames);
+    public UniqueNameBuilder NewScope() => new(this);
 
     public string New(string name)
     {
         var i = 0;
         var uniqueName = name;
-        while (!_usedNames.Add(uniqueName))
+        while (Contains(uniqueName))
         {
             i++;
             uniqueName = name + i;
         }
 
+        _usedNames.Add(uniqueName);
+
         return uniqueName;
+    }
+
+    private bool Contains(string name)
+    {
+        if (_usedNames.Contains(name))
+            return true;
+
+        if (_parentScope != null)
+            return _parentScope.Contains(name);
+
+        return false;
     }
 }


### PR DESCRIPTION
I noticed that `UniqueNameBuilder` would repeatedly copy a large `HashSet` whenever a subscope was created. Often, the child scope would generate one or two new names and then exit.

To counter this, I optimized `UniqueNamebuilder` to reference and check its parent scope. If there are few items in its parent, to copy its parents names and check its grandparents scope. By checking the parents scope we prevent a lot of copying to subscopes. By optionally copying the parent and using the grandparent we reduce the depth of the generated `UniqueNameBuilders` and keep the runing time of `New` down. However, instantiating the `UniqueNameBuilder` takes longer and uses more memory due to the copying.

This is a pretty micro benchmarky change and relies upon a parents scope not changing when a child scope is being used. `Mapperly` doesn't appear to violate this, but if this changes it could result in variable names having incorrect numbers added or invalid names being used in sub scopes.

The best value for when a parent is copied or referenced depends on how many nested scopes are expected, total number of names and desired speed over memory. A small value will use the least memory but can make generation slower under some circumstances, similarly a large value will use a lot of memory but can also be slower under some circumstances.

**TLDR**
 I chose a smallish (8) number to keep memory usage down, realistically its unlikely that a lot of sub scopes will be created, that and the cost of copying a parent to its children will likely outweigh any benefits from not creating a deep tree.



### Benchmarks

These changes save about 200KB for `LargeCompile`, there are likely some small performance benefits although the benchmarks don't show this.
#### Baseline Unchanged
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.737 ms | 0.0345 ms | 0.0547 ms |   85.9375 |  15.6250 |  187.18 KB |
| LargeCompile | 50.392 ms | 0.9305 ms | 0.7770 ms | 1375.0000 | 250.0000 | 8665.69 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.739 ms | 0.0229 ms | 0.0214 ms |   97.6563 |  19.5313 |  187.46 KB |
| LargeCompile | 49.000 ms | 0.7502 ms | 0.5857 ms | 1333.3333 | 333.3333 | 8666.31 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.728 ms | 0.0207 ms | 0.0184 ms |   85.9375 |   7.8125 |     187 KB |
| LargeCompile | 47.254 ms | 0.4024 ms | 0.3360 ms | 1333.3333 | 333.3333 | 8666.67 KB |

#### Node 0
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.747 ms | 0.0188 ms | 0.0157 ms |   93.7500 |  19.5313 |  184.28 KB |
| LargeCompile | 49.971 ms | 0.9620 ms | 0.8528 ms | 1333.3333 | 333.3333 | 8484.35 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.712 ms | 0.0215 ms | 0.0201 ms |   93.7500 |  23.4375 |   185.1 KB |
| LargeCompile | 48.708 ms | 0.7362 ms | 0.6148 ms | 1333.3333 | 333.3333 | 8484.28 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.721 ms | 0.0194 ms | 0.0172 ms |   97.6563 |  23.4375 |  184.14 KB |
| LargeCompile | 48.903 ms | 0.7557 ms | 0.5900 ms | 1333.3333 | 333.3333 | 8483.77 KB |

#### Node 8
Node 8
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.738 ms | 0.0243 ms | 0.0203 ms |  105.4688 |  23.4375 |  185.04 KB |
| LargeCompile | 50.034 ms | 0.9816 ms | 1.0503 ms | 1333.3333 | 333.3333 | 8490.15 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.706 ms | 0.0158 ms | 0.0148 ms |   93.7500 |  19.5313 |  183.83 KB |
| LargeCompile | 47.312 ms | 0.7584 ms | 0.6723 ms | 1333.3333 | 333.3333 | 8482.69 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.736 ms | 0.0235 ms | 0.0208 ms |   97.6563 |  19.5313 |  185.37 KB |
| LargeCompile | 49.524 ms | 0.8619 ms | 1.2633 ms | 1375.0000 | 375.0000 | 8483.54 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.765 ms | 0.0352 ms | 0.0330 ms |   93.7500 |  15.6250 |  185.04 KB |
| LargeCompile | 49.129 ms | 0.7416 ms | 1.1975 ms | 1285.7143 | 285.7143 | 8482.86 KB |

<details>
<summary> All benchmarks </summary>
Note that the timing is unreliable, the memory cost appears to be more stable

Baseline Unchanged
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.737 ms | 0.0345 ms | 0.0547 ms |   85.9375 |  15.6250 |  187.18 KB |
| LargeCompile | 50.392 ms | 0.9305 ms | 0.7770 ms | 1375.0000 | 250.0000 | 8665.69 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.739 ms | 0.0229 ms | 0.0214 ms |   97.6563 |  19.5313 |  187.46 KB |
| LargeCompile | 49.000 ms | 0.7502 ms | 0.5857 ms | 1333.3333 | 333.3333 | 8666.31 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.728 ms | 0.0207 ms | 0.0184 ms |   85.9375 |   7.8125 |     187 KB |
| LargeCompile | 47.254 ms | 0.4024 ms | 0.3360 ms | 1333.3333 | 333.3333 | 8666.67 KB |




Node 0
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.747 ms | 0.0188 ms | 0.0157 ms |   93.7500 |  19.5313 |  184.28 KB |
| LargeCompile | 49.971 ms | 0.9620 ms | 0.8528 ms | 1333.3333 | 333.3333 | 8484.35 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.712 ms | 0.0215 ms | 0.0201 ms |   93.7500 |  23.4375 |   185.1 KB |
| LargeCompile | 48.708 ms | 0.7362 ms | 0.6148 ms | 1333.3333 | 333.3333 | 8484.28 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.721 ms | 0.0194 ms | 0.0172 ms |   97.6563 |  23.4375 |  184.14 KB |
| LargeCompile | 48.903 ms | 0.7557 ms | 0.5900 ms | 1333.3333 | 333.3333 | 8483.77 KB |

Node 1
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.732 ms | 0.0306 ms | 0.0286 ms |  101.5625 |  19.5313 |  185.67 KB |
| LargeCompile | 50.166 ms | 0.7044 ms | 1.3738 ms | 1375.0000 | 375.0000 | 8483.42 KB |



Node 2
|       Method |      Mean |     Error |    StdDev |    Median |      Gen0 |     Gen1 | Allocated |
|------------- |----------:|----------:|----------:|----------:|----------:|---------:|----------:|
|      Compile |  1.736 ms | 0.0251 ms | 0.0223 ms |  1.731 ms |   89.8438 |  15.6250 | 184.81 KB |
| LargeCompile | 51.790 ms | 2.0021 ms | 5.6470 ms | 48.670 ms | 1333.3333 | 333.3333 | 8487.7 KB |
|       Method |      Mean |     Error |    StdDev |    Median |      Gen0 |     Gen1 | Allocated |
|------------- |----------:|----------:|----------:|----------:|----------:|---------:|----------:|
|      Compile |  1.736 ms | 0.0246 ms | 0.0218 ms |  1.732 ms |   97.6563 |  19.5313 | 186.57 KB |
| LargeCompile | 54.197 ms | 2.5640 ms | 7.2735 ms | 50.543 ms | 1333.3333 | 333.3333 | 8481.4 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.805 ms | 0.0354 ms | 0.0394 ms |   85.9375 |  23.4375 |  182.19 KB |
| LargeCompile | 48.550 ms | 0.8174 ms | 0.9085 ms | 1333.3333 | 333.3333 | 8481.62 KB |



Node 4
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.753 ms | 0.0327 ms | 0.0290 ms |   93.7500 |  23.4375 |  186.91 KB |
| LargeCompile | 51.716 ms | 0.9932 ms | 0.8805 ms | 1375.0000 | 375.0000 | 8490.48 KB |



Node 8
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.738 ms | 0.0243 ms | 0.0203 ms |  105.4688 |  23.4375 |  185.04 KB |
| LargeCompile | 50.034 ms | 0.9816 ms | 1.0503 ms | 1333.3333 | 333.3333 | 8490.15 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.706 ms | 0.0158 ms | 0.0148 ms |   93.7500 |  19.5313 |  183.83 KB |
| LargeCompile | 47.312 ms | 0.7584 ms | 0.6723 ms | 1333.3333 | 333.3333 | 8482.69 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.736 ms | 0.0235 ms | 0.0208 ms |   97.6563 |  19.5313 |  185.37 KB |
| LargeCompile | 49.524 ms | 0.8619 ms | 1.2633 ms | 1375.0000 | 375.0000 | 8483.54 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.765 ms | 0.0352 ms | 0.0330 ms |   93.7500 |  15.6250 |  185.04 KB |
| LargeCompile | 49.129 ms | 0.7416 ms | 1.1975 ms | 1285.7143 | 285.7143 | 8482.86 KB |



Node 16
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.748 ms | 0.0341 ms | 0.0405 ms |   93.7500 |  15.6250 |  184.06 KB |
| LargeCompile | 52.655 ms | 1.0132 ms | 0.9478 ms | 1375.0000 | 250.0000 | 8489.68 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.759 ms | 0.0291 ms | 0.0582 ms |   85.9375 |  15.6250 |  185.74 KB |
| LargeCompile | 48.654 ms | 0.7797 ms | 0.6912 ms | 1333.3333 | 333.3333 | 8483.26 KB |

|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.754 ms | 0.0244 ms | 0.0228 ms |   97.6563 |  15.6250 |  186.92 KB |
| LargeCompile | 50.772 ms | 0.6574 ms | 0.6150 ms | 1375.0000 | 250.0000 | 8482.26 KB |


Node 32
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.745 ms | 0.0344 ms | 0.0321 ms |   85.9375 |  15.6250 |  185.37 KB |
| LargeCompile | 51.164 ms | 0.9583 ms | 1.0254 ms | 1333.3333 | 333.3333 | 8488.31 KB |



</details>