### PR TITLE
feat: introduce experimental full nameof support

### DIFF
--- a/docs/docs/configuration/flattening.md
+++ b/docs/docs/configuration/flattening.md
@@ -14,9 +14,31 @@ by either using the source and target property path names as arrays or using a d
 [MapProperty(new[] { nameof(Car.Make), nameof(Car.Make.Id) }, new[] { nameof(CarDto.MakeId) })]
 // Or alternatively
 [MapProperty("Make.Id", "MakeId")]
+// Or
+[MapProperty($"{nameof(Make)}.{nameof(Make.Id)}", "MakeId")]
 partial CarDto Map(Car car);
 ```
 
 :::info
 Unflattening is not automatically configured by Mapperly and needs to be configured manually via `MapPropertyAttribute`.
+:::
+
+## Experimental full `nameof`
+
+Mapperly supports an experimental "fullnameof".
+It can be used to configure property paths using `nameof`.
+Opt-in is done by prefixing the path with `@`.
+
+```csharp
+[MapProperty(nameof(@Car.Make.Id), nameof(CarDto.MakeId))]
+partial CarDto Map(Car car);
+```
+
+`@nameof(Car.Make.Id)` will result in the property path `Make.Id`.
+The first part of the property path is stripped.
+Make sure these property paths start with the type of the property and not with a namespace or a property.
+
+:::warning
+This is an experimental API.
+Its API surface is not subject to semantic releases and may break in any release.
 :::

--- a/docs/docs/configuration/mapper.mdx
+++ b/docs/docs/configuration/mapper.mdx
@@ -31,6 +31,7 @@ public partial class CarMapper
 
 On each mapping method declaration, property and field mappings can be customized.
 If a property or field on the target has a different name than on the source, the `MapPropertyAttribute` can be applied.
+See also the documentation on [flattening / unflattening](./flattening.md).
 
 ```csharp
 [Mapper]

--- a/docs/src/plugins/rehype/rehype-faq/index.js
+++ b/docs/src/plugins/rehype/rehype-faq/index.js
@@ -13,7 +13,7 @@ import { toHtml } from 'hast-util-to-html';
 
   If working on this script,
   testing changes needs the .docusaurus cache directory to be cleared.
-  Eg. `rm -rf .docusaurus; npm run start`
+  Eg. `npm run clear; npm run start`
 */
 
 const faqFileName = 'faq.md';


### PR DESCRIPTION
# introduce experimental full nameof support

## Description

Introduces experimental full nameof support.
See #401.

This would allow simpler `MapProperty` attributes for nested properties:
`[MapProperty(nameof(@A.B.C), nameof(@D.E.F)]` would be the same as `[MapProperty(new[]{nameof(A.B), nameof(A.B.C)}, new[]{nameof(D.E), nameof(D.E.F)}]`.


## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
