### PR TITLE
chore: cache members, mappable members, get attribute and optimize `CollectionInfoBu…

### DIFF
--- a/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
@@ -13,6 +13,7 @@ public class DescriptorBuilder
 {
     private readonly MapperDescriptor _mapperDescriptor;
 
+    private readonly WellKnownTypes _wellKnownTypes;
     private readonly MappingCollection _mappings = new();
     private readonly MethodNameBuilder _methodNameBuilder = new();
     private readonly MappingBodyBuilder _mappingBodyBuilder;
@@ -28,6 +29,7 @@ public class DescriptorBuilder
         WellKnownTypes wellKnownTypes
     )
     {
+        _wellKnownTypes = wellKnownTypes;
         _mapperDescriptor = new MapperDescriptor(mapperSyntax, mapperSymbol, _methodNameBuilder);
         _mappingBodyBuilder = new MappingBodyBuilder(_mappings);
         _builderContext = new SimpleMappingBuilderContext(
@@ -77,7 +79,7 @@ public class DescriptorBuilder
 
     private void ReserveMethodNames()
     {
-        foreach (var methodSymbol in _mapperDescriptor.Symbol.GetAllMembers())
+        foreach (var methodSymbol in _mapperDescriptor.Symbol.GetAllMembers(_wellKnownTypes))
         {
             _methodNameBuilder.Reserve(methodSymbol.Name);
         }

--- a/src/Riok.Mapperly/Descriptors/Enumerables/CollectionInfoBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/CollectionInfoBuilder.cs
@@ -6,7 +6,7 @@ namespace Riok.Mapperly.Descriptors.Enumerables;
 
 public static class CollectionInfoBuilder
 {
-    private record CollectionTypeInfo(
+    private readonly record struct CollectionTypeInfo(
         CollectionType CollectionType,
         Type? ReflectionType = null,
         string? TypeFullName = null,
@@ -52,56 +52,80 @@ public static class CollectionInfoBuilder
         new CollectionTypeInfo(CollectionType.ImmutableSortedSet, typeof(ImmutableSortedSet<>), Immutable: true),
         new CollectionTypeInfo(CollectionType.ImmutableQueue, typeof(ImmutableQueue<>), Immutable: true),
         new CollectionTypeInfo(CollectionType.IImmutableQueue, typeof(IImmutableQueue<>), Immutable: true),
-        new CollectionTypeInfo(CollectionType.IImmutableQueue, typeof(IImmutableQueue<>), Immutable: true),
         new CollectionTypeInfo(CollectionType.ImmutableStack, typeof(ImmutableStack<>), Immutable: true),
         new CollectionTypeInfo(CollectionType.IImmutableStack, typeof(IImmutableStack<>), Immutable: true),
         new CollectionTypeInfo(CollectionType.IImmutableDictionary, typeof(IImmutableDictionary<,>), Immutable: true),
         new CollectionTypeInfo(CollectionType.ImmutableDictionary, typeof(ImmutableDictionary<,>), Immutable: true),
+        new CollectionTypeInfo(CollectionType.ImmutableSortedDictionary, typeof(ImmutableSortedDictionary<,>), Immutable: true),
     };
 
-    public static CollectionInfos? Build(WellKnownTypes wellKnownTypes, ITypeSymbol source, ITypeSymbol target)
+    public static CollectionInfos? BuildCollectionInfos(WellKnownTypes wellKnownTypes, ITypeSymbol source, ITypeSymbol target)
     {
-        if (Build(wellKnownTypes, source) is not { } sourceInfo)
+        // check for enumerated type to quickly check that both are collection types
+        var enumeratedSourceType = GetEnumeratedType(wellKnownTypes, source);
+        if (enumeratedSourceType == null)
             return null;
 
-        if (Build(wellKnownTypes, target) is not { } targetInfo)
+        var enumeratedTargetType = GetEnumeratedType(wellKnownTypes, target);
+        if (enumeratedTargetType == null)
             return null;
+
+        var sourceInfo = Build(wellKnownTypes, source, enumeratedSourceType);
+        var targetInfo = Build(wellKnownTypes, target, enumeratedTargetType);
 
         return new CollectionInfos(sourceInfo, targetInfo);
     }
 
-    private static CollectionInfo? Build(WellKnownTypes wellKnownTypes, ITypeSymbol type)
+    private static CollectionInfo Build(WellKnownTypes wellKnownTypes, ITypeSymbol type, ITypeSymbol enumeratedType)
     {
-        var enumeratedType = GetEnumeratedType(wellKnownTypes, type);
-        if (enumeratedType == null)
-            return null;
-
         var collectionTypeInfo = GetCollectionTypeInfo(wellKnownTypes, type);
+        var typeInfo = collectionTypeInfo?.CollectionType ?? CollectionType.None;
+
         return new CollectionInfo(
-            collectionTypeInfo?.CollectionType ?? CollectionType.None,
-            GetImplementedCollectionTypes(wellKnownTypes, type),
+            typeInfo,
+            GetImplementedCollectionTypes(wellKnownTypes, type, typeInfo),
             enumeratedType,
-            IsCountKnown(wellKnownTypes, type),
-            HasValidAddMethod(wellKnownTypes, type),
+            IsCountKnown(wellKnownTypes, type, typeInfo),
+            HasValidAddMethod(wellKnownTypes, type, typeInfo),
             collectionTypeInfo?.Immutable == true
         );
     }
 
     private static ITypeSymbol? GetEnumeratedType(WellKnownTypes types, ITypeSymbol type)
     {
-        return type.ImplementsGeneric(types.Get(typeof(IEnumerable<>)), out var enumerableIntf) ? enumerableIntf.TypeArguments[0] : null;
+        return type.ImplementsGeneric(types.Get(typeof(IEnumerable<>)), out var enumerable) ? enumerable.TypeArguments[0] : null;
     }
 
-    private static bool HasValidAddMethod(WellKnownTypes types, ITypeSymbol t)
+    private static bool HasValidAddMethod(WellKnownTypes types, ITypeSymbol t, CollectionType typeInfo)
     {
+        if (
+            typeInfo
+            is CollectionType.ICollection
+                or CollectionType.IList
+                or CollectionType.List
+                or CollectionType.ISet
+                or CollectionType.HashSet
+                or CollectionType.SortedSet
+        )
+            return true;
+
+        if (typeInfo is not CollectionType.None)
+            return false;
+
         return t.HasImplicitGenericImplementation(types.Get(typeof(ICollection<>)), nameof(ICollection<object>.Add))
             || t.HasImplicitGenericImplementation(types.Get(typeof(ISet<>)), nameof(ISet<object>.Add));
     }
 
-    private static bool IsCountKnown(WellKnownTypes types, ITypeSymbol t)
+    private static bool IsCountKnown(WellKnownTypes types, ITypeSymbol t, CollectionType typeInfo)
     {
+        if (typeInfo is CollectionType.IEnumerable)
+            return false;
+
+        if (typeInfo is not CollectionType.None)
+            return true;
+
         var intType = types.Get<int>();
-        return t.GetAccessibleMappableMembers()
+        return t.GetAccessibleMappableMembers(types)
             .Any(
                 x =>
                     x.Name is nameof(ICollection<object>.Count) or nameof(Array.Length)
@@ -113,6 +137,10 @@ public static class CollectionInfoBuilder
     {
         if (type.IsArrayType())
             return _collectionTypeInfoArray;
+
+        // string is a collection but does implement IEnumerable, return early
+        if (type.SpecialType == SpecialType.System_String)
+            return null;
 
         foreach (var typeInfo in _collectionTypeInfos)
         {
@@ -126,21 +154,144 @@ public static class CollectionInfoBuilder
         return null;
     }
 
-    private static CollectionType GetImplementedCollectionTypes(WellKnownTypes types, ITypeSymbol type)
+    private static CollectionType GetImplementedCollectionTypes(WellKnownTypes types, ITypeSymbol type, CollectionType collectionType)
     {
-        var implementedCollectionTypes = type.IsArrayType() ? CollectionType.Array : CollectionType.None;
-
-        foreach (var typeInfo in _collectionTypeInfos)
+        return collectionType switch
         {
-            if (typeInfo.GetTypeSymbol(types) is not { } typeSymbol)
-                continue;
+            CollectionType.Array
+                => CollectionType.Array
+                    | CollectionType.IList
+                    | CollectionType.IReadOnlyList
+                    | CollectionType.IList
+                    | CollectionType.ICollection
+                    | CollectionType.IReadOnlyCollection
+                    | CollectionType.IEnumerable,
+            CollectionType.IEnumerable => CollectionType.IEnumerable,
+            CollectionType.List
+                => CollectionType.List
+                    | CollectionType.IList
+                    | CollectionType.IReadOnlyList
+                    | CollectionType.ICollection
+                    | CollectionType.IReadOnlyCollection
+                    | CollectionType.IEnumerable,
+            CollectionType.Stack => CollectionType.Stack | CollectionType.IReadOnlyCollection | CollectionType.IEnumerable,
+            CollectionType.Queue => CollectionType.Queue | CollectionType.IReadOnlyCollection | CollectionType.IEnumerable,
+            CollectionType.IReadOnlyCollection => CollectionType.IReadOnlyCollection | CollectionType.IEnumerable,
+            CollectionType.IList => CollectionType.IList | CollectionType.ICollection | CollectionType.IEnumerable,
+            CollectionType.IReadOnlyList => CollectionType.IReadOnlyList | CollectionType.IReadOnlyCollection | CollectionType.IEnumerable,
+            CollectionType.ICollection => CollectionType.ICollection | CollectionType.IEnumerable,
+            CollectionType.HashSet
+                => CollectionType.HashSet
+                    | CollectionType.ISet
+                    | CollectionType.IReadOnlySet
+                    | CollectionType.ICollection
+                    | CollectionType.IReadOnlyCollection
+                    | CollectionType.IEnumerable,
+            CollectionType.SortedSet
+                => CollectionType.SortedSet
+                    | CollectionType.ISet
+                    | CollectionType.IReadOnlySet
+                    | CollectionType.ICollection
+                    | CollectionType.IReadOnlyCollection
+                    | CollectionType.IEnumerable,
+            CollectionType.ISet => CollectionType.ISet | CollectionType.ICollection | CollectionType.IEnumerable,
+            CollectionType.IReadOnlySet => CollectionType.IReadOnlySet | CollectionType.IReadOnlyCollection | CollectionType.IEnumerable,
+            CollectionType.IDictionary => CollectionType.IDictionary | CollectionType.ICollection | CollectionType.IEnumerable,
+            CollectionType.IReadOnlyDictionary
+                => CollectionType.IReadOnlyDictionary | CollectionType.IReadOnlyCollection | CollectionType.IEnumerable,
+            CollectionType.Dictionary
+                => CollectionType.Dictionary
+                    | CollectionType.IDictionary
+                    | CollectionType.IReadOnlyDictionary
+                    | CollectionType.ICollection
+                    | CollectionType.IReadOnlyCollection
+                    | CollectionType.IEnumerable,
 
-            if (type.ImplementsGeneric(typeSymbol, out _))
+            CollectionType.ImmutableArray
+                => CollectionType.ImmutableArray
+                    | CollectionType.IImmutableList
+                    | CollectionType.IList
+                    | CollectionType.IReadOnlyList
+                    | CollectionType.ICollection
+                    | CollectionType.IReadOnlyCollection
+                    | CollectionType.IEnumerable,
+            CollectionType.ImmutableList
+                => CollectionType.ImmutableList
+                    | CollectionType.IImmutableList
+                    | CollectionType.IList
+                    | CollectionType.IReadOnlyList
+                    | CollectionType.ICollection
+                    | CollectionType.IReadOnlyCollection
+                    | CollectionType.IEnumerable,
+            CollectionType.IImmutableList
+                => CollectionType.IImmutableList
+                    | CollectionType.IReadOnlyList
+                    | CollectionType.IReadOnlyCollection
+                    | CollectionType.IEnumerable,
+            CollectionType.ImmutableHashSet
+                => CollectionType.ImmutableHashSet
+                    | CollectionType.IImmutableSet
+                    | CollectionType.IReadOnlySet
+                    | CollectionType.ISet
+                    | CollectionType.ICollection
+                    | CollectionType.IReadOnlyCollection
+                    | CollectionType.IEnumerable,
+            CollectionType.IImmutableSet => CollectionType.IImmutableSet | CollectionType.IReadOnlyCollection | CollectionType.IEnumerable,
+            CollectionType.ImmutableSortedSet
+                => CollectionType.ImmutableSortedSet
+                    | CollectionType.IImmutableSet
+                    | CollectionType.IList
+                    | CollectionType.IReadOnlyList
+                    | CollectionType.ISet
+                    | CollectionType.IReadOnlySet
+                    | CollectionType.ICollection
+                    | CollectionType.IReadOnlyCollection
+                    | CollectionType.IEnumerable,
+            CollectionType.ImmutableQueue => CollectionType.ImmutableQueue | CollectionType.IImmutableQueue | CollectionType.IEnumerable,
+            CollectionType.IImmutableQueue => CollectionType.IImmutableQueue | CollectionType.IEnumerable,
+            CollectionType.ImmutableStack => CollectionType.ImmutableStack | CollectionType.IImmutableStack | CollectionType.IEnumerable,
+            CollectionType.IImmutableStack => CollectionType.IImmutableStack | CollectionType.IEnumerable,
+            CollectionType.ImmutableDictionary
+                => CollectionType.ImmutableDictionary
+                    | CollectionType.IImmutableDictionary
+                    | CollectionType.IDictionary
+                    | CollectionType.IReadOnlyDictionary
+                    | CollectionType.ICollection
+                    | CollectionType.IReadOnlyCollection
+                    | CollectionType.IEnumerable,
+            CollectionType.IImmutableDictionary
+                => CollectionType.IImmutableDictionary
+                    | CollectionType.IReadOnlyDictionary
+                    | CollectionType.IReadOnlyCollection
+                    | CollectionType.IEnumerable,
+
+            CollectionType.ImmutableSortedDictionary
+                => CollectionType.ImmutableSortedDictionary
+                    | CollectionType.IImmutableDictionary
+                    | CollectionType.IReadOnlyDictionary
+                    | CollectionType.IReadOnlyCollection
+                    | CollectionType.IEnumerable,
+
+            CollectionType.None when SymbolEqualityComparer.Default.Equals(type, types.Get<string>()) => CollectionType.IEnumerable,
+            _ => IterateHierarchy(type, types)
+        };
+
+        static CollectionType IterateHierarchy(ITypeSymbol type, WellKnownTypes types)
+        {
+            var implementedCollectionTypes = type.IsArrayType() ? CollectionType.Array : CollectionType.None;
+
+            foreach (var typeInfo in _collectionTypeInfos)
             {
-                implementedCollectionTypes |= typeInfo.CollectionType;
-            }
-        }
+                if (typeInfo.GetTypeSymbol(types) is not { } typeSymbol)
+                    continue;
 
-        return implementedCollectionTypes;
+                if (type.ImplementsGeneric(typeSymbol, out _))
+                {
+                    implementedCollectionTypes |= typeInfo.CollectionType;
+                }
+            }
+
+            return implementedCollectionTypes;
+        }
     }
 }

--- a/src/Riok.Mapperly/Descriptors/Enumerables/CollectionType.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/CollectionType.cs
@@ -40,4 +40,5 @@ public enum CollectionType
     IImmutableStack = 1 << 25,
     ImmutableDictionary = 1 << 26,
     IImmutableDictionary = 1 << 27,
+    ImmutableSortedDictionary = 1 << 28,
 }

--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityBuilder.cs
@@ -17,7 +17,7 @@ public static class EnsureCapacityBuilder
     public static EnsureCapacity? TryBuildEnsureCapacity(MappingBuilderContext ctx)
     {
         var capacityMethod = ctx.Target
-            .GetAllMethods(EnsureCapacityName)
+            .GetAllMethods(EnsureCapacityName, ctx.Types)
             .FirstOrDefault(x => x.Parameters.Length == 1 && x.Parameters[0].Type.SpecialType == SpecialType.System_Int32 && !x.IsStatic);
 
         // if EnsureCapacity is not available then return null

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
@@ -68,12 +68,14 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
 
     private HashSet<string> GetSourceMemberNames()
     {
-        return Mapping.SourceType.GetAccessibleMappableMembers().Select(x => x.Name).ToHashSet();
+        return Mapping.SourceType.GetAccessibleMappableMembers(BuilderContext.Types).Select(x => x.Name).ToHashSet();
     }
 
     private Dictionary<string, IMappableMember> GetTargetMembers()
     {
-        return Mapping.TargetType.GetAccessibleMappableMembers().ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+        return Mapping.TargetType
+            .GetAccessibleMappableMembers(BuilderContext.Types)
+            .ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
     }
 
     private Dictionary<string, List<PropertyMappingConfiguration>> GetMemberConfigurations()

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
@@ -48,6 +48,7 @@ public static class ObjectMemberMappingBodyBuilder
                     MemberPathCandidateBuilder.BuildMemberPathCandidates(targetMember.Name),
                     ctx.IgnoredSourceMemberNames,
                     memberNameComparer,
+                    ctx.BuilderContext.Types,
                     out var sourceMemberPath
                 )
             )
@@ -75,7 +76,7 @@ public static class ObjectMemberMappingBodyBuilder
         PropertyMappingConfiguration config
     )
     {
-        if (!MemberPath.TryFind(ctx.Mapping.TargetType, config.Target.Path, out var targetMemberPath))
+        if (!MemberPath.TryFind(ctx.Mapping.TargetType, config.Target.Path, ctx.BuilderContext.Types, out var targetMemberPath))
         {
             ctx.BuilderContext.ReportDiagnostic(
                 DiagnosticDescriptors.ConfiguredMappingTargetMemberNotFound,
@@ -85,7 +86,7 @@ public static class ObjectMemberMappingBodyBuilder
             return;
         }
 
-        if (!MemberPath.TryFind(ctx.Mapping.SourceType, config.Source.Path, out var sourceMemberPath))
+        if (!MemberPath.TryFind(ctx.Mapping.SourceType, config.Source.Path, ctx.BuilderContext.Types, out var sourceMemberPath))
         {
             ctx.BuilderContext.ReportDiagnostic(
                 DiagnosticDescriptors.ConfiguredMappingSourceMemberNotFound,

--- a/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
@@ -53,7 +53,7 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
 
     public ITypeSymbol Target { get; }
 
-    public CollectionInfos? CollectionInfos => _collectionInfos ??= CollectionInfoBuilder.Build(Types, Source, Target);
+    public CollectionInfos? CollectionInfos => _collectionInfos ??= CollectionInfoBuilder.BuildCollectionInfos(Types, Source, Target);
 
     protected IMethodSymbol? UserSymbol { get; }
 

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/DictionaryMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/DictionaryMappingBuilder.cs
@@ -39,7 +39,7 @@ public static class DictionaryMappingBuilder
         )
         {
             var sourceHasCount = ctx.Source
-                .GetAllProperties(CountPropertyName)
+                .GetAllProperties(CountPropertyName, ctx.Types)
                 .Any(x => !x.IsStatic && !x.IsIndexer && !x.IsWriteOnly && x.Type.SpecialType == SpecialType.System_Int32);
 
             var targetDictionarySymbol = ctx.Types.Get(typeof(Dictionary<,>)).Construct(keyMapping.TargetType, valueMapping.TargetType);

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumMappingBuilder.cs
@@ -99,7 +99,7 @@ public static class EnumMappingBuilder
         var checkDefinedMode = checkTargetDefined switch
         {
             false => EnumCastMapping.CheckDefinedMode.NoCheck,
-            _ when ctx.Target.HasAttribute(ctx.Types.Get<FlagsAttribute>()) => EnumCastMapping.CheckDefinedMode.Flags,
+            _ when ctx.Target.HasAttribute(ctx.Types.Get<FlagsAttribute>(), ctx.Types) => EnumCastMapping.CheckDefinedMode.Flags,
             _ => EnumCastMapping.CheckDefinedMode.Value,
         };
 

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/ParseMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/ParseMappingBuilder.cs
@@ -20,7 +20,7 @@ public static class ParseMappingBuilder
         var targetIsNullable = ctx.Target.NonNullable(out var nonNullableTarget);
 
         var parseMethodCandidates = nonNullableTarget
-            .GetAllMethods(ParseMethodName)
+            .GetAllMethods(ParseMethodName, ctx.Types)
             .Where(
                 m =>
                     m.IsStatic

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/ObjectFactoryBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/ObjectFactoryBuilder.cs
@@ -12,7 +12,7 @@ public static class ObjectFactoryBuilder
         var objectFactories = mapperSymbol
             .GetMembers()
             .OfType<IMethodSymbol>()
-            .Where(m => m.HasAttribute(ctx.Types.Get<ObjectFactoryAttribute>()))
+            .Where(m => m.HasAttribute(ctx.Types.Get<ObjectFactoryAttribute>(), ctx.Types))
             .Select(x => BuildObjectFactory(ctx, x))
             .WhereNotNull()
             .ToList();

--- a/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
+++ b/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
@@ -1,4 +1,7 @@
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
+using Riok.Mapperly.Helpers;
+using Riok.Mapperly.Symbols;
 
 namespace Riok.Mapperly.Descriptors;
 
@@ -6,6 +9,9 @@ public class WellKnownTypes
 {
     private readonly Compilation _compilation;
     private readonly Dictionary<string, INamedTypeSymbol?> _cachedTypes = new();
+    private readonly Dictionary<ISymbol, ImmutableArray<AttributeData>> _cachedAttributes = new(SymbolEqualityComparer.Default);
+    private readonly Dictionary<ITypeSymbol, ISymbol[]> _allMembers = new(SymbolEqualityComparer.Default);
+    private readonly Dictionary<ITypeSymbol, IMappableMember[]> _allAccessibleMembers = new(SymbolEqualityComparer.Default);
 
     internal WellKnownTypes(Compilation compilation)
     {
@@ -36,5 +42,67 @@ public class WellKnownTypes
         _cachedTypes.Add(typeFullName, typeSymbol);
 
         return typeSymbol;
+    }
+
+    public ImmutableArray<AttributeData> GetAttributes(ISymbol symbol)
+    {
+        if (_cachedAttributes.TryGetValue(symbol, out var attributes))
+        {
+            return attributes;
+        }
+
+        attributes = symbol.GetAttributes();
+        _cachedAttributes.Add(symbol, attributes);
+
+        return attributes;
+    }
+
+    public ISymbol[] GetAllMembers(ITypeSymbol symbol)
+    {
+        if (_allMembers.TryGetValue(symbol, out var members))
+        {
+            return members;
+        }
+
+        members = GetAllMembersCore(symbol).ToArray();
+        _allMembers.Add(symbol, members);
+
+        return members;
+    }
+
+    public IMappableMember[] GetAllAccessibleMappableMembers(ITypeSymbol symbol)
+    {
+        if (_allAccessibleMembers.TryGetValue(symbol, out var members))
+        {
+            return members;
+        }
+
+        members = GetAllAccessibleMappableMembersCore(symbol);
+        _allAccessibleMembers.Add(symbol, members);
+
+        return members;
+    }
+
+    private IEnumerable<ISymbol> GetAllMembersCore(ITypeSymbol symbol)
+    {
+        var members = symbol.GetMembers();
+
+        if (symbol.TypeKind == TypeKind.Interface)
+        {
+            var interfaceProperties = symbol.AllInterfaces.SelectMany(GetAllMembers);
+            return members.Concat(interfaceProperties);
+        }
+
+        return symbol.BaseType == null ? members : members.Concat(GetAllMembers(symbol.BaseType));
+    }
+
+    private IMappableMember[] GetAllAccessibleMappableMembersCore(ITypeSymbol symbol)
+    {
+        return GetAllMembers(symbol)
+            .Where(x => !x.IsStatic && x.IsAccessible() && x.Kind is SymbolKind.Property or SymbolKind.Field)
+            .DistinctBy(x => x.Name)
+            .Select(MappableMember.Create)
+            .WhereNotNull()
+            .ToArray();
     }
 }

--- a/src/Riok.Mapperly/MapperGenerator.cs
+++ b/src/Riok.Mapperly/MapperGenerator.cs
@@ -45,7 +45,7 @@ public class MapperGenerator : IIncrementalGenerator
             if (mapperModel.GetDeclaredSymbol(mapperSyntax) is not INamedTypeSymbol mapperSymbol)
                 continue;
 
-            if (!mapperSymbol.HasAttribute(mapperAttributeSymbol))
+            if (!mapperSymbol.HasAttribute(mapperAttributeSymbol, wellKnownTypes))
                 continue;
 
             var builder = new DescriptorBuilder(ctx, compilation, mapperSyntax, mapperSymbol, wellKnownTypes);

--- a/src/Riok.Mapperly/Symbols/MemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/MemberPath.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Descriptors;
 using Riok.Mapperly.Helpers;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Riok.Mapperly.Emit.SyntaxFactoryHelper;
@@ -179,18 +180,20 @@ public class MemberPath
         ITypeSymbol type,
         IEnumerable<IEnumerable<string>> pathCandidates,
         IReadOnlyCollection<string> ignoredNames,
+        WellKnownTypes types,
         [NotNullWhen(true)] out MemberPath? memberPath
-    ) => TryFind(type, pathCandidates, ignoredNames, StringComparer.Ordinal, out memberPath);
+    ) => TryFind(type, pathCandidates, ignoredNames, StringComparer.Ordinal, types, out memberPath);
 
     public static bool TryFind(
         ITypeSymbol type,
         IEnumerable<IEnumerable<string>> pathCandidates,
         IReadOnlyCollection<string> ignoredNames,
         IEqualityComparer<string> comparer,
+        WellKnownTypes types,
         [NotNullWhen(true)] out MemberPath? memberPath
     )
     {
-        foreach (var pathCandidate in FindCandidates(type, pathCandidates, comparer))
+        foreach (var pathCandidate in FindCandidates(type, pathCandidates, comparer, types))
         {
             if (ignoredNames.Contains(pathCandidate.Path.First().Name))
                 continue;
@@ -203,18 +206,23 @@ public class MemberPath
         return false;
     }
 
-    public static bool TryFind(ITypeSymbol type, IReadOnlyCollection<string> path, [NotNullWhen(true)] out MemberPath? memberPath) =>
-        TryFind(type, path, StringComparer.Ordinal, out memberPath);
+    public static bool TryFind(
+        ITypeSymbol type,
+        IReadOnlyCollection<string> path,
+        WellKnownTypes types,
+        [NotNullWhen(true)] out MemberPath? memberPath
+    ) => TryFind(type, path, StringComparer.Ordinal, types, out memberPath);
 
     private static IEnumerable<MemberPath> FindCandidates(
         ITypeSymbol type,
         IEnumerable<IEnumerable<string>> pathCandidates,
-        IEqualityComparer<string> comparer
+        IEqualityComparer<string> comparer,
+        WellKnownTypes types
     )
     {
         foreach (var pathCandidate in pathCandidates)
         {
-            if (TryFind(type, pathCandidate.ToList(), comparer, out var memberPath))
+            if (TryFind(type, pathCandidate.ToList(), comparer, types, out var memberPath))
                 yield return memberPath;
         }
     }
@@ -223,10 +231,11 @@ public class MemberPath
         ITypeSymbol type,
         IReadOnlyCollection<string> path,
         IEqualityComparer<string> comparer,
+        WellKnownTypes types,
         [NotNullWhen(true)] out MemberPath? memberPath
     )
     {
-        var foundPath = Find(type, path, comparer).ToList();
+        var foundPath = Find(type, path, comparer, types).ToList();
         if (foundPath.Count != path.Count)
         {
             memberPath = null;
@@ -237,11 +246,16 @@ public class MemberPath
         return true;
     }
 
-    private static IEnumerable<IMappableMember> Find(ITypeSymbol type, IEnumerable<string> path, IEqualityComparer<string> comparer)
+    private static IEnumerable<IMappableMember> Find(
+        ITypeSymbol type,
+        IEnumerable<string> path,
+        IEqualityComparer<string> comparer,
+        WellKnownTypes types
+    )
     {
         foreach (var name in path)
         {
-            if (FindMember(type, name, comparer) is not { } member)
+            if (FindMember(type, name, comparer, types) is not { } member)
                 break;
 
             type = member.Type;
@@ -249,8 +263,8 @@ public class MemberPath
         }
     }
 
-    private static IMappableMember? FindMember(ITypeSymbol type, string name, IEqualityComparer<string> comparer)
+    private static IMappableMember? FindMember(ITypeSymbol type, string name, IEqualityComparer<string> comparer, WellKnownTypes types)
     {
-        return type.GetMappableMembers(name, comparer).FirstOrDefault();
+        return type.GetMappableMembers(name, comparer, types).FirstOrDefault();
     }
 }


### PR DESCRIPTION
## Cached GetMembers, GetAccessibleMappableMembers and optimized `CollectionInfoBuilder`

### Description
Modified `WellKnownTypes` to cache more members, mappable members and attributes. Added a couple of checks to `CollectionInfoBuilder` to speed up common paths.

- Added cached methods to `WellKnownTypes` for `GetAttributes`, `GetAllMembers` and `GetAllAccessibleMappableMembers`
- CollectionTypeInfo
  - Converted `CollectionTypeInfo` to a struct
  - Removed duplicate `IImmutableQueue` and added `ImmutableSortedDictionary`
  - Added check to `HasValidAddMethod` for types with known `Add` methods, otherwise all none `None` types return false. `None` types are manually checked for `Add` methods.
  - `IsCountKnown` returns false for `IEnumerable` and true for all none `None` types. `None` types are manually checked for length properties.
  - Added a massive switch expression to `GetImplementedCollectionTypes`, it uses the known `CollectionTypeInfo` to get the implemented types. `None` types are manually checked for implemented types. Could be moved into `_collectionTypeInfos`.
    - Added a special check for `string` to return `IEnumerable`, because string isn't actually a "collection" type but does implement `IEnumerable` and is marked `None` by `GetCollectionTypeInfo`. It would iterate thrrought every possible collection type causing a considerable slow down.
- Moved `GetEnumeratedType` into `BuildCollectionInfos`. This is a quick check to ensure that both the source and target types are actually enumerable, saving a lot of wasted time.

I kept the slightly modified `GetAllMembers`and `GetAccessibleMappableMembers` (they call `WellKnownTypes`) in `SymbolExtensions`. Should I remove them and update all the call sites to use the `WellKnownTypes` version?

### Benchmarks

#### Optimized
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.699 ms | 0.0322 ms | 0.0317 ms |   85.9375 |  19.5313 |  180.45 KB |
| LargeCompile | 54.299 ms | 0.9632 ms | 0.9460 ms | 1500.0000 | 375.0000 | 9344.24 KB |

#### Original
|       Method |       Mean |     Error |     StdDev |      Gen0 |     Gen1 |   Allocated |
|------------- |-----------:|----------:|-----------:|----------:|---------:|------------:|
|      Compile |   3.569 ms | 0.2264 ms |  0.6641 ms |  171.8750 |  31.2500 |   311.38 KB |
| LargeCompile | 100.170 ms | 4.6670 ms | 13.3905 ms | 2200.0000 | 800.0000 | 13395.01 KB |

Helps #72

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
