### PR TITLE
feat: add option to ignore enum values

### DIFF
--- a/docs/docs/configuration/enum.mdx
+++ b/docs/docs/configuration/enum.mdx
@@ -75,6 +75,23 @@ public partial class CarMapper
 }
 ```
 
+## Ignore enum values
+
+To ignore an enum value the `MapperIgnoreSourceValue` or `MapperIgnoreTargetValue` attributes can be used.
+This is especially useful when applying [strict enum mappings](#strict-enum-mappings).
+
+```csharp
+[Mapper]
+public partial class CarMapper
+{
+    // highlight-start
+    [MapperIgnoreSourceValue(Fruit.Apple)]
+    [MapperIgnoreTargetValue(FruitDto.Pineapple)]
+    // highlight-end
+    public partial FruitDto Map(Fruit source);
+}
+```
+
 ## Fallback value
 
 To map to a fallback value instead of throwing when encountering an unknown value,

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "prebuild": "ts-node prebuild.ts",
+    "prestart": "ts-node prebuild.ts",
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",

--- a/src/Riok.Mapperly.Abstractions/MapperIgnoreSourceValueAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperIgnoreSourceValueAttribute.cs
@@ -1,0 +1,22 @@
+namespace Riok.Mapperly.Abstractions;
+
+/// <summary>
+/// Ignores a source enum value from the mapping.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+public class MapperIgnoreSourceValueAttribute : Attribute
+{
+    /// <summary>
+    /// Ignores the specified source enum value from the mapping.
+    /// </summary>
+    /// <param name="source">The source enum value to ignore.</param>
+    public MapperIgnoreSourceValueAttribute(object source)
+    {
+        SourceValue = (Enum)source;
+    }
+
+    /// <summary>
+    /// Gets the source enum value which should be ignored from the mapping.
+    /// </summary>
+    public Enum? SourceValue { get; }
+}

--- a/src/Riok.Mapperly.Abstractions/MapperIgnoreTargetValueAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperIgnoreTargetValueAttribute.cs
@@ -1,0 +1,22 @@
+namespace Riok.Mapperly.Abstractions;
+
+/// <summary>
+/// Ignores a target enum value from the mapping.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+public class MapperIgnoreTargetValueAttribute : Attribute
+{
+    /// <summary>
+    /// Ignores the specified target enum value from the mapping.
+    /// </summary>
+    /// <param name="target">The target enum value to ignore.</param>
+    public MapperIgnoreTargetValueAttribute(object target)
+    {
+        TargetValue = (Enum)target;
+    }
+
+    /// <summary>
+    /// Gets the target enum value which should be ignored from the mapping.
+    /// </summary>
+    public Enum? TargetValue { get; }
+}

--- a/src/Riok.Mapperly.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Riok.Mapperly.Abstractions/PublicAPI.Shipped.txt
@@ -89,3 +89,9 @@ Riok.Mapperly.Abstractions.MapDerivedTypeAttribute.TargetType.get -> System.Type
 Riok.Mapperly.Abstractions.EnumMappingStrategy.ByValueCheckDefined = 2 -> Riok.Mapperly.Abstractions.EnumMappingStrategy
 Riok.Mapperly.Abstractions.MapEnumAttribute.FallbackValue.get -> object?
 Riok.Mapperly.Abstractions.MapEnumAttribute.FallbackValue.set -> void
+Riok.Mapperly.Abstractions.MapperIgnoreSourceValueAttribute
+Riok.Mapperly.Abstractions.MapperIgnoreSourceValueAttribute.MapperIgnoreSourceValueAttribute(object! source) -> void
+Riok.Mapperly.Abstractions.MapperIgnoreTargetValueAttribute
+Riok.Mapperly.Abstractions.MapperIgnoreTargetValueAttribute.MapperIgnoreTargetValueAttribute(object! target) -> void
+Riok.Mapperly.Abstractions.MapperIgnoreSourceValueAttribute.SourceValue.get -> System.Enum?
+Riok.Mapperly.Abstractions.MapperIgnoreTargetValueAttribute.TargetValue.get -> System.Enum?

--- a/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
@@ -102,3 +102,5 @@ RMG040  | Mapper   | Error    | A target enum member value does not match the ta
 RMG041  | Mapper   | Error    | A source enum member value does not match the source enum type
 RMG042  | Mapper   | Error    | The type of the enum fallback value does not match the target enum type
 RMG043  | Mapper   | Warning  | Enum fallback values are only supported for the ByName and ByValueCheckDefined strategies, but not for the ByValue strategy
+RMG044  | Mapper   | Warning  | An ignored enum member can not be found on the source enum
+RMG045  | Mapper   | Warning  | An ignored enum member can not be found on the target enum

--- a/src/Riok.Mapperly/Configuration/EnumMappingConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/EnumMappingConfiguration.cs
@@ -7,5 +7,10 @@ public record EnumMappingConfiguration(
     EnumMappingStrategy Strategy,
     bool IgnoreCase,
     IFieldSymbol? FallbackValue,
+    IReadOnlyCollection<IFieldSymbol> IgnoredSourceMembers,
+    IReadOnlyCollection<IFieldSymbol> IgnoredTargetMembers,
     IReadOnlyCollection<EnumValueMappingConfiguration> ExplicitMappings
-);
+)
+{
+    public bool HasExplicitConfigurations => ExplicitMappings.Count > 0 || IgnoredSourceMembers.Count > 0 || IgnoredTargetMembers.Count > 0;
+}

--- a/src/Riok.Mapperly/Configuration/MapperIgnoreEnumValueConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/MapperIgnoreEnumValueConfiguration.cs
@@ -1,0 +1,5 @@
+using Microsoft.CodeAnalysis;
+
+namespace Riok.Mapperly.Configuration;
+
+public record MapperIgnoreEnumValueConfiguration(IFieldSymbol Value);

--- a/src/Riok.Mapperly/Configuration/MappingConfigurationReference.cs
+++ b/src/Riok.Mapperly/Configuration/MappingConfigurationReference.cs
@@ -1,0 +1,5 @@
+using Microsoft.CodeAnalysis;
+
+namespace Riok.Mapperly.Configuration;
+
+public record struct MappingConfigurationReference(IMethodSymbol? Method, ITypeSymbol Source, ITypeSymbol Target);

--- a/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
@@ -29,7 +29,7 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
         Source = source;
         Target = target;
         UserSymbol = userSymbol;
-        Configuration = ReadConfiguration(UserSymbol);
+        Configuration = ReadConfiguration(new MappingConfigurationReference(UserSymbol, source, target));
     }
 
     protected MappingBuilderContext(

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumMappingBuilder.cs
@@ -32,61 +32,40 @@ public static class EnumMappingBuilder
             return null;
 
         // map enums by strategy
-        var explicitMappings = BuildExplicitValueMapping(ctx);
         return ctx.Configuration.Enum.Strategy switch
         {
             EnumMappingStrategy.ByName when ctx.IsExpression => BuildCastMappingAndDiagnostic(ctx),
-            EnumMappingStrategy.ByValue when ctx.IsExpression && explicitMappings.Count > 0 => BuildCastMappingAndDiagnostic(ctx),
+            EnumMappingStrategy.ByValue when ctx is { IsExpression: true, Configuration.Enum.HasExplicitConfigurations: true }
+                => BuildCastMappingAndDiagnostic(ctx),
             EnumMappingStrategy.ByValueCheckDefined when ctx.IsExpression => BuildCastMappingAndDiagnostic(ctx),
-            EnumMappingStrategy.ByName => BuildNameMapping(ctx, explicitMappings),
-            EnumMappingStrategy.ByValueCheckDefined => BuildEnumToEnumCastMapping(ctx, explicitMappings, true),
-            _ => BuildEnumToEnumCastMapping(ctx, explicitMappings),
+            EnumMappingStrategy.ByName => BuildNameMapping(ctx),
+            EnumMappingStrategy.ByValueCheckDefined => BuildEnumToEnumCastMapping(ctx, checkTargetDefined: true),
+            _ => BuildEnumToEnumCastMapping(ctx),
         };
     }
 
     private static TypeMapping BuildCastMappingAndDiagnostic(MappingBuilderContext ctx)
     {
         ctx.ReportDiagnostic(
-            DiagnosticDescriptors.EnumMappingStrategyByNameNotSupportedInProjectionMappings,
+            DiagnosticDescriptors.EnumMappingNotSupportedInProjectionMappings,
             ctx.Source.ToDisplayString(),
             ctx.Target.ToDisplayString()
         );
-        return BuildEnumToEnumCastMapping(ctx, new Dictionary<IFieldSymbol, IFieldSymbol>(SymbolEqualityComparer.Default));
+        return BuildEnumToEnumCastMapping(ctx, true);
     }
 
     private static TypeMapping BuildEnumToEnumCastMapping(
         MappingBuilderContext ctx,
-        IReadOnlyDictionary<IFieldSymbol, IFieldSymbol> explicitMappings,
+        bool ignoreExplicitAndIgnoredMappings = false,
         bool checkTargetDefined = false
     )
     {
-        var explicitMappingSourceNames = explicitMappings.Keys.Select(x => x.Name).ToHashSet();
-        var explicitMappingTargetNames = explicitMappings.Values.Select(x => x.Name).ToHashSet();
-        var sourceValues = ctx.SymbolAccessor
-            .GetAllFields(ctx.Source)
-            .Where(x => !explicitMappingSourceNames.Contains(x.Name))
-            .ToDictionary(field => field.Name, field => field.ConstantValue);
-        var targetValues = ctx.SymbolAccessor
-            .GetAllFields(ctx.Target)
-            .Where(x => !explicitMappingTargetNames.Contains(x.Name))
-            .ToDictionary(field => field.Name, field => field.ConstantValue);
-        var targetMemberNames = ctx.SymbolAccessor.GetAllFields(ctx.Target).Select(x => x.Name).ToHashSet();
-
-        var missingTargetValues = targetValues.Where(
-            field =>
-                !sourceValues.ContainsValue(field.Value) && ctx.Configuration.Enum.FallbackValue?.ConstantValue?.Equals(field.Value) != true
+        var enumMemberMappings = BuildEnumMemberMappings(
+            ctx,
+            ignoreExplicitAndIgnoredMappings,
+            static x => x.ConstantValue!,
+            EqualityComparer<object>.Default
         );
-        foreach (var member in missingTargetValues)
-        {
-            ctx.ReportDiagnostic(DiagnosticDescriptors.TargetEnumValueNotMapped, member.Key, member.Value!, ctx.Target, ctx.Source);
-        }
-
-        var missingSourceValues = sourceValues.Where(field => !targetValues.ContainsValue(field.Value));
-        foreach (var member in missingSourceValues)
-        {
-            ctx.ReportDiagnostic(DiagnosticDescriptors.SourceEnumValueNotMapped, member.Key, member.Value!, ctx.Source, ctx.Target);
-        }
-
         var fallbackMapping = BuildFallbackMapping(ctx);
         if (fallbackMapping.FallbackMember != null && !checkTargetDefined)
         {
@@ -101,86 +80,156 @@ public static class EnumMappingBuilder
             _ => EnumCastMapping.CheckDefinedMode.Value,
         };
 
-        var castFallbackMapping = new EnumCastMapping(ctx.Source, ctx.Target, checkDefinedMode, targetMemberNames, fallbackMapping);
-        if (explicitMappings.Count == 0)
+        var castFallbackMapping = new EnumCastMapping(
+            ctx.Source,
+            ctx.Target,
+            checkDefinedMode,
+            enumMemberMappings.TargetMembers,
+            fallbackMapping
+        );
+        var differentValueExplicitEnumMappings = enumMemberMappings.ExplicitMemberMappings
+            .Where(x => x.Key.ConstantValue?.Equals(x.Value.ConstantValue) != true)
+            .ToDictionary(x => x.Key, x => x.Value, (IEqualityComparer<IFieldSymbol>)SymbolEqualityComparer.Default);
+
+        if (differentValueExplicitEnumMappings.Count == 0)
             return castFallbackMapping;
 
-        var explicitNameMappings = explicitMappings
-            .Where(x => !x.Value.ConstantValue?.Equals(x.Key.ConstantValue) == true)
-            .ToDictionary(x => x.Key.Name, x => x.Value.Name);
         return new EnumNameMapping(
             ctx.Source,
             ctx.Target,
-            explicitNameMappings,
+            differentValueExplicitEnumMappings,
             new EnumFallbackValueMapping(ctx.Source, ctx.Target, castFallbackMapping)
         );
     }
 
-    private static EnumNameMapping BuildNameMapping(
-        MappingBuilderContext ctx,
-        IReadOnlyDictionary<IFieldSymbol, IFieldSymbol> explicitMappings
-    )
+    private static EnumNameMapping BuildNameMapping(MappingBuilderContext ctx)
     {
         var fallbackMapping = BuildFallbackMapping(ctx);
-        var targetFieldsByName = ctx.SymbolAccessor.GetAllFields(ctx.Target).ToDictionary(x => x.Name);
-        var sourceFieldsByName = ctx.SymbolAccessor.GetAllFields(ctx.Source).ToDictionary(x => x.Name);
+        var enumMemberMappings = ctx.Configuration.Enum.IgnoreCase
+            ? BuildEnumMemberMappings(ctx, false, static x => x.Name, StringComparer.Ordinal, StringComparer.OrdinalIgnoreCase)
+            : BuildEnumMemberMappings(ctx, false, static x => x.Name, StringComparer.Ordinal);
 
-        Func<IFieldSymbol, IFieldSymbol?> getTargetField;
-        if (ctx.Configuration.Enum.IgnoreCase)
-        {
-            var targetFieldsByNameIgnoreCase = targetFieldsByName
-                .DistinctBy(x => x.Key, StringComparer.OrdinalIgnoreCase)
-                .ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
-            getTargetField = source =>
-                explicitMappings.GetValueOrDefault(source)
-                ?? targetFieldsByName.GetValueOrDefault(source.Name)
-                ?? targetFieldsByNameIgnoreCase.GetValueOrDefault(source.Name);
-        }
-        else
-        {
-            getTargetField = source => explicitMappings.GetValueOrDefault(source) ?? targetFieldsByName.GetValueOrDefault(source.Name);
-        }
-
-        var enumMemberMappings = ctx.SymbolAccessor
-            .GetAllFields(ctx.Source)
-            .Select(x => (Source: x, Target: getTargetField(x)))
-            .Where(x => x.Target != null)
-            .ToDictionary(x => x.Source.Name, x => x.Target!.Name);
-
-        if (enumMemberMappings.Count == 0)
+        if (enumMemberMappings.MemberMappings.Count == 0)
         {
             ctx.ReportDiagnostic(DiagnosticDescriptors.EnumNameMappingNoOverlappingValuesFound, ctx.Source, ctx.Target);
         }
 
-        var missingSourceMembers = sourceFieldsByName.Where(field => !enumMemberMappings.ContainsKey(field.Key));
-        foreach (var member in missingSourceMembers)
+        return new EnumNameMapping(ctx.Source, ctx.Target, enumMemberMappings.MemberMappings, fallbackMapping);
+    }
+
+    private static EnumMemberMappings BuildEnumMemberMappings<T>(
+        MappingBuilderContext ctx,
+        bool ignoreExplicitAndIgnoredMappings,
+        Func<IFieldSymbol, T> propertySelector,
+        params IEqualityComparer<T>[] propertyComparer
+    )
+    {
+        var ignoredSourceMembers = ignoreExplicitAndIgnoredMappings
+            ? new HashSet<IFieldSymbol>(SymbolEqualityComparer.Default)
+            : ctx.Configuration.Enum.IgnoredSourceMembers.ToHashSet();
+        var ignoredTargetMembers = ignoreExplicitAndIgnoredMappings
+            ? new HashSet<IFieldSymbol>(SymbolEqualityComparer.Default)
+            : ctx.Configuration.Enum.IgnoredTargetMembers.ToHashSet();
+        var explicitMappings = ignoreExplicitAndIgnoredMappings
+            ? new Dictionary<IFieldSymbol, IFieldSymbol>(SymbolEqualityComparer.Default)
+            : BuildExplicitValueMappings(ctx);
+        var sourceMembers = ctx.Source.GetMembers().OfType<IFieldSymbol>().Where(x => !ignoredSourceMembers.Remove(x)).ToHashSet();
+        var targetMembers = ctx.Target.GetMembers().OfType<IFieldSymbol>().Where(x => !ignoredTargetMembers.Remove(x)).ToHashSet();
+
+        var targetMembersByProperty = propertyComparer
+            .Select(pc => targetMembers.DistinctBy(propertySelector, pc).ToDictionary(propertySelector, x => x, pc))
+            .ToList();
+
+        var mappedTargetMembers = new HashSet<IFieldSymbol>(SymbolEqualityComparer.Default);
+        var mappings = new Dictionary<IFieldSymbol, IFieldSymbol>(SymbolEqualityComparer.Default);
+        foreach (var sourceMember in sourceMembers)
+        {
+            if (!explicitMappings.TryGetValue(sourceMember, out var targetMember))
+            {
+                var sourceProperty = propertySelector(sourceMember);
+                foreach (var targetMembersByPropertyCandidate in targetMembersByProperty)
+                {
+                    if (targetMembersByPropertyCandidate.TryGetValue(sourceProperty, out targetMember))
+                        break;
+                }
+
+                if (targetMember == null)
+                    continue;
+            }
+
+            mappings.Add(sourceMember, targetMember);
+            mappedTargetMembers.Add(targetMember);
+        }
+
+        AddUnmappedMembersDiagnostics(ctx, mappings, mappedTargetMembers, sourceMembers, targetMembers);
+        AddUnmatchedIgnoredMembers(ctx, ignoredSourceMembers, ignoredTargetMembers);
+        return new EnumMemberMappings(mappings, explicitMappings, targetMembers);
+    }
+
+    private static void AddUnmatchedIgnoredMembers(
+        MappingBuilderContext ctx,
+        ISet<IFieldSymbol> ignoredUnmatchedSourceMembers,
+        ISet<IFieldSymbol> ignoredUnmatchedTargetMembers
+    )
+    {
+        foreach (var member in ignoredUnmatchedSourceMembers)
         {
             ctx.ReportDiagnostic(
-                DiagnosticDescriptors.SourceEnumValueNotMapped,
-                member.Key,
-                member.Value.ConstantValue!,
+                DiagnosticDescriptors.IgnoredEnumSourceMemberNotFound,
+                member.Name,
+                member.ConstantValue!,
                 ctx.Source,
                 ctx.Target
             );
         }
 
-        var missingTargetMembers = targetFieldsByName.Where(
+        foreach (var member in ignoredUnmatchedTargetMembers)
+        {
+            ctx.ReportDiagnostic(
+                DiagnosticDescriptors.IgnoredEnumTargetMemberNotFound,
+                member.Name,
+                member.ConstantValue!,
+                ctx.Source,
+                ctx.Target
+            );
+        }
+    }
+
+    private static void AddUnmappedMembersDiagnostics(
+        MappingBuilderContext ctx,
+        IReadOnlyDictionary<IFieldSymbol, IFieldSymbol> mappings,
+        ISet<IFieldSymbol> mappedTargetMembers,
+        IEnumerable<IFieldSymbol> sourceMembers,
+        IEnumerable<IFieldSymbol> targetMembers
+    )
+    {
+        var missingSourceMembers = sourceMembers.Where(field => !mappings.ContainsKey(field));
+        foreach (var member in missingSourceMembers)
+        {
+            ctx.ReportDiagnostic(
+                DiagnosticDescriptors.SourceEnumValueNotMapped,
+                member.Name,
+                member.ConstantValue!,
+                ctx.Source,
+                ctx.Target
+            );
+        }
+
+        var missingTargetMembers = targetMembers.Where(
             field =>
-                !enumMemberMappings.ContainsValue(field.Key)
-                && ctx.Configuration.Enum.FallbackValue?.ConstantValue?.Equals(field.Value.ConstantValue) != true
+                !mappedTargetMembers.Contains(field)
+                && ctx.Configuration.Enum.FallbackValue?.ConstantValue?.Equals(field.ConstantValue) != true
         );
         foreach (var member in missingTargetMembers)
         {
             ctx.ReportDiagnostic(
                 DiagnosticDescriptors.TargetEnumValueNotMapped,
-                member.Key,
-                member.Value.ConstantValue!,
+                member.Name,
+                member.ConstantValue!,
                 ctx.Target,
                 ctx.Source
             );
         }
-
-        return new EnumNameMapping(ctx.Source, ctx.Target, enumMemberMappings, fallbackMapping);
     }
 
     private static EnumFallbackValueMapping BuildFallbackMapping(MappingBuilderContext ctx)
@@ -202,7 +251,7 @@ public static class EnumMappingBuilder
         return new EnumFallbackValueMapping(ctx.Source, ctx.Target);
     }
 
-    private static IReadOnlyDictionary<IFieldSymbol, IFieldSymbol> BuildExplicitValueMapping(MappingBuilderContext ctx)
+    private static IReadOnlyDictionary<IFieldSymbol, IFieldSymbol> BuildExplicitValueMappings(MappingBuilderContext ctx)
     {
         var targetFieldsByExplicitValue = new Dictionary<IFieldSymbol, IFieldSymbol>(SymbolEqualityComparer.Default);
         foreach (var (source, target) in ctx.Configuration.Enum.ExplicitMappings)
@@ -243,4 +292,10 @@ public static class EnumMappingBuilder
 
         return targetFieldsByExplicitValue;
     }
+
+    private record EnumMemberMappings(
+        IReadOnlyDictionary<IFieldSymbol, IFieldSymbol> MemberMappings,
+        IReadOnlyDictionary<IFieldSymbol, IFieldSymbol> ExplicitMemberMappings,
+        IReadOnlyCollection<IFieldSymbol> TargetMembers
+    );
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/Enums/EnumCastMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/Enums/EnumCastMapping.cs
@@ -12,7 +12,7 @@ namespace Riok.Mapperly.Descriptors.Mappings.Enums;
 public class EnumCastMapping : CastMapping
 {
     private readonly CheckDefinedMode _checkDefinedMode;
-    private readonly IReadOnlyCollection<string> _targetEnumMemberNames;
+    private readonly IReadOnlyCollection<IFieldSymbol> _targetEnumMembers;
     private readonly EnumFallbackValueMapping _fallback;
 
     public enum CheckDefinedMode
@@ -37,13 +37,13 @@ public class EnumCastMapping : CastMapping
         ITypeSymbol sourceType,
         ITypeSymbol targetType,
         CheckDefinedMode checkDefinedMode,
-        IReadOnlyCollection<string> targetEnumMemberNames,
+        IReadOnlyCollection<IFieldSymbol> targetEnumMembers,
         EnumFallbackValueMapping fallback
     )
         : base(sourceType, targetType)
     {
         _checkDefinedMode = checkDefinedMode;
-        _targetEnumMemberNames = targetEnumMemberNames;
+        _targetEnumMembers = targetEnumMembers;
         _fallback = fallback;
     }
 
@@ -59,7 +59,7 @@ public class EnumCastMapping : CastMapping
 
     private ExpressionSyntax BuildIsDefinedCondition(ExpressionSyntax convertedSourceValue)
     {
-        var allEnumMembers = _targetEnumMemberNames.Select(x => MemberAccess(FullyQualifiedIdentifier(TargetType), x));
+        var allEnumMembers = _targetEnumMembers.Select(x => MemberAccess(FullyQualifiedIdentifier(TargetType), x.Name));
         return _checkDefinedMode switch
         {
             // (TargetEnum)v is TargetEnum.A or TargetEnum.B or ...

--- a/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
@@ -68,5 +68,5 @@ public class SimpleMappingBuilderContext
         _diagnostics.Add(Diagnostic.Create(descriptor, nodeLocation ?? _descriptor.Syntax.GetLocation(), messageArgs));
     }
 
-    protected MappingConfiguration ReadConfiguration(IMethodSymbol? userSymbol) => _configuration.ForMethod(userSymbol);
+    protected MappingConfiguration ReadConfiguration(MappingConfigurationReference configRef) => _configuration.BuildFor(configRef);
 }

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -276,10 +276,10 @@ internal static class DiagnosticDescriptors
         true
     );
 
-    public static readonly DiagnosticDescriptor EnumMappingStrategyByNameNotSupportedInProjectionMappings = new DiagnosticDescriptor(
+    public static readonly DiagnosticDescriptor EnumMappingNotSupportedInProjectionMappings = new DiagnosticDescriptor(
         "RMG032",
-        "The enum mapping strategy ByName, ByValueCheckDefined and explicit enum mappings cannot be used in projection mappings",
-        "The enum mapping strategy ByName, ByValueCheckDefined and explicit enum mappings cannot be used in projection mappings to map from {0} to {1}",
+        "The enum mapping strategy ByName, ByValueCheckDefined, explicit enum mappings and ignored enum values cannot be used in projection mappings",
+        "The enum mapping strategy ByName, ByValueCheckDefined, explicit enum mappings and ignored enum values cannot be used in projection mappings to map from {0} to {1}",
         DiagnosticCategories.Mapper,
         DiagnosticSeverity.Warning,
         true
@@ -379,6 +379,24 @@ internal static class DiagnosticDescriptors
         "RMG043",
         "Enum fallback values are only supported for the ByName and ByValueCheckDefined strategies, but not for the ByValue strategy",
         "Enum fallback values are only supported for the ByName and ByValueCheckDefined strategies, but not for the ByValue strategy",
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Warning,
+        true
+    );
+
+    public static readonly DiagnosticDescriptor IgnoredEnumSourceMemberNotFound = new DiagnosticDescriptor(
+        "RMG044",
+        "An ignored enum member can not be found on the source enum",
+        "Ignored enum member {0} ({1}) on {2} not found on source enum {3}",
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Warning,
+        true
+    );
+
+    public static readonly DiagnosticDescriptor IgnoredEnumTargetMemberNotFound = new DiagnosticDescriptor(
+        "RMG045",
+        "An ignored enum member can not be found on the target enum",
+        "Ignored enum member {0} ({1}) not found on target enum {3}",
         DiagnosticCategories.Mapper,
         DiagnosticSeverity.Warning,
         true

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/StaticTestMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/StaticTestMapper.cs
@@ -97,6 +97,12 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         [MapEnumValue(TestEnumDtoAdditionalValue.Value40, TestEnum.Value30)]
         public static partial TestEnum MapToEnumByValueWithExplicit(TestEnumDtoAdditionalValue v);
 
+        [MapEnum(EnumMappingStrategy.ByName)]
+        [MapperIgnoreSourceValue(TestEnumDtoAdditionalValue.Value30)]
+        [MapperIgnoreSourceValue(TestEnumDtoAdditionalValue.Value40)]
+        [MapperIgnoreTargetValue(TestEnum.Value30)]
+        public static partial TestEnum MapToEnumByNameWithIgnored(TestEnumDtoAdditionalValue v);
+
         [MapEnum(EnumMappingStrategy.ByValueCheckDefined)]
         public static partial TestEnum MapToEnumByValueCheckDefined(TestEnumDtoByValue v);
 

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -516,6 +516,16 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             };
         }
 
+        public static partial global::Riok.Mapperly.IntegrationTests.Models.TestEnum MapToEnumByNameWithIgnored(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue v)
+        {
+            return v switch
+            {
+                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value10 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value10,
+                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value20 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value20,
+                _ => throw new System.ArgumentOutOfRangeException(nameof(v), v, "The value of enum TestEnumDtoAdditionalValue is not supported"),
+            };
+        }
+
         public static partial global::Riok.Mapperly.IntegrationTests.Models.TestEnum MapToEnumByValueCheckDefined(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue v)
         {
             return (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)v is global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value10 or global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value20 or global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30 ? (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)v : throw new System.ArgumentOutOfRangeException(nameof(v), v, "The value of enum TestEnumDtoByValue is not supported");

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -515,6 +515,16 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             };
         }
 
+        public static partial global::Riok.Mapperly.IntegrationTests.Models.TestEnum MapToEnumByNameWithIgnored(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue v)
+        {
+            return v switch
+            {
+                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value10 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value10,
+                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value20 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value20,
+                _ => throw new System.ArgumentOutOfRangeException(nameof(v), v, "The value of enum TestEnumDtoAdditionalValue is not supported"),
+            };
+        }
+
         public static partial global::Riok.Mapperly.IntegrationTests.Models.TestEnum MapToEnumByValueCheckDefined(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue v)
         {
             return (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)v is global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value10 or global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value20 or global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30 ? (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)v : throw new System.ArgumentOutOfRangeException(nameof(v), v, "The value of enum TestEnumDtoByValue is not supported");

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -524,6 +524,16 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             };
         }
 
+        public static partial global::Riok.Mapperly.IntegrationTests.Models.TestEnum MapToEnumByNameWithIgnored(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue v)
+        {
+            return v switch
+            {
+                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value10 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value10,
+                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value20 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value20,
+                _ => throw new System.ArgumentOutOfRangeException(nameof(v), v, "The value of enum TestEnumDtoAdditionalValue is not supported"),
+            };
+        }
+
         public static partial global::Riok.Mapperly.IntegrationTests.Models.TestEnum MapToEnumByValueCheckDefined(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue v)
         {
             return (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)v is global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value10 or global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value20 or global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30 ? (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)v : throw new System.ArgumentOutOfRangeException(nameof(v), v, "The value of enum TestEnumDtoByValue is not supported");

--- a/test/Riok.Mapperly.Tests/Mapping/EnumIgnoreTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumIgnoreTest.cs
@@ -1,0 +1,40 @@
+using Riok.Mapperly.Diagnostics;
+
+namespace Riok.Mapperly.Tests.Mapping;
+
+public class EnumIgnoreTest
+{
+    [Fact]
+    public void ByValueWithIgnoredSourceValueShouldWork()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapperIgnoreSourceValue(E1.D), MapEnum(EnumMappingStrategy.ByValue)] partial E2 ToE1(E1 source);",
+            "enum E1 {A, B, C, D = 100, E}",
+            "enum E2 {AA, BB, CC}"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.SourceEnumValueNotMapped, "Enum member E (101) on E1 not found on target enum E2")
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody("return (global::E2)source;");
+    }
+
+    [Fact]
+    public void ByValueWithIgnoredTargetValueShouldWork()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapperIgnoreTargetValue(E2.DD), MapEnum(EnumMappingStrategy.ByValue)] partial E2 ToE1(E1 source);",
+            "enum E1 {A, B, C}",
+            "enum E2 {AA, BB, CC, DD = 100, EE}"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.TargetEnumValueNotMapped, "Enum member EE (101) on E2 not found on source enum E1")
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody("return (global::E2)source;");
+    }
+}

--- a/test/Riok.Mapperly.Tests/Mapping/QueryableProjectionEnumTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/QueryableProjectionEnumTest.cs
@@ -41,8 +41,8 @@ public class QueryableProjectionEnumTest
             .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
             .HaveDiagnostic(
-                DiagnosticDescriptors.EnumMappingStrategyByNameNotSupportedInProjectionMappings,
-                "The enum mapping strategy ByName, ByValueCheckDefined and explicit enum mappings cannot be used in projection mappings to map from C to D"
+                DiagnosticDescriptors.EnumMappingNotSupportedInProjectionMappings,
+                "The enum mapping strategy ByName, ByValueCheckDefined, explicit enum mappings and ignored enum values cannot be used in projection mappings to map from C to D"
             )
             .HaveAssertedAllDiagnostics();
     }
@@ -71,8 +71,8 @@ public class QueryableProjectionEnumTest
             .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
             .HaveDiagnostic(
-                DiagnosticDescriptors.EnumMappingStrategyByNameNotSupportedInProjectionMappings,
-                "The enum mapping strategy ByName, ByValueCheckDefined and explicit enum mappings cannot be used in projection mappings to map from C to D"
+                DiagnosticDescriptors.EnumMappingNotSupportedInProjectionMappings,
+                "The enum mapping strategy ByName, ByValueCheckDefined, explicit enum mappings and ignored enum values cannot be used in projection mappings to map from C to D"
             )
             .HaveDiagnostic(DiagnosticDescriptors.TargetEnumValueNotMapped, "Enum member Value2 (200) on D not found on source enum C")
             .HaveDiagnostic(DiagnosticDescriptors.SourceEnumValueNotMapped, "Enum member Value2 (100) on C not found on target enum D")

--- a/test/Riok.Mapperly.Tests/_snapshots/EnumTest.EnumToOtherEnumByNameWithoutOverlap.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/EnumTest.EnumToOtherEnumByNameWithoutOverlap.verified.txt
@@ -1,18 +1,6 @@
 ﻿{
   Diagnostics: [
     {
-      Id: RMG003,
-      Title: No overlapping enum members found,
-      Severity: Warning,
-      WarningLevel: 1,
-      Location: : (11,4)-(11,69),
-      Description: ,
-      HelpLink: ,
-      MessageFormat: {0} and {1} don't have overlapping enum member names, mapping will therefore always result in an exception,
-      Message: E1 and E2 don't have overlapping enum member names, mapping will therefore always result in an exception,
-      Category: Mapper
-    },
-    {
       Id: RMG038,
       Title: An enum member could not be found on the target enum,
       Severity: Info,
@@ -82,6 +70,18 @@
       HelpLink: ,
       MessageFormat: Enum member {0} ({1}) on {2} not found on source enum {3},
       Message: Enum member F (2) on E2 not found on source enum E1,
+      Category: Mapper
+    },
+    {
+      Id: RMG003,
+      Title: No overlapping enum members found,
+      Severity: Warning,
+      WarningLevel: 1,
+      Location: : (11,4)-(11,69),
+      Description: ,
+      HelpLink: ,
+      MessageFormat: {0} and {1} don't have overlapping enum member names, mapping will therefore always result in an exception,
+      Message: E1 and E2 don't have overlapping enum member names, mapping will therefore always result in an exception,
       Category: Mapper
     }
   ]


### PR DESCRIPTION
# Adds option to ignore enum values

Adds new attributes `MapperIgnoreSourceValue` and `MapperIgnoreTargetValue` to ignore source/target enum values. This is especially useful for strict enum mappings (to ignore single values not present in the source and/or target without emitting a diagnostic).

Fixes #337 

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
