### PR TITLE
chore: add member, mappable member and attribute caching

### DIFF
--- a/src/Riok.Mapperly/Configuration/AttributeDataAccessor.cs
+++ b/src/Riok.Mapperly/Configuration/AttributeDataAccessor.cs
@@ -10,11 +10,11 @@ namespace Riok.Mapperly.Configuration;
 /// </summary>
 internal class AttributeDataAccessor
 {
-    private readonly WellKnownTypes _types;
+    private readonly SymbolAccessor _symbolAccessor;
 
-    public AttributeDataAccessor(WellKnownTypes types)
+    public AttributeDataAccessor(SymbolAccessor symbolAccessor)
     {
-        _types = types;
+        _symbolAccessor = symbolAccessor;
     }
 
     public T AccessSingle<T>(ISymbol symbol)
@@ -42,11 +42,8 @@ internal class AttributeDataAccessor
     {
         var attrType = typeof(TAttribute);
         var dataType = typeof(TData);
-        var attrSymbol = _types.Get($"{attrType.Namespace}.{attrType.Name}");
 
-        var attrDatas = symbol
-            .GetAttributes()
-            .Where(x => SymbolEqualityComparer.Default.Equals(x.AttributeClass?.ConstructedFrom ?? x.AttributeClass, attrSymbol));
+        var attrDatas = _symbolAccessor.GetAttributes<TAttribute>(symbol);
 
         foreach (var attrData in attrDatas)
         {

--- a/src/Riok.Mapperly/Configuration/MapperConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/MapperConfiguration.cs
@@ -9,9 +9,9 @@ public class MapperConfiguration
     private readonly MappingConfiguration _defaultConfiguration;
     private readonly AttributeDataAccessor _dataAccessor;
 
-    public MapperConfiguration(WellKnownTypes wellKnownTypes, ISymbol mapperSymbol)
+    public MapperConfiguration(SymbolAccessor symbolAccessor, ISymbol mapperSymbol)
     {
-        _dataAccessor = new AttributeDataAccessor(wellKnownTypes);
+        _dataAccessor = new AttributeDataAccessor(symbolAccessor);
         Mapper = _dataAccessor.AccessSingle<MapperAttribute>(mapperSymbol);
         _defaultConfiguration = new MappingConfiguration(
             new EnumMappingConfiguration(

--- a/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
@@ -12,6 +12,7 @@ namespace Riok.Mapperly.Descriptors;
 public class DescriptorBuilder
 {
     private readonly MapperDescriptor _mapperDescriptor;
+    private readonly SymbolAccessor _symbolAccessor;
 
     private readonly MappingCollection _mappings = new();
     private readonly MethodNameBuilder _methodNameBuilder = new();
@@ -25,15 +26,18 @@ public class DescriptorBuilder
         Compilation compilation,
         ClassDeclarationSyntax mapperSyntax,
         INamedTypeSymbol mapperSymbol,
-        WellKnownTypes wellKnownTypes
+        WellKnownTypes wellKnownTypes,
+        SymbolAccessor symbolAccessor
     )
     {
         _mapperDescriptor = new MapperDescriptor(mapperSyntax, mapperSymbol, _methodNameBuilder);
+        _symbolAccessor = symbolAccessor;
         _mappingBodyBuilder = new MappingBodyBuilder(_mappings);
         _builderContext = new SimpleMappingBuilderContext(
             compilation,
-            new MapperConfiguration(wellKnownTypes, mapperSymbol),
+            new MapperConfiguration(symbolAccessor, mapperSymbol),
             wellKnownTypes,
+            _symbolAccessor,
             _mapperDescriptor,
             sourceContext,
             new MappingBuilder(_mappings),
@@ -77,7 +81,7 @@ public class DescriptorBuilder
 
     private void ReserveMethodNames()
     {
-        foreach (var methodSymbol in _mapperDescriptor.Symbol.GetAllMembers())
+        foreach (var methodSymbol in _symbolAccessor.GetAllMembers(_mapperDescriptor.Symbol))
         {
             _methodNameBuilder.Reserve(methodSymbol.Name);
         }

--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
-using Riok.Mapperly.Helpers;
 
 namespace Riok.Mapperly.Descriptors.Enumerables.EnsureCapacity;
 
@@ -19,8 +18,8 @@ public static class EnsureCapacityBuilder
         if (ctx.CollectionInfos == null)
             return null;
 
-        var capacityMethod = ctx.Target
-            .GetAllMethods(EnsureCapacityName)
+        var capacityMethod = ctx.SymbolAccessor
+            .GetAllMethods(ctx.Target, EnsureCapacityName)
             .FirstOrDefault(x => x.Parameters.Length == 1 && x.Parameters[0].Type.SpecialType == SpecialType.System_Int32 && !x.IsStatic);
 
         // if EnsureCapacity is not available then return null

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
@@ -68,12 +68,14 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
 
     private HashSet<string> GetSourceMemberNames()
     {
-        return Mapping.SourceType.GetAccessibleMappableMembers().Select(x => x.Name).ToHashSet();
+        return BuilderContext.SymbolAccessor.GetAllAccessibleMappableMembers(Mapping.SourceType).Select(x => x.Name).ToHashSet();
     }
 
     private Dictionary<string, IMappableMember> GetTargetMembers()
     {
-        return Mapping.TargetType.GetAccessibleMappableMembers().ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+        return BuilderContext.SymbolAccessor
+            .GetAllAccessibleMappableMembers(Mapping.TargetType)
+            .ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
     }
 
     private Dictionary<string, List<PropertyMappingConfiguration>> GetMemberConfigurations()

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
@@ -48,6 +48,7 @@ public static class ObjectMemberMappingBodyBuilder
                     MemberPathCandidateBuilder.BuildMemberPathCandidates(targetMember.Name),
                     ctx.IgnoredSourceMemberNames,
                     memberNameComparer,
+                    ctx.BuilderContext.SymbolAccessor,
                     out var sourceMemberPath
                 )
             )
@@ -75,7 +76,7 @@ public static class ObjectMemberMappingBodyBuilder
         PropertyMappingConfiguration config
     )
     {
-        if (!MemberPath.TryFind(ctx.Mapping.TargetType, config.Target.Path, out var targetMemberPath))
+        if (!MemberPath.TryFind(ctx.Mapping.TargetType, config.Target.Path, ctx.BuilderContext.SymbolAccessor, out var targetMemberPath))
         {
             ctx.BuilderContext.ReportDiagnostic(
                 DiagnosticDescriptors.ConfiguredMappingTargetMemberNotFound,
@@ -85,7 +86,7 @@ public static class ObjectMemberMappingBodyBuilder
             return;
         }
 
-        if (!MemberPath.TryFind(ctx.Mapping.SourceType, config.Source.Path, out var sourceMemberPath))
+        if (!MemberPath.TryFind(ctx.Mapping.SourceType, config.Source.Path, ctx.BuilderContext.SymbolAccessor, out var sourceMemberPath))
         {
             ctx.BuilderContext.ReportDiagnostic(
                 DiagnosticDescriptors.ConfiguredMappingSourceMemberNotFound,

--- a/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
@@ -53,7 +53,7 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
 
     public ITypeSymbol Target { get; }
 
-    public CollectionInfos? CollectionInfos => _collectionInfos ??= CollectionInfoBuilder.Build(Types, Source, Target);
+    public CollectionInfos? CollectionInfos => _collectionInfos ??= CollectionInfoBuilder.Build(Types, SymbolAccessor, Source, Target);
 
     protected IMethodSymbol? UserSymbol { get; }
 

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/DictionaryMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/DictionaryMappingBuilder.cs
@@ -38,8 +38,8 @@ public static class DictionaryMappingBuilder
                 or CollectionType.IReadOnlyDictionary
         )
         {
-            var sourceHasCount = ctx.Source
-                .GetAllProperties(CountPropertyName)
+            var sourceHasCount = ctx.SymbolAccessor
+                .GetAllProperties(ctx.Source, CountPropertyName)
                 .Any(x => !x.IsStatic && x is { IsIndexer: false, IsWriteOnly: false, Type.SpecialType: SpecialType.System_Int32 });
 
             var targetDictionarySymbol = ctx.Types.Get(typeof(Dictionary<,>)).Construct(keyMapping.TargetType, valueMapping.TargetType);

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumToStringMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumToStringMappingBuilder.cs
@@ -18,6 +18,6 @@ public static class EnumToStringMappingBuilder
 
         // to string => use an optimized method of Enum.ToString which would use slow reflection
         // use Enum.ToString as fallback (for ex. for flags)
-        return new EnumToStringMapping(ctx.Source, ctx.Target, ctx.Source.GetMembers().OfType<IFieldSymbol>());
+        return new EnumToStringMapping(ctx.Source, ctx.Target, ctx.SymbolAccessor.GetAllFields(ctx.Source));
     }
 }

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/ParseMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/ParseMappingBuilder.cs
@@ -19,8 +19,8 @@ public static class ParseMappingBuilder
 
         var targetIsNullable = ctx.Target.NonNullable(out var nonNullableTarget);
 
-        var parseMethodCandidates = nonNullableTarget
-            .GetAllMethods(ParseMethodName)
+        var parseMethodCandidates = ctx.SymbolAccessor
+            .GetAllMethods(nonNullableTarget, ParseMethodName)
             .Where(
                 m =>
                     m.IsStatic

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/StringToEnumMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/StringToEnumMappingBuilder.cs
@@ -37,7 +37,7 @@ public static class StringToEnumMappingBuilder
         // however we currently don't support all features of Enum.Parse yet (ex. flags)
         // therefore we use Enum.Parse as fallback.
         var fallbackMapping = BuildFallbackParseMapping(ctx, genericEnumParseMethodSupported);
-        var members = ctx.Target.GetFields();
+        var members = ctx.SymbolAccessor.GetAllFields(ctx.Target);
         if (fallbackMapping.FallbackMember != null)
         {
             // no need to explicitly map fallback value

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/ObjectFactoryBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/ObjectFactoryBuilder.cs
@@ -12,7 +12,7 @@ public static class ObjectFactoryBuilder
         var objectFactories = mapperSymbol
             .GetMembers()
             .OfType<IMethodSymbol>()
-            .Where(m => m.HasAttribute(ctx.Types.Get<ObjectFactoryAttribute>()))
+            .Where(m => ctx.SymbolAccessor.HasAttribute<ObjectFactoryAttribute>(m))
             .Select(x => BuildObjectFactory(ctx, x))
             .WhereNotNull()
             .ToList();

--- a/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
@@ -18,6 +18,7 @@ public class SimpleMappingBuilderContext
         Compilation compilation,
         MapperConfiguration configuration,
         WellKnownTypes types,
+        SymbolAccessor symbolAccessor,
         MapperDescriptor descriptor,
         SourceProductionContext context,
         MappingBuilder mappingBuilder,
@@ -26,6 +27,7 @@ public class SimpleMappingBuilderContext
     {
         Compilation = compilation;
         Types = types;
+        SymbolAccessor = symbolAccessor;
         _configuration = configuration;
         _descriptor = descriptor;
         _context = context;
@@ -38,6 +40,7 @@ public class SimpleMappingBuilderContext
             ctx.Compilation,
             ctx._configuration,
             ctx.Types,
+            ctx.SymbolAccessor,
             ctx._descriptor,
             ctx._context,
             ctx.MappingBuilder,
@@ -49,6 +52,7 @@ public class SimpleMappingBuilderContext
     public MapperAttribute MapperConfiguration => _configuration.Mapper;
 
     public WellKnownTypes Types { get; }
+    public SymbolAccessor SymbolAccessor { get; }
 
     protected MappingBuilder MappingBuilder { get; }
 

--- a/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Riok.Mapperly.Helpers;
+using Riok.Mapperly.Symbols;
+
+namespace Riok.Mapperly.Descriptors;
+
+public class SymbolAccessor
+{
+    private readonly WellKnownTypes _types;
+    private readonly Dictionary<ISymbol, ImmutableArray<AttributeData>> _attributes = new(SymbolEqualityComparer.Default);
+    private readonly Dictionary<ITypeSymbol, IReadOnlyCollection<ISymbol>> _allMembers = new(SymbolEqualityComparer.Default);
+    private readonly Dictionary<ITypeSymbol, IReadOnlyCollection<IMappableMember>> _allAccessibleMembers =
+        new(SymbolEqualityComparer.Default);
+
+    public SymbolAccessor(WellKnownTypes types)
+    {
+        _types = types;
+    }
+
+    internal IEnumerable<AttributeData> GetAttributes<T>(ISymbol symbol)
+        where T : Attribute
+    {
+        var attributeSymbol = _types.Get<T>();
+        return GetAttributesCore(symbol)
+            .Where(x => SymbolEqualityComparer.Default.Equals(x.AttributeClass?.ConstructedFrom ?? x.AttributeClass, attributeSymbol));
+    }
+
+    internal bool HasAttribute<T>(ISymbol symbol)
+        where T : Attribute => GetAttributes<T>(symbol).Any();
+
+    internal IEnumerable<IMethodSymbol> GetAllMethods(ITypeSymbol symbol) => GetAllMembers(symbol).OfType<IMethodSymbol>();
+
+    internal IEnumerable<IMethodSymbol> GetAllMethods(ITypeSymbol symbol, string name) =>
+        GetAllMembers(symbol, name).OfType<IMethodSymbol>();
+
+    internal IEnumerable<IPropertySymbol> GetAllProperties(ITypeSymbol symbol, string name) =>
+        GetAllMembers(symbol, name).OfType<IPropertySymbol>();
+
+    internal IEnumerable<IFieldSymbol> GetAllFields(ITypeSymbol symbol) => GetAllMembers(symbol).OfType<IFieldSymbol>();
+
+    internal IReadOnlyCollection<ISymbol> GetAllMembers(ITypeSymbol symbol)
+    {
+        if (_allMembers.TryGetValue(symbol, out var members))
+        {
+            return members;
+        }
+
+        members = GetAllMembersCore(symbol).ToArray();
+        _allMembers.Add(symbol, members);
+
+        return members;
+    }
+
+    internal IReadOnlyCollection<IMappableMember> GetAllAccessibleMappableMembers(ITypeSymbol symbol)
+    {
+        if (_allAccessibleMembers.TryGetValue(symbol, out var members))
+        {
+            return members;
+        }
+
+        members = GetAllAccessibleMappableMembersCore(symbol).ToArray();
+        _allAccessibleMembers.Add(symbol, members);
+
+        return members;
+    }
+
+    internal IEnumerable<IMappableMember> GetMappableMembers(ITypeSymbol symbol, string name, IEqualityComparer<string> comparer)
+    {
+        return GetAllAccessibleMappableMembers(symbol).Where(x => comparer.Equals(name, x.Name));
+    }
+
+    private IEnumerable<ISymbol> GetAllMembers(ITypeSymbol symbol, string name) => GetAllMembers(symbol).Where(x => name.Equals(x.Name));
+
+    private ImmutableArray<AttributeData> GetAttributesCore(ISymbol symbol)
+    {
+        if (_attributes.TryGetValue(symbol, out var attributes))
+        {
+            return attributes;
+        }
+
+        attributes = symbol.GetAttributes();
+        _attributes.Add(symbol, attributes);
+
+        return attributes;
+    }
+
+    private IEnumerable<ISymbol> GetAllMembersCore(ITypeSymbol symbol)
+    {
+        var members = symbol.GetMembers();
+
+        if (symbol.TypeKind == TypeKind.Interface)
+        {
+            var interfaceProperties = symbol.AllInterfaces.SelectMany(GetAllMembers);
+            return members.Concat(interfaceProperties);
+        }
+
+        return symbol.BaseType == null ? members : members.Concat(GetAllMembers(symbol.BaseType));
+    }
+
+    private IEnumerable<IMappableMember> GetAllAccessibleMappableMembersCore(ITypeSymbol symbol)
+    {
+        return GetAllMembers(symbol)
+            .Where(x => x is { IsStatic: false, Kind: SymbolKind.Property or SymbolKind.Field } && x.IsAccessible())
+            .DistinctBy(x => x.Name)
+            .Select(MappableMember.Create)
+            .WhereNotNull();
+    }
+}

--- a/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
+++ b/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
@@ -21,10 +21,16 @@ public class WellKnownTypes
     public ITypeSymbol GetArrayType(ITypeSymbol type) =>
         _compilation.CreateArrayTypeSymbol(type, elementNullableAnnotation: type.NullableAnnotation).NonNullable();
 
-    public INamedTypeSymbol Get<T>() => Get(typeof(T).FullName);
+    public INamedTypeSymbol Get<T>() => Get(typeof(T));
 
-    public INamedTypeSymbol Get(Type type) =>
-        Get(type.FullName ?? throw new InvalidOperationException("Could not get name of type " + type));
+    public INamedTypeSymbol Get(Type type)
+    {
+        if (type.IsConstructedGenericType)
+        {
+            type = type.GetGenericTypeDefinition();
+        }
+        return Get(type.FullName ?? throw new InvalidOperationException("Could not get name of type " + type));
+    }
 
     public INamedTypeSymbol Get(string typeFullName) =>
         TryGet(typeFullName) ?? throw new InvalidOperationException("Could not get type " + typeFullName);

--- a/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
+++ b/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
@@ -1,9 +1,7 @@
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Riok.Mapperly.Symbols;
 
 namespace Riok.Mapperly.Helpers;
 
@@ -13,9 +11,6 @@ internal static class SymbolExtensions
         typeof(Uri).FullName,
         typeof(Version).FullName
     );
-
-    internal static bool HasAttribute(this ISymbol symbol, INamedTypeSymbol attributeSymbol) =>
-        symbol.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeSymbol));
 
     internal static bool IsImmutable(this ISymbol symbol) =>
         symbol is INamedTypeSymbol namedSymbol
@@ -56,47 +51,7 @@ internal static class SymbolExtensions
         return enumType != null;
     }
 
-    internal static IEnumerable<IMethodSymbol> GetAllMethods(this ITypeSymbol symbol) => symbol.GetAllMembers().OfType<IMethodSymbol>();
-
-    internal static IEnumerable<IMethodSymbol> GetAllMethods(this ITypeSymbol symbol, string name) =>
-        symbol.GetAllMembers(name).OfType<IMethodSymbol>();
-
-    internal static IEnumerable<IPropertySymbol> GetAllProperties(this ITypeSymbol symbol, string name) =>
-        symbol.GetAllMembers(name).OfType<IPropertySymbol>();
-
     internal static IEnumerable<IFieldSymbol> GetFields(this ITypeSymbol symbol) => symbol.GetMembers().OfType<IFieldSymbol>();
-
-    internal static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol symbol)
-    {
-        var members = symbol.GetMembers();
-
-        if (symbol.TypeKind == TypeKind.Interface)
-        {
-            var interfaceProperties = symbol.AllInterfaces.SelectMany(i => i.GetAllMembers());
-            return members.Concat(interfaceProperties);
-        }
-
-        return symbol.BaseType == null ? members : members.Concat(symbol.BaseType.GetAllMembers());
-    }
-
-    internal static IEnumerable<IMappableMember> GetMappableMembers(
-        this ITypeSymbol symbol,
-        string name,
-        IEqualityComparer<string> comparer
-    )
-    {
-        return symbol.GetAllMembers().Where(x => !x.IsStatic && comparer.Equals(name, x.Name)).Select(MappableMember.Create).WhereNotNull();
-    }
-
-    internal static IEnumerable<IMappableMember> GetAccessibleMappableMembers(this ITypeSymbol symbol)
-    {
-        return symbol
-            .GetAllMembers()
-            .Where(x => !x.IsStatic && x.IsAccessible())
-            .DistinctBy(x => x.Name)
-            .Select(MappableMember.Create)
-            .WhereNotNull();
-    }
 
     internal static IMethodSymbol? GetStaticGenericMethod(this INamedTypeSymbol namedType, string methodName)
     {
@@ -209,7 +164,4 @@ internal static class SymbolExtensions
 
         return true;
     }
-
-    private static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol symbol, string name) =>
-        symbol.GetAllMembers().Where(x => name.Equals(x.Name));
 }

--- a/src/Riok.Mapperly/MapperGenerator.cs
+++ b/src/Riok.Mapperly/MapperGenerator.cs
@@ -38,6 +38,7 @@ public class MapperGenerator : IIncrementalGenerator
             return;
 
         var wellKnownTypes = new WellKnownTypes(compilation);
+        var symbolAccessor = new SymbolAccessor(wellKnownTypes);
         var uniqueNameBuilder = new UniqueNameBuilder();
         foreach (var mapperSyntax in mappers.Distinct())
         {
@@ -45,10 +46,10 @@ public class MapperGenerator : IIncrementalGenerator
             if (mapperModel.GetDeclaredSymbol(mapperSyntax) is not INamedTypeSymbol mapperSymbol)
                 continue;
 
-            if (!mapperSymbol.HasAttribute(mapperAttributeSymbol))
+            if (!symbolAccessor.HasAttribute<MapperAttribute>(mapperSymbol))
                 continue;
 
-            var builder = new DescriptorBuilder(ctx, compilation, mapperSyntax, mapperSymbol, wellKnownTypes);
+            var builder = new DescriptorBuilder(ctx, compilation, mapperSyntax, mapperSymbol, wellKnownTypes, symbolAccessor);
             var descriptor = builder.Build();
 
             ctx.AddSource(


### PR DESCRIPTION
# Add member, mappable member and attribute caching

## Description
Added member, mappable member and attribute caching to improve performance and reduce memory usage.

Splitting up changes from #530 

## Benchmarks
10ms time and 3000KB memory savings
### Cache
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  2.491 ms | 0.0391 ms | 0.0366 ms |  156.2500 |  31.2500 |  284.15 KB |
| LargeCompile | 64.276 ms | 1.2297 ms | 1.2628 ms | 1714.2857 | 714.2857 | 10713.9 KB |

### Original
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |   Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|------------:|
|      Compile |  2.640 ms | 0.0524 ms | 0.0490 ms |  179.6875 |  46.8750 |   320.39 KB |
| LargeCompile | 75.350 ms | 1.4524 ms | 1.3586 ms | 2333.3333 | 833.3333 | 14283.01 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |   Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|------------:|
|      Compile |  2.627 ms | 0.0428 ms | 0.0379 ms |  179.6875 |  39.0625 |   326.46 KB |
| LargeCompile | 72.979 ms | 1.1195 ms | 0.8740 ms | 2285.7143 | 571.4286 | 14280.24 KB |



## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
