### PR TITLE
chore: optimize CollectionInfoBuilder

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Enumerables/CollectionType.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/CollectionType.cs
@@ -1,7 +1,7 @@
 namespace Riok.Mapperly.Descriptors.Enumerables;
 
 [Flags]
-public enum CollectionType
+public enum CollectionType : ulong
 {
     None = 0,
     Array = 1 << 0,
@@ -40,9 +40,10 @@ public enum CollectionType
     IImmutableStack = 1 << 25,
     ImmutableDictionary = 1 << 26,
     IImmutableDictionary = 1 << 27,
+    ImmutableSortedDictionary = 1 << 28,
 
-    Span = 1 << 28,
-    ReadOnlySpan = 1 << 29,
-    Memory = 1 << 30,
-    ReadOnlyMemory = 1 << 31,
+    Span = 1 << 29,
+    ReadOnlySpan = 1 << 30,
+    Memory = 1L << 31,
+    ReadOnlyMemory = 1L << 32,
 }


### PR DESCRIPTION
# Optimize `CollectioninfoBuilder`

## Description
- Converted `CollectionTypeInfo` to a struct
- Removed duplicate `IImmutableQueue` and added `ImmutableSortedDictionary`
- Added check to `HasValidAddMethod` for types with known `Add` methods, otherwise all none `None` types return false. `None` types are manually checked for `Add` methods.
- `IsCountKnown` returns null for `IEnumerable`, "Length" for `Array`, `Span` and `Memory` and "Count" for all none `None` types. `None` types are manually checked for length properties.
  - Added a special check for `string` to return `IEnumerable`, because string isn't actually a "collection" type but does implement `IEnumerable` and is marked `None` by `GetCollectionTypeInfo`. It would iterate thrrought every possible collection type causing a considerable slow down.
- Moved `GetEnumeratedType` into `BuildCollectionInfos`. This is a quick check to ensure that both the source and target types are actually enumerable, saving a lot of wasted time.
<!-- Please include a summary of the changes and the related issue. -->

Splitting up changes from https://github.com/riok/mapperly/pull/530

## Benchmarks
Small performance boost with 2000KB memory savings
### Optimize `CollectionInfoBuilder `
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  2.498 ms | 0.0321 ms | 0.0284 ms |  160.1563 |  35.1563 |  289.22 KB |
| LargeCompile | 66.696 ms | 1.2895 ms | 1.0768 ms | 1833.3333 | 666.6667 | 11943.5 KB |

|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |     Gen2 |   Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|---------:|------------:|
|      Compile |  2.500 ms | 0.0365 ms | 0.0305 ms |  164.0625 |  35.1563 |        - |   290.83 KB |
| LargeCompile | 69.251 ms | 1.3676 ms | 2.4310 ms | 2000.0000 | 714.2857 | 142.8571 | 11946.09 KB |

### Original
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |   Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|------------:|
|      Compile |  2.640 ms | 0.0524 ms | 0.0490 ms |  179.6875 |  46.8750 |   320.39 KB |
| LargeCompile | 75.350 ms | 1.4524 ms | 1.3586 ms | 2333.3333 | 833.3333 | 14283.01 KB |
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |   Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|------------:|
|      Compile |  2.627 ms | 0.0428 ms | 0.0379 ms |  179.6875 |  39.0625 |   326.46 KB |
| LargeCompile | 72.979 ms | 1.1195 ms | 0.8740 ms | 2285.7143 | 571.4286 | 14280.24 KB |



## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
