### PR TITLE
fix: generate nameof compatible member access

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/NullMemberMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/NullMemberMapping.cs
@@ -57,10 +57,11 @@ public class NullMemberMapping : IMemberMapping
         if (_delegateMapping.IsSynthetic && (_useNullConditionalAccess || !SourcePath.IsAnyObjectPathNullable()))
         {
             var nullConditionalSourceAccess = SourcePath.BuildAccess(ctx.Source, nullConditional: true);
+            var nameofSourceAccess = SourcePath.BuildAccess(ctx.Source, nullConditional: false);
             var mapping = _delegateMapping.Build(ctx.WithSource(nullConditionalSourceAccess));
             return _nullFallback == NullFallbackValue.Default && _targetType.IsNullable()
                 ? mapping
-                : Coalesce(mapping, NullSubstitute(_delegateMapping.TargetType, nullConditionalSourceAccess, _nullFallback));
+                : Coalesce(mapping, NullSubstitute(_delegateMapping.TargetType, nameofSourceAccess, _nullFallback));
         }
 
         var notNullCondition = _useNullConditionalAccess

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyConstructorResolverTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyConstructorResolverTest.cs
@@ -327,7 +327,7 @@ public class ObjectPropertyConstructorResolverTest
             .Should()
             .HaveSingleMethodBody(
                 """
-                var target = new global::B(source.Nested?.Value ?? throw new System.ArgumentNullException(nameof(source.Nested?.Value)));
+                var target = new global::B(source.Nested?.Value ?? throw new System.ArgumentNullException(nameof(source.Nested.Value)));
                 return target;
                 """
             );

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyInitPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyInitPropertyTest.cs
@@ -172,7 +172,7 @@ public class ObjectPropertyInitPropertyTest
                 """
                 var target = new global::B()
                 {
-                    NestedValue = source.Nested?.Value ?? throw new System.ArgumentNullException(nameof(source.Nested?.Value))
+                    NestedValue = source.Nested?.Value ?? throw new System.ArgumentNullException(nameof(source.Nested.Value))
                 };
                 return target;
                 """


### PR DESCRIPTION
# Generate nameof compatible member path

## Description
Use a non nullable path argument in the nameof expression.

Fixes #528

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
