### PR TITLE
Use `string` for methods instead of `IMethodSymbol`

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Enumerables/CollectionInfoBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/CollectionInfoBuilder.cs
@@ -167,13 +167,10 @@ public static class CollectionInfoBuilder
         if (typeInfo is not CollectionType.None)
             return "Count";
 
-        var intType = types.Get<int>();
         var member = symbolAccessor
             .GetAllAccessibleMappableMembers(t)
             .FirstOrDefault(
-                x =>
-                    x.Name is nameof(ICollection<object>.Count) or nameof(Array.Length)
-                    && SymbolEqualityComparer.IncludeNullability.Equals(intType, x.Type)
+                x => x.Name is nameof(ICollection<object>.Count) or nameof(Array.Length) && x.Type.SpecialType == SpecialType.System_Int32
             );
         return member?.Name;
     }

--- a/src/Riok.Mapperly/Descriptors/Mappings/LinqConstructorMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/LinqConstructorMapping.cs
@@ -12,14 +12,14 @@ public class LinqConstructorMapping : TypeMapping
 {
     private readonly INamedTypeSymbol _targetTypeToConstruct;
     private readonly ITypeMapping _elementMapping;
-    private readonly IMethodSymbol? _selectMethod;
+    private readonly string? _selectMethod;
 
     public LinqConstructorMapping(
         ITypeSymbol sourceType,
         ITypeSymbol targetType,
         INamedTypeSymbol targetTypeToConstruct,
         ITypeMapping elementMapping,
-        IMethodSymbol? selectMethod
+        string? selectMethod
     )
         : base(sourceType, targetType)
     {
@@ -38,7 +38,7 @@ public class LinqConstructorMapping : TypeMapping
             var (lambdaCtx, lambdaSourceName) = ctx.WithNewScopedSource();
             var sourceMapExpression = _elementMapping.Build(lambdaCtx);
             var convertLambda = SimpleLambdaExpression(Parameter(Identifier(lambdaSourceName))).WithExpressionBody(sourceMapExpression);
-            mappedSource = StaticInvocation(_selectMethod, ctx.Source, convertLambda);
+            mappedSource = Invocation(_selectMethod, ctx.Source, convertLambda);
         }
         else
         {

--- a/src/Riok.Mapperly/Descriptors/Mappings/LinqDictionaryMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/LinqDictionaryMapping.cs
@@ -8,19 +8,19 @@ namespace Riok.Mapperly.Descriptors.Mappings;
 /// <summary>
 /// Represents an enumerable mapping which works by using linq (select + collect).
 /// </summary>
-public class LinqDicitonaryMapping : TypeMapping
+public class LinqDictionaryMapping : TypeMapping
 {
     private const string KeyPropertyName = nameof(KeyValuePair<object, object>.Key);
     private const string ValuePropertyName = nameof(KeyValuePair<object, object>.Value);
 
-    private readonly IMethodSymbol _collectMethod;
+    private readonly string _collectMethod;
     private readonly ITypeMapping _keyMapping;
     private readonly ITypeMapping _valueMapping;
 
-    public LinqDicitonaryMapping(
+    public LinqDictionaryMapping(
         ITypeSymbol sourceType,
         ITypeSymbol targetType,
-        IMethodSymbol collectMethod,
+        string collectMethod,
         ITypeMapping keyMapping,
         ITypeMapping valueMapping
     )
@@ -36,7 +36,7 @@ public class LinqDicitonaryMapping : TypeMapping
         // if key and value types do not change then use a simple call
         // ie: source.ToImmutableDictionary();
         if (_keyMapping.IsSynthetic && _valueMapping.IsSynthetic)
-            return StaticInvocation(_collectMethod, ctx.Source);
+            return Invocation(_collectMethod, ctx.Source);
 
         // create expressions mapping the key and value and then create the final expression
         // ie: source.ToImmutableDictionary(x => x.Key, x => (int)x.Value);
@@ -48,6 +48,6 @@ public class LinqDicitonaryMapping : TypeMapping
         var valueMapExpression = _valueMapping.Build(valueLambdaCtx);
         var valueExpression = SimpleLambdaExpression(Parameter(Identifier(valueLambdaParamName))).WithExpressionBody(valueMapExpression);
 
-        return StaticInvocation(_collectMethod, ctx.Source, keyExpression, valueExpression);
+        return Invocation(_collectMethod, ctx.Source, keyExpression, valueExpression);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/LinqEnumerableMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/LinqEnumerableMapping.cs
@@ -11,15 +11,15 @@ namespace Riok.Mapperly.Descriptors.Mappings;
 public class LinqEnumerableMapping : TypeMapping
 {
     private readonly ITypeMapping _elementMapping;
-    private readonly IMethodSymbol? _selectMethod;
-    private readonly IMethodSymbol? _collectMethod;
+    private readonly string? _selectMethod;
+    private readonly string? _collectMethod;
 
     public LinqEnumerableMapping(
         ITypeSymbol sourceType,
         ITypeSymbol targetType,
         ITypeMapping elementMapping,
-        IMethodSymbol? selectMethod,
-        IMethodSymbol? collectMethod
+        string? selectMethod,
+        string? collectMethod
     )
         : base(sourceType, targetType)
     {
@@ -38,13 +38,13 @@ public class LinqEnumerableMapping : TypeMapping
             var (lambdaCtx, lambdaSourceName) = ctx.WithNewScopedSource();
             var sourceMapExpression = _elementMapping.Build(lambdaCtx);
             var convertLambda = SimpleLambdaExpression(Parameter(Identifier(lambdaSourceName))).WithExpressionBody(sourceMapExpression);
-            mappedSource = StaticInvocation(_selectMethod, ctx.Source, convertLambda);
+            mappedSource = Invocation(_selectMethod, ctx.Source, convertLambda);
         }
         else
         {
             mappedSource = _elementMapping.Build(ctx);
         }
 
-        return _collectMethod == null ? mappedSource : StaticInvocation(_collectMethod, mappedSource);
+        return _collectMethod == null ? mappedSource : Invocation(_collectMethod, mappedSource);
     }
 }

--- a/src/Riok.Mapperly/Emit/SyntaxFactoryHelper.cs
+++ b/src/Riok.Mapperly/Emit/SyntaxFactoryHelper.cs
@@ -299,21 +299,26 @@ public static class SyntaxFactoryHelper
         return InvocationExpression(methodAccess).WithArgumentList(ArgumentList(arguments));
     }
 
-    public static InvocationExpressionSyntax StaticInvocation(IMethodSymbol method, params ExpressionSyntax[] arguments) =>
-        StaticInvocation(
-            FullyQualifiedIdentifierName(method.ReceiverType?.NonNullable()!)
-                ?? throw new ArgumentNullException(nameof(method.ReceiverType)),
-            method.Name,
-            arguments
-        );
+    public static string StaticMethodString(IMethodSymbol method)
+    {
+        var receiver = method.ReceiverType ?? throw new NullReferenceException(nameof(method.ReceiverType) + " is null");
+        var qualifiedReceiverName = FullyQualifiedIdentifierName(receiver.NonNullable());
+        return $"{qualifiedReceiverName}.{method.Name}";
+    }
+
+    public static InvocationExpressionSyntax StaticInvocation(IMethodSymbol method, params ExpressionSyntax[] arguments)
+    {
+        var receiver = method.ReceiverType ?? throw new NullReferenceException(nameof(method.ReceiverType) + " is null");
+        var qualifiedReceiverName = FullyQualifiedIdentifierName(receiver.NonNullable());
+        return StaticInvocation(qualifiedReceiverName, method.Name, arguments);
+    }
 
     public static InvocationExpressionSyntax StaticInvocation(IMethodSymbol method, params ArgumentSyntax[] arguments)
     {
-        var receiverType =
-            FullyQualifiedIdentifierName(method.ReceiverType?.NonNullable()!)
-            ?? throw new ArgumentNullException(nameof(method.ReceiverType));
+        var receiver = method.ReceiverType ?? throw new NullReferenceException(nameof(method.ReceiverType) + " is null");
+        var qualifiedReceiverName = FullyQualifiedIdentifierName(receiver.NonNullable());
 
-        var receiverTypeIdentifier = IdentifierName(receiverType);
+        var receiverTypeIdentifier = IdentifierName(qualifiedReceiverName);
         var methodAccess = MemberAccessExpression(
             SyntaxKind.SimpleMemberAccessExpression,
             receiverTypeIdentifier,


### PR DESCRIPTION
# Use `string` for methods instead of `IMethodSymbol`

## Description
Inspired [by Sytem.Text.Json](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Text.Json/gen/Helpers/KnownTypeSymbols.cs#L237C13-L237C13) to use the known string of a method instead of looking it up via the compilation.

- `CollectionInfoBuilder` - used `SpecialType.System_Int32` instead of `types.Get<int>()`
- `EnumerableMappingBuilder` - use method string instead of retrieving the type and looking for a matching method, this has been done for ImmutableCollections, Collect methods and `Select`
- `DictionaryMappingBuilder`
  - Use switch expression in `ResolveImmutableCollectMethod` to use `CollectionType`
  - Use method string instead of retrieving the type and looking for a matching method.
  - Fix typo `LinqDicitonaryMapping`

Related to #530

Note that I've used a branch where #537 and #542 are added. This shouldn't be merged until after they are added.
By using a known method string it might be possible to remove the qualified type signature and use a using statement. See #507 

## Benchmarks
Saves 0.5MB with a small 5% speed boost
### Original
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.653 ms | 0.0307 ms | 0.0301 ms |   93.7500 |  23.4375 |   180.8 KB |
| LargeCompile | 58.961 ms | 0.9728 ms | 1.6253 ms | 1571.4286 | 571.4286 | 9712.91 KB |

### Changed
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.618 ms | 0.0317 ms | 0.0412 ms |   93.7500 |  23.4375 |  174.31 KB |
| LargeCompile | 55.762 ms | 0.8799 ms | 1.2620 ms | 1500.0000 | 500.0000 | 9284.46 KB |

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
