### PR TITLE
fix: add modifying nested struct diagnostic

### DIFF
--- a/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
@@ -105,3 +105,4 @@ RMG043  | Mapper   | Warning  | Enum fallback values are only supported for the 
 RMG044  | Mapper   | Warning  | An ignored enum member can not be found on the source enum
 RMG045  | Mapper   | Warning  | An ignored enum member can not be found on the target enum
 RMG046  | Mapper   | Error    | The used C# language version is not supported by Mapperly, Mapperly requires at least C# 9.0
+RMG047  | Mapper   | Error    | Cannot map to member path due to modifying a temporary value, see CS1612

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -410,4 +410,13 @@ internal static class DiagnosticDescriptors
         DiagnosticSeverity.Error,
         true
     );
+
+    public static readonly DiagnosticDescriptor CannotMapToTemporarySourceMember = new DiagnosticDescriptor(
+        "RMG047",
+        "Cannot map to member path due to modifying a temporary value, see CS1612",
+        "Cannot map from member {0}.{1} of type {2} to member path {3}.{4} of type {5} because {6}.{7} is a value type, returning a temporary value, see CS1612",
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Error,
+        true
+    );
 }


### PR DESCRIPTION
# Add diagnostic for modifying a temporary value type

## Description
Added check for if a nested value type is being modified.

Probably not a common issue so I went with a diagnostic.
I considered nested chain assignment or a `with` expression ie `target.NestedValue = target.NestedValue with { StringValue = src.StringValue };` (can repeatedly chain)


Fixes #516

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
