### PR TITLE
fix: private members can override public members

### DIFF
--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
@@ -333,6 +333,29 @@ public class ObjectPropertyTest
     }
 
     [Fact]
+    public void PrivateMemberPropertyShouldNotOverride()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            "class A { private int MyValue { get; set; } public C My { get; set; } }",
+            "class B { public int MyValue { get; set; } }",
+            "class C { public int Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                target.MyValue = source.My.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public Task WithPrivateSourceGetterShouldIgnoreAndDiagnostic()
     {
         var source = TestSourceBuilder.Mapping(


### PR DESCRIPTION
# Private members with greater flattening priority can override public members

## Description
Under specific circumstances, when Mapperly attempts to map to a target, a private source members with greater flattening priority can override another public member. A later validation check would reject the mapping as the source is inaccessible, emitting a diagnostic.
#537 prevents this by only mapping accessable source members.

This PR contains a test to validate that the bug is fixed.

Fixes #521

## Checklist

- [ ] Unit tests are added/updated
