### PR TITLE
chore: common linq loop allocations, add small optimisations 

### DIFF
--- a/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
@@ -22,8 +22,13 @@ public class SymbolAccessor
         where T : Attribute
     {
         var attributeSymbol = _types.Get<T>();
-        return GetAttributesCore(symbol)
-            .Where(x => SymbolEqualityComparer.Default.Equals(x.AttributeClass?.ConstructedFrom ?? x.AttributeClass, attributeSymbol));
+        foreach (var attr in GetAttributesCore(symbol))
+        {
+            if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass?.ConstructedFrom ?? attr.AttributeClass, attributeSymbol))
+            {
+                yield return attr;
+            }
+        }
     }
 
     internal bool HasAttribute<T>(ISymbol symbol)
@@ -67,7 +72,13 @@ public class SymbolAccessor
 
     internal IEnumerable<IMappableMember> GetMappableMembers(ITypeSymbol symbol, string name, IEqualityComparer<string> comparer)
     {
-        return GetAllAccessibleMappableMembers(symbol).Where(x => comparer.Equals(name, x.Name));
+        foreach (var member in GetAllAccessibleMappableMembers(symbol))
+        {
+            if (comparer.Equals(name, member.Name))
+            {
+                yield return member;
+            }
+        }
     }
 
     private IEnumerable<ISymbol> GetAllMembers(ITypeSymbol symbol, string name) => GetAllMembers(symbol).Where(x => name.Equals(x.Name));

--- a/src/Riok.Mapperly/Helpers/NullableSymbolExtensions.cs
+++ b/src/Riok.Mapperly/Helpers/NullableSymbolExtensions.cs
@@ -5,8 +5,6 @@ namespace Riok.Mapperly.Helpers;
 
 public static class NullableSymbolExtensions
 {
-    private const string NullableGenericTypeName = "System.Nullable<T>";
-
     internal static bool HasSameOrStricterNullability(this ITypeSymbol symbol, ITypeSymbol other)
     {
         return symbol.NullableAnnotation == NullableAnnotation.NotAnnotated
@@ -109,10 +107,7 @@ public static class NullableSymbolExtensions
 
     private static ITypeSymbol? NonNullableValueType(this ITypeSymbol symbol)
     {
-        if (
-            symbol is INamedTypeSymbol { IsValueType: true, IsGenericType: true } namedType
-            && namedType.ConstructedFrom.ToDisplayString() == NullableGenericTypeName
-        )
+        if (symbol.IsValueType && symbol is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } namedType)
             return namedType.TypeArguments[0];
         return null;
     }

--- a/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
+++ b/src/Riok.Mapperly/Helpers/SymbolExtensions.cs
@@ -70,10 +70,17 @@ internal static class SymbolExtensions
             return true;
         }
 
-        typedInterface = t.AllInterfaces.FirstOrDefault(
-            x => x.IsGenericType && SymbolEqualityComparer.Default.Equals(x.OriginalDefinition, genericInterfaceSymbol)
-        );
-        return typedInterface != null;
+        foreach (var typeSymbol in t.AllInterfaces)
+        {
+            if (typeSymbol.IsGenericType && SymbolEqualityComparer.Default.Equals(typeSymbol.OriginalDefinition, genericInterfaceSymbol))
+            {
+                typedInterface = typeSymbol;
+                return true;
+            }
+        }
+
+        typedInterface = null;
+        return false;
     }
 
     internal static bool ImplementsGeneric(


### PR DESCRIPTION
# Remove linq allocations, add small optimisations

## Description
Slightly microbenchmarky improvements, not sure about the  manual foreach loops

- Remove `FirstOrDefault` allocation from `SymbolExtensions.ImplementsGeneric` - 106KB - `Func<INamedTypeSymbol, Boolean>`
- Remove `Where` allocation from `SymbolAccessor.GetMappableMembers` - 76KB - `Func<ISymbol, Boolean>`
- Remove `Where` allocation from `SymbolAccessor.GetAttributes` - 150KB - `Func<AttributeData, Boolean>`
- Use non string comparison `NonNullableValueType` check
- Add `IsRefLike` check to `GetEnumeratedType`
- Remove unneeded `types.Get<int>()` call  from `CollectionInfoBuilder.FindCountProperty`


<!-- Please include a summary of the changes and the related issue. -->

Related to #530

## Benchmarks
200 KB saved, little change in speed.
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.441 ms | 0.0206 ms | 0.0237 ms |   78.1250 |  15.6250 |  162.41 KB |
| LargeCompile | 56.606 ms | 1.1015 ms | 1.4323 ms | 1428.5714 | 428.5714 | 9367.77 KB |

### Original
|       Method |      Mean |     Error |    StdDev |      Gen0 |     Gen1 |  Allocated |
|------------- |----------:|----------:|----------:|----------:|---------:|-----------:|
|      Compile |  1.450 ms | 0.0288 ms | 0.0374 ms |   78.1250 |  19.5313 |  167.37 KB |
| LargeCompile | 55.899 ms | 1.0530 ms | 1.3318 ms | 1428.5714 | 428.5714 | 9579.64 KB |

### Changes

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented

