### PR TITLE
fix: required/init properties not using PropertyNameMappingStrategy (…

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
@@ -34,6 +34,11 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
 
     private static void BuildInitOnlyMemberMappings(INewInstanceBuilderContext<IMapping> ctx, bool includeAllMembers = false)
     {
+        var memberNameComparer =
+            ctx.BuilderContext.MapperConfiguration.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseSensitive
+                ? StringComparer.Ordinal
+                : StringComparer.OrdinalIgnoreCase;
+
         var initOnlyTargetMembers = includeAllMembers
             ? ctx.TargetMembers.Values.ToArray()
             : ctx.TargetMembers.Values.Where(x => x.CanOnlySetViaInitializer()).ToArray();
@@ -52,6 +57,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
                     ctx.Mapping.SourceType,
                     MemberPathCandidateBuilder.BuildMemberPathCandidates(targetMember.Name),
                     ctx.IgnoredSourceMemberNames,
+                    memberNameComparer,
                     ctx.BuilderContext.SymbolAccessor,
                     out var sourceMemberPath
                 )

--- a/src/Riok.Mapperly/Symbols/MemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/MemberPath.cs
@@ -180,14 +180,6 @@ public class MemberPath
         ITypeSymbol type,
         IEnumerable<IEnumerable<string>> pathCandidates,
         IReadOnlyCollection<string> ignoredNames,
-        SymbolAccessor symbolAccessor,
-        [NotNullWhen(true)] out MemberPath? memberPath
-    ) => TryFind(type, pathCandidates, ignoredNames, StringComparer.Ordinal, symbolAccessor, out memberPath);
-
-    public static bool TryFind(
-        ITypeSymbol type,
-        IEnumerable<IEnumerable<string>> pathCandidates,
-        IReadOnlyCollection<string> ignoredNames,
         IEqualityComparer<string> comparer,
         SymbolAccessor symbolAccessor,
         [NotNullWhen(true)] out MemberPath? memberPath

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
@@ -176,8 +176,8 @@ public class ObjectPropertyTest
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             "partial B Map(A source);",
             new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.CaseInsensitive },
-            "class A { public string StringValue { get; set; } }",
-            "class B { public string stringvalue { get; set; } }"
+            "class A { public string StringValue { get; set; } public int Value { get; set; } }",
+            "class B { public string stringvalue { get; set; } public required int value { get; init; } }"
         );
 
         TestHelper
@@ -185,7 +185,10 @@ public class ObjectPropertyTest
             .Should()
             .HaveSingleMethodBody(
                 """
-                var target = new global::B();
+                var target = new global::B()
+                {
+                    value = source.Value
+                };
                 target.stringvalue = source.StringValue;
                 return target;
                 """


### PR DESCRIPTION
# Fix `required` and `init` properties not using `PropertyNameMappingStrategy`

## Description

Use the `MemberPath.TryFind` method overload with an `IEqualityComparer ` parameter inside `NewInstanceObjectMemberMappingBodyBuilder.BuildInitOnlyMemberMappings` and deleted the one it used before (a method overload without a comparer parameter)

Fixes #505 

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Unit tests are added/updated