### PR TITLE
chore: minor refactor for `GetAttributes` and UserMethods

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedExistingTargetMethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedExistingTargetMethodMapping.cs
@@ -15,8 +15,10 @@ public class UserDefinedExistingTargetMethodMapping : MethodMapping, IUserMappin
 {
     private const string NoMappingComment = "// Could not generate mapping";
 
+    private const string ReferenceHandlerTypeName =
+        "global::Riok.Mapperly.Abstractions.ReferenceHandling.Internal.PreserveReferenceHandler";
+
     private readonly bool _enableReferenceHandling;
-    private readonly INamedTypeSymbol _referenceHandlerType;
     private IExistingTargetMapping? _delegateMapping;
 
     public UserDefinedExistingTargetMethodMapping(
@@ -24,13 +26,11 @@ public class UserDefinedExistingTargetMethodMapping : MethodMapping, IUserMappin
         MethodParameter sourceParameter,
         MethodParameter targetParameter,
         MethodParameter? referenceHandlerParameter,
-        bool enableReferenceHandling,
-        INamedTypeSymbol referenceHandlerType
+        bool enableReferenceHandling
     )
         : base(method, sourceParameter, referenceHandlerParameter, targetParameter.Type)
     {
         _enableReferenceHandling = enableReferenceHandling;
-        _referenceHandlerType = referenceHandlerType;
         Method = method;
         TargetParameter = targetParameter;
     }
@@ -68,7 +68,7 @@ public class UserDefinedExistingTargetMethodMapping : MethodMapping, IUserMappin
         {
             // var refHandler = new RefHandler();
             var referenceHandlerName = ctx.NameBuilder.New(DefaultReferenceHandlerParameterName);
-            var createRefHandler = CreateInstance(_referenceHandlerType);
+            var createRefHandler = CreateInstance(ReferenceHandlerTypeName);
             yield return DeclareLocalVariable(referenceHandlerName, createRefHandler);
             ctx = ctx.WithRefHandler(referenceHandlerName);
         }

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceGenericTypeMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceGenericTypeMapping.cs
@@ -20,11 +20,10 @@ public class UserDefinedNewInstanceGenericTypeMapping : UserDefinedNewInstanceRu
         GenericMappingTypeParameters typeParameters,
         MappingMethodParameters parameters,
         bool enableReferenceHandling,
-        INamedTypeSymbol referenceHandlerType,
         NullFallbackValue nullArm,
         ITypeSymbol objectType
     )
-        : base(method, parameters.Source, parameters.ReferenceHandler, enableReferenceHandling, referenceHandlerType, nullArm, objectType)
+        : base(method, parameters.Source, parameters.ReferenceHandler, enableReferenceHandling, nullArm, objectType)
     {
         TypeParameters = typeParameters;
     }

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceMethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceMethodMapping.cs
@@ -13,21 +13,20 @@ namespace Riok.Mapperly.Descriptors.Mappings.UserMappings;
 public class UserDefinedNewInstanceMethodMapping : MethodMapping, IDelegateUserMapping
 {
     private const string NoMappingComment = "// Could not generate mapping";
+    private const string ReferenceHandlerTypeName =
+        "global::Riok.Mapperly.Abstractions.ReferenceHandling.Internal.PreserveReferenceHandler";
 
     private readonly bool _enableReferenceHandling;
-    private readonly INamedTypeSymbol _referenceHandlerType;
 
     public UserDefinedNewInstanceMethodMapping(
         IMethodSymbol method,
         MethodParameter sourceParameter,
         MethodParameter? referenceHandlerParameter,
-        bool enableReferenceHandling,
-        INamedTypeSymbol referenceHandlerType
+        bool enableReferenceHandling
     )
         : base(method, sourceParameter, referenceHandlerParameter, method.ReturnType.UpgradeNullable())
     {
         _enableReferenceHandling = enableReferenceHandling;
-        _referenceHandlerType = referenceHandlerType;
         Method = method;
     }
 
@@ -50,7 +49,7 @@ public class UserDefinedNewInstanceMethodMapping : MethodMapping, IDelegateUserM
         if (_enableReferenceHandling && ReferenceHandlerParameter == null)
         {
             // new RefHandler();
-            var createRefHandler = CreateInstance(_referenceHandlerType);
+            var createRefHandler = CreateInstance(ReferenceHandlerTypeName);
             ctx = ctx.WithRefHandler(createRefHandler);
             return new[] { ReturnStatement(DelegateMapping.Build(ctx)) };
         }

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceRuntimeTargetTypeMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceRuntimeTargetTypeMapping.cs
@@ -15,10 +15,11 @@ public abstract class UserDefinedNewInstanceRuntimeTargetTypeMapping : MethodMap
 {
     private const string IsAssignableFromMethodName = nameof(Type.IsAssignableFrom);
     private const string GetTypeMethodName = nameof(GetType);
+    private const string ReferenceHandlerTypeName =
+        "global::Riok.Mapperly.Abstractions.ReferenceHandling.Internal.PreserveReferenceHandler";
 
     private readonly List<RuntimeTargetTypeMapping> _mappings = new();
     private readonly bool _enableReferenceHandling;
-    private readonly INamedTypeSymbol _referenceHandlerType;
     private readonly NullFallbackValue _nullArm;
     private readonly ITypeSymbol _objectType;
 
@@ -27,7 +28,6 @@ public abstract class UserDefinedNewInstanceRuntimeTargetTypeMapping : MethodMap
         MethodParameter sourceParameter,
         MethodParameter? referenceHandlerParameter,
         bool enableReferenceHandling,
-        INamedTypeSymbol referenceHandlerType,
         NullFallbackValue nullArm,
         ITypeSymbol objectType
     )
@@ -35,7 +35,6 @@ public abstract class UserDefinedNewInstanceRuntimeTargetTypeMapping : MethodMap
     {
         Method = method;
         _enableReferenceHandling = enableReferenceHandling;
-        _referenceHandlerType = referenceHandlerType;
         _nullArm = nullArm;
         _objectType = objectType;
     }
@@ -61,7 +60,7 @@ public abstract class UserDefinedNewInstanceRuntimeTargetTypeMapping : MethodMap
         {
             // var refHandler = new RefHandler();
             var referenceHandlerName = ctx.NameBuilder.New(DefaultReferenceHandlerParameterName);
-            var createRefHandler = CreateInstance(_referenceHandlerType);
+            var createRefHandler = CreateInstance(ReferenceHandlerTypeName);
             yield return DeclareLocalVariable(referenceHandlerName, createRefHandler);
 
             ctx = ctx.WithRefHandler(referenceHandlerName);

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceRuntimeTargetTypeParameterMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceRuntimeTargetTypeParameterMapping.cs
@@ -18,11 +18,10 @@ public class UserDefinedNewInstanceRuntimeTargetTypeParameterMapping : UserDefin
         IMethodSymbol method,
         RuntimeTargetTypeMappingMethodParameters parameters,
         bool enableReferenceHandling,
-        INamedTypeSymbol referenceHandlerType,
         NullFallbackValue nullArm,
         ITypeSymbol objectType
     )
-        : base(method, parameters.Source, parameters.ReferenceHandler, enableReferenceHandling, referenceHandlerType, nullArm, objectType)
+        : base(method, parameters.Source, parameters.ReferenceHandler, enableReferenceHandling, nullArm, objectType)
     {
         _targetTypeParameter = parameters.TargetType;
     }

--- a/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
@@ -21,8 +21,14 @@ public class SymbolAccessor
     internal IEnumerable<AttributeData> GetAttributes<T>(ISymbol symbol)
         where T : Attribute
     {
+        var attributes = GetAttributesCore(symbol);
+        if (attributes.IsEmpty)
+        {
+            yield break;
+        }
+
         var attributeSymbol = _types.Get<T>();
-        foreach (var attr in GetAttributesCore(symbol))
+        foreach (var attr in attributes)
         {
             if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass?.ConstructedFrom ?? attr.AttributeClass, attributeSymbol))
             {

--- a/src/Riok.Mapperly/Descriptors/UserMethodMappingExtractor.cs
+++ b/src/Riok.Mapperly/Descriptors/UserMethodMappingExtractor.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Riok.Mapperly.Abstractions.ReferenceHandling;
-using Riok.Mapperly.Abstractions.ReferenceHandling.Internal;
 using Riok.Mapperly.Descriptors.Mappings;
 using Riok.Mapperly.Descriptors.Mappings.UserMappings;
 using Riok.Mapperly.Diagnostics;
@@ -104,7 +103,6 @@ public static class UserMethodMappingExtractor
                 methodSymbol,
                 runtimeTargetTypeParams,
                 ctx.MapperConfiguration.UseReferenceHandling,
-                ctx.Types.Get<PreserveReferenceHandler>(),
                 GetTypeSwitchNullArm(methodSymbol, runtimeTargetTypeParams, null),
                 ctx.Compilation.ObjectType
             );
@@ -123,7 +121,6 @@ public static class UserMethodMappingExtractor
                 typeParameters.Value,
                 parameters,
                 ctx.MapperConfiguration.UseReferenceHandling,
-                ctx.Types.Get<PreserveReferenceHandler>(),
                 GetTypeSwitchNullArm(methodSymbol, parameters, typeParameters),
                 ctx.Compilation.ObjectType
             );
@@ -142,8 +139,7 @@ public static class UserMethodMappingExtractor
                 parameters.Source,
                 parameters.Target.Value,
                 parameters.ReferenceHandler,
-                ctx.MapperConfiguration.UseReferenceHandling,
-                ctx.Types.Get<PreserveReferenceHandler>()
+                ctx.MapperConfiguration.UseReferenceHandling
             );
         }
 
@@ -151,8 +147,7 @@ public static class UserMethodMappingExtractor
             methodSymbol,
             parameters.Source,
             parameters.ReferenceHandler,
-            ctx.MapperConfiguration.UseReferenceHandling,
-            ctx.Types.Get<PreserveReferenceHandler>()
+            ctx.MapperConfiguration.UseReferenceHandling
         );
     }
 

--- a/src/Riok.Mapperly/Emit/SyntaxFactoryHelper.cs
+++ b/src/Riok.Mapperly/Emit/SyntaxFactoryHelper.cs
@@ -354,6 +354,12 @@ public static class SyntaxFactoryHelper
     public static StatementSyntax CreateInstance(string variableName, ITypeSymbol typeSymbol) =>
         DeclareLocalVariable(variableName, CreateInstance(typeSymbol));
 
+    public static ObjectCreationExpressionSyntax CreateInstance(string typeName)
+    {
+        var type = IdentifierName(typeName);
+        return ObjectCreationExpression(type).WithArgumentList(SyntaxFactory.ArgumentList());
+    }
+
     public static ObjectCreationExpressionSyntax CreateInstance(ITypeSymbol typeSymbol)
     {
         var type = NonNullableIdentifier(typeSymbol);


### PR DESCRIPTION
# Refactor UserMethods and optimize `GetAttributes`

## Description
- Remove usage of `Get<PreserveReferenceHandler>()` from UserMethods, replace with a constant display string, simplifying logic and slightly improving memory usage (one less call to `WellKnownType.Get`).
- Reorder logic in `GetAttributes<T>` to get the symbols attributes before retrieving the attribute type. This way if the symbol doesn't have any attributes the symbol doesn't have to be retrieved.

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
