### PR TITLE
feat: diagnostic if an incompatible language version is used

### DIFF
--- a/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
@@ -104,3 +104,4 @@ RMG042  | Mapper   | Error    | The type of the enum fallback value does not mat
 RMG043  | Mapper   | Warning  | Enum fallback values are only supported for the ByName and ByValueCheckDefined strategies, but not for the ByValue strategy
 RMG044  | Mapper   | Warning  | An ignored enum member can not be found on the source enum
 RMG045  | Mapper   | Warning  | An ignored enum member can not be found on the target enum
+RMG046  | Mapper   | Error    | The used C# language version is not supported by Mapperly, Mapperly requires at least C# 9.0

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -401,4 +401,13 @@ internal static class DiagnosticDescriptors
         DiagnosticSeverity.Warning,
         true
     );
+
+    public static readonly DiagnosticDescriptor LanguageVersionNotSupported = new DiagnosticDescriptor(
+        "RMG046",
+        "The used C# language version is not supported by Mapperly, Mapperly requires at least C# 9.0",
+        "Mapperly does not support the C# language version {0} but requires at C# least version {1}",
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Error,
+        true
+    );
 }

--- a/test/Riok.Mapperly.Tests/Generator/IncrementalGeneratorTest.cs
+++ b/test/Riok.Mapperly.Tests/Generator/IncrementalGeneratorTest.cs
@@ -35,17 +35,17 @@ public class IncrementalGeneratorTest
 
         var secondary = TestSourceBuilder.SyntaxTree(
             """
-                    using Riok.Mapperly.Abstractions;
+            using Riok.Mapperly.Abstractions;
 
-                    namespace Test.B
-                    {
-                        [Mapper]
-                        internal partial class BarFooMapper
-                        {
-                            internal partial string BarToFoo(string value);
-                        }
-                    }
-                    """
+            namespace Test.B
+            {
+                [Mapper]
+                internal partial class BarFooMapper
+                {
+                    internal partial string BarToFoo(string value);
+                }
+            }
+            """
         );
 
         var syntaxTree = CSharpSyntaxTree.ParseText(source, CSharpParseOptions.Default);

--- a/test/Riok.Mapperly.Tests/Mapping/MapperTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/MapperTest.cs
@@ -1,3 +1,6 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Riok.Mapperly.Diagnostics;
+
 namespace Riok.Mapperly.Tests.Mapping;
 
 [UsesVerify]
@@ -107,5 +110,19 @@ public class MapperTest
         );
 
         return TestHelper.VerifyGenerator(source);
+    }
+
+    [Fact]
+    public void LanguageLevelLower9ShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.Mapping("string", "int");
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics with { LanguageVersion = LanguageVersion.CSharp8 })
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.LanguageVersionNotSupported,
+                "Mapperly does not support the C# language version 8.0 but requires at C# least version 9.0"
+            )
+            .HaveAssertedAllDiagnostics();
     }
 }


### PR DESCRIPTION
# diagnostic if an incompatible language version is used

## Description

Emits RMG046 as an error if a language version < 9.0 is used.

Fixes #532

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
