### PR TITLE
chore: use `WellKnowTypes` to get `MapperAttribute`

### DIFF
--- a/src/Riok.Mapperly/MapperGenerator.cs
+++ b/src/Riok.Mapperly/MapperGenerator.cs
@@ -62,11 +62,11 @@ public class MapperGenerator : IIncrementalGenerator
 #if DEBUG_SOURCE_GENERATOR
         DebuggerUtil.AttachDebugger();
 #endif
-        var mapperAttributeSymbol = compilation.GetTypeByMetadataName(MapperAttributeName);
+        var wellKnownTypes = new WellKnownTypes(compilation);
+        var mapperAttributeSymbol = wellKnownTypes.TryGet(MapperAttributeName);
         if (mapperAttributeSymbol == null)
             return MapperResults.Empty;
 
-        var wellKnownTypes = new WellKnownTypes(compilation);
         var symbolAccessor = new SymbolAccessor(wellKnownTypes);
         var uniqueNameBuilder = new UniqueNameBuilder();
 


### PR DESCRIPTION
# Use `WellKnowTypes` to get `MapperAttribute`

## Description
Reorder `MapperGenerator` to get the `MapperAttribute` with `WellKnowTypes`

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code

