### PR TITLE
fix: `Nullable<T>.Value` is no longer treated as a member

### DIFF
--- a/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
@@ -136,7 +136,9 @@ public class SymbolAccessor
     {
         foreach (var name in path)
         {
-            if (GetMappableMembers(type, name, comparer).FirstOrDefault() is not { } member)
+            // get T if type is Nullable<T>, prevents Value being treated as a member
+            var actualType = type.NonNullableValueType() ?? type;
+            if (GetMappableMembers(actualType, name, comparer).FirstOrDefault() is not { } member)
                 break;
 
             type = member.Type;

--- a/src/Riok.Mapperly/Helpers/NullableSymbolExtensions.cs
+++ b/src/Riok.Mapperly/Helpers/NullableSymbolExtensions.cs
@@ -83,6 +83,13 @@ public static class NullableSymbolExtensions
 
     internal static bool IsNullableValueType(this ITypeSymbol symbol) => symbol.NonNullableValueType() != null;
 
+    internal static ITypeSymbol? NonNullableValueType(this ITypeSymbol symbol)
+    {
+        if (symbol.IsValueType && symbol is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } namedType)
+            return namedType.TypeArguments[0];
+        return null;
+    }
+
     /// <summary>
     /// Whether or not the <see cref="ITypeParameterSymbol"/> is nullable.
     /// </summary>
@@ -104,11 +111,4 @@ public static class NullableSymbolExtensions
     }
 
     private static bool IsNullable(this NullableAnnotation nullable) => nullable is NullableAnnotation.Annotated or NullableAnnotation.None;
-
-    private static ITypeSymbol? NonNullableValueType(this ITypeSymbol symbol)
-    {
-        if (symbol.IsValueType && symbol is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } namedType)
-            return namedType.TypeArguments[0];
-        return null;
-    }
 }


### PR DESCRIPTION
# `Nullable<T>.Value` is no longer treated as a member

## Description
Added check to `SymbolAccessor` for nullable value types. This way `Nullable<T>.Value` will not be treated as a member resulting in invalid auto resolved flattenings

Fixes #572 & #571

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [ ] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] Unit tests are added/updated

