### PR TITLE
fix: incorrect initialization for nullable nested memberpath unflattening

### DIFF
--- a/src/Riok.Mapperly/Symbols/MemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/MemberPath.cs
@@ -65,7 +65,7 @@ public class MemberPath
             if (!pathPart.IsNullable)
                 continue;
 
-            yield return pathParts;
+            yield return pathParts.ToArray();
         }
     }
 


### PR DESCRIPTION
# Fix incorrect initialzation code for nested nullable members when unflattening

## Description
When using `MapProperty` to map to deeply nested nullable members, Mapperly will generate a series of identical statements initializing the same field. This is because all the `MemberNullAssignmentInitializerMapping` mistakenly use the same `IReadOnlyCollection` so will all update the same path.

Added a `ToArray` to `ObjectPathNullableSubPaths` to collect the paths into separate collections.

### Example bug
```C#
var target = new global::B();
target.Value.Nested ??= new();
target.Value.Nested ??= new();
target.Value.Nested ??= new();
target.Value.Nested.Id = source.MyValueId;
target.Value.Nested.Id2 = source.MyValueId2;
return target;
```



## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Unit tests are added/updated

