### PR TITLE
fix: disable warning when iterating nullable array elements

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Mappings/NullDelegateMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/NullDelegateMapping.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Helpers;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -59,6 +60,12 @@ public class NullDelegateMapping : TypeMapping
         // or for nullable value types:
         // source == null ? <null-substitute> : Map(source.Value)
         var sourceValue = SourceType.IsNullableValueType() ? MemberAccess(ctx.Source, NullableValueProperty) : ctx.Source;
+
+        // disable nullable waring if accessing array
+        if (sourceValue is ElementAccessExpressionSyntax)
+        {
+            sourceValue = PostfixUnaryExpression(SyntaxKind.SuppressNullableWarningExpression, sourceValue);
+        }
 
         return ConditionalExpression(
             IsNull(ctx.Source),

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
@@ -82,7 +82,7 @@ public class EnumerableTest
                 var target = new global::B[source.Length];
                 for (var i = 0; i < source.Length; i++)
                 {
-                    target[i] = source[i] == null ? throw new System.NullReferenceException($"Sequence {nameof(source)}, contained a null value at index {i}.") : source[i];
+                    target[i] = source[i] == null ? throw new System.NullReferenceException($"Sequence {nameof(source)}, contained a null value at index {i}.") : source[i]!;
                 }
 
                 return target;


### PR DESCRIPTION
# Disable warning when accessing nullable elements 

## Description
As suggested added null supression to `NullDelegateMapping` when accessing array elements.

Fixes #416

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] Unit tests are added/updated

