### PR TITLE
chore: use `HasImplicitAdd` and optimize `HasValidAddMethod`

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/SpanMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/SpanMappingBuilder.cs
@@ -91,10 +91,7 @@ public static class SpanMappingBuilder
         // create a foreach loop with add calls if source is not an array
         // and ICollection.Add(T): void is implemented and not explicit
         // ensures add is not called and immutable types
-        if (
-            target.CollectionType is not CollectionType.Array
-            && ctx.Target.HasImplicitGenericImplementation(ctx.Types.Get(typeof(ICollection<>)), AddMethodName)
-        )
+        if (target.CollectionType is not CollectionType.Array && target.HasImplicitCollectionAddMethod)
             return CreateForEach(AddMethodName);
 
         // if a mapping could be created for an immutable collection
@@ -148,10 +145,7 @@ public static class SpanMappingBuilder
         // create a foreach loop with add calls if source is not an array
         // and ICollection.Add(T): void is implemented and not explicit
         // ensures add is not called and immutable types
-        if (
-            target.CollectionType is not CollectionType.Array
-            && ctx.Target.HasImplicitGenericImplementation(ctx.Types.Get(typeof(ICollection<>)), AddMethodName)
-        )
+        if (target.CollectionType is not CollectionType.Array && target.HasImplicitCollectionAddMethod)
             return CreateForEach(AddMethodName, objectFactory);
 
         return MapSpanArrayToEnumerableMethod(ctx);


### PR DESCRIPTION
# Use `HasImplicitAdd` and optimize `HasValidAddMethod`

## Description
Minor nit picks
- Use `HasImplicitAdd` in `SpanMappingBuilder` instead of manually checking for valid `Add` methods again.
- Optimize `HasValidAddMethod` to use the implemented types to check before searching for an implicit add method.
 

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
