### PR TITLE
fix: handle internal visibility correctly

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Enumerables/CollectionInfoBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/CollectionInfoBuilder.cs
@@ -163,6 +163,7 @@ public static class CollectionInfoBuilder
         {
             return true;
         }
+
         // has valid add if type implements ISet and has implicit Add method
         if (
             implementedTypes.HasFlag(CollectionType.ISet)

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
@@ -1,6 +1,5 @@
 using Riok.Mapperly.Descriptors.Mappings.MemberMappings;
 using Riok.Mapperly.Diagnostics;
-using Riok.Mapperly.Helpers;
 using Riok.Mapperly.Symbols;
 
 namespace Riok.Mapperly.Descriptors.MappingBodyBuilders.BuilderContext;
@@ -39,7 +38,7 @@ public class MembersContainerBuilderContext<T> : MembersMappingBuilderContext<T>
         {
             var nullablePath = new MemberPath(nullableTrailPath);
             var type = nullablePath.Member.Type;
-            if (!type.HasAccessibleParameterlessConstructor())
+            if (!BuilderContext.SymbolAccessor.HasAccessibleParameterlessConstructor(type))
             {
                 BuilderContext.ReportDiagnostic(DiagnosticDescriptors.NoParameterlessConstructorFound, type);
                 continue;

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
@@ -189,7 +189,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
         // then by descending parameter count
         // ctors annotated with [Obsolete] are considered last unless they have a MapperConstructor attribute set
         var ctorCandidates = namedTargetType.InstanceConstructors
-            .Where(ctor => ctor.IsAccessible())
+            .Where(ctor => ctx.BuilderContext.SymbolAccessor.IsAccessible(ctor))
             .OrderByDescending(x => ctx.BuilderContext.SymbolAccessor.HasAttribute<MapperConstructorAttribute>(x))
             .ThenBy(x => ctx.BuilderContext.SymbolAccessor.HasAttribute<MapperConstructorAttribute>(x))
             .ThenByDescending(x => x.Parameters.Length == 0)

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewValueTupleMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewValueTupleMappingBodyBuilder.cs
@@ -196,23 +196,17 @@ public static class NewValueTupleMappingBodyBuilder
         if (!ctx.Mapping.SourceType.IsTupleType || ctx.Mapping.SourceType is not INamedTypeSymbol namedType)
             return false;
 
-        var mappableMember = namedType.TupleElements
-            .Where(
-                x =>
-                    x.CorrespondingTupleField != default
-                    && !ctx.IgnoredSourceMemberNames.Contains(x.Name)
-                    && string.Equals(field.CorrespondingTupleField!.Name, x.CorrespondingTupleField!.Name)
-            )
-            .Select(MappableMember.Create)
-            .WhereNotNull()
-            .FirstOrDefault();
+        var mappableField = namedType.TupleElements.FirstOrDefault(
+            x =>
+                x.CorrespondingTupleField != default
+                && !ctx.IgnoredSourceMemberNames.Contains(x.Name)
+                && string.Equals(field.CorrespondingTupleField!.Name, x.CorrespondingTupleField!.Name)
+        );
 
-        if (mappableMember != default)
-        {
-            sourcePath = new MemberPath(new[] { mappableMember });
-            return true;
-        }
+        if (mappableField == default)
+            return false;
 
-        return false;
+        sourcePath = new MemberPath(new[] { new FieldMember(mappableField) });
+        return true;
     }
 }

--- a/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
@@ -176,7 +176,7 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
         if (targetType.SpecialType == SpecialType.System_String)
             return NullFallbackValue.EmptyString;
 
-        if (targetType.HasAccessibleParameterlessConstructor())
+        if (SymbolAccessor.HasAccessibleParameterlessConstructor(targetType))
             return NullFallbackValue.CreateInstance;
 
         ReportDiagnostic(DiagnosticDescriptors.NoParameterlessConstructorFound, targetType);

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/CtorMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/CtorMappingBuilder.cs
@@ -17,7 +17,7 @@ public static class CtorMappingBuilder
 
         // resolve ctors which have the source as single argument
         var ctorMethod = namedTarget.InstanceConstructors
-            .Where(x => x.IsAccessible())
+            .Where(ctx.SymbolAccessor.IsAccessible)
             .FirstOrDefault(
                 m =>
                     m.Parameters.Length == 1

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/DerivedTypeMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/DerivedTypeMappingBuilder.cs
@@ -38,11 +38,11 @@ public static class DerivedTypeMappingBuilder
         var derivedTypeMappingSourceTypes = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
         var derivedTypeMappings = new List<ITypeMapping>(configs.Count);
         Func<ITypeSymbol, bool> isAssignableToSource = ctx.Source is ITypeParameterSymbol sourceTypeParameter
-            ? t => sourceTypeParameter.CanConsumeType(ctx.Compilation, ctx.Source.NullableAnnotation, t)
-            : t => t.IsAssignableTo(ctx.Compilation, ctx.Source);
+            ? t => ctx.SymbolAccessor.DoesTypeSatisfyTypeParameterConstraints(sourceTypeParameter, t, ctx.Source.NullableAnnotation)
+            : t => ctx.SymbolAccessor.HasImplicitConversion(t, ctx.Source);
         Func<ITypeSymbol, bool> isAssignableToTarget = ctx.Target is ITypeParameterSymbol targetTypeParameter
-            ? t => targetTypeParameter.CanConsumeType(ctx.Compilation, ctx.Target.NullableAnnotation, t)
-            : t => t.IsAssignableTo(ctx.Compilation, ctx.Target);
+            ? t => ctx.SymbolAccessor.DoesTypeSatisfyTypeParameterConstraints(targetTypeParameter, t, ctx.Target.NullableAnnotation)
+            : t => ctx.SymbolAccessor.HasImplicitConversion(t, ctx.Target);
 
         foreach (var config in configs)
         {

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/DictionaryMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/DictionaryMappingBuilder.cs
@@ -64,7 +64,7 @@ public static class DictionaryMappingBuilder
         // it should have a an object factory or a parameterless public ctor
         if (
             !ctx.ObjectFactories.TryFindObjectFactory(ctx.Source, ctx.Target, out var objectFactory)
-            && !ctx.Target.HasAccessibleParameterlessConstructor()
+            && !ctx.SymbolAccessor.HasAccessibleParameterlessConstructor(ctx.Target)
         )
         {
             ctx.ReportDiagnostic(DiagnosticDescriptors.NoParameterlessConstructorFound, ctx.Target);

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
@@ -165,7 +165,7 @@ public static class EnumerableMappingBuilder
     {
         if (
             !ctx.ObjectFactories.TryFindObjectFactory(ctx.Source, ctx.Target, out var objectFactory)
-            && !ctx.Target.HasAccessibleParameterlessConstructor()
+            && !ctx.SymbolAccessor.HasAccessibleParameterlessConstructor(ctx.Target)
         )
         {
             ctx.ReportDiagnostic(DiagnosticDescriptors.NoParameterlessConstructorFound, ctx.Target);

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/NewInstanceObjectPropertyMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/NewInstanceObjectPropertyMappingBuilder.cs
@@ -21,7 +21,7 @@ public static class NewInstanceObjectPropertyMappingBuilder
                 ctx.MapperConfiguration.UseReferenceHandling
             );
 
-        if (ctx.Target is not INamedTypeSymbol namedTarget || namedTarget.Constructors.All(x => !x.IsAccessible()))
+        if (ctx.Target is not INamedTypeSymbol namedTarget || namedTarget.Constructors.All(x => !ctx.SymbolAccessor.IsAccessible(x)))
             return null;
 
         if (ctx.Source.IsEnum() || ctx.Target.IsEnum())

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/SpanMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/SpanMappingBuilder.cs
@@ -5,7 +5,6 @@ using Riok.Mapperly.Descriptors.Mappings;
 using Riok.Mapperly.Descriptors.Mappings.ExistingTarget;
 using Riok.Mapperly.Descriptors.ObjectFactories;
 using Riok.Mapperly.Diagnostics;
-using Riok.Mapperly.Helpers;
 
 namespace Riok.Mapperly.Descriptors.MappingBuilders;
 
@@ -130,7 +129,7 @@ public static class SpanMappingBuilder
 
         if (
             !ctx.ObjectFactories.TryFindObjectFactory(ctx.Source, ctx.Target, out var objectFactory)
-            && !ctx.Target.HasAccessibleParameterlessConstructor()
+            && !ctx.SymbolAccessor.HasAccessibleParameterlessConstructor(ctx.Target)
         )
         {
             return MapSpanArrayToEnumerableMethod(ctx);

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericSourceObjectFactory.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericSourceObjectFactory.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Riok.Mapperly.Helpers;
 using static Riok.Mapperly.Emit.SyntaxFactoryHelper;
 
 namespace Riok.Mapperly.Descriptors.ObjectFactories;
@@ -12,17 +11,16 @@ namespace Riok.Mapperly.Descriptors.ObjectFactories;
 /// </summary>
 public class GenericSourceObjectFactory : ObjectFactory
 {
-    private readonly Compilation _compilation;
-
-    public GenericSourceObjectFactory(IMethodSymbol method, Compilation compilation)
-        : base(method)
-    {
-        _compilation = compilation;
-    }
+    public GenericSourceObjectFactory(SymbolAccessor symbolAccessor, IMethodSymbol method)
+        : base(symbolAccessor, method) { }
 
     public override bool CanCreateType(ITypeSymbol sourceType, ITypeSymbol targetTypeToCreate) =>
         SymbolEqualityComparer.Default.Equals(Method.ReturnType, targetTypeToCreate)
-        && Method.TypeParameters[0].CanConsumeType(_compilation, Method.Parameters[0].Type.NullableAnnotation, sourceType);
+        && SymbolAccessor.DoesTypeSatisfyTypeParameterConstraints(
+            Method.TypeParameters[0],
+            sourceType,
+            Method.Parameters[0].Type.NullableAnnotation
+        );
 
     protected override ExpressionSyntax BuildCreateType(ITypeSymbol sourceType, ITypeSymbol targetTypeToCreate, ExpressionSyntax source) =>
         GenericInvocation(Method.Name, new[] { NonNullableIdentifier(sourceType) }, source);

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericSourceTargetObjectFactory.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericSourceTargetObjectFactory.cs
@@ -1,34 +1,31 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Riok.Mapperly.Helpers;
 using static Riok.Mapperly.Emit.SyntaxFactoryHelper;
 
 namespace Riok.Mapperly.Descriptors.ObjectFactories;
 
 public class GenericSourceTargetObjectFactory : ObjectFactory
 {
-    private readonly Compilation _compilation;
     private readonly int _sourceTypeParameterIndex;
     private readonly int _targetTypeParameterIndex;
 
-    public GenericSourceTargetObjectFactory(IMethodSymbol method, Compilation compilation, int sourceTypeParameterIndex)
-        : base(method)
+    public GenericSourceTargetObjectFactory(SymbolAccessor symbolAccessor, IMethodSymbol method, int sourceTypeParameterIndex)
+        : base(symbolAccessor, method)
     {
-        _compilation = compilation;
         _sourceTypeParameterIndex = sourceTypeParameterIndex;
         _targetTypeParameterIndex = (sourceTypeParameterIndex + 1) % 2;
     }
 
     public override bool CanCreateType(ITypeSymbol sourceType, ITypeSymbol targetTypeToCreate) =>
-        Method.TypeParameters[_sourceTypeParameterIndex].CanConsumeType(
-            _compilation,
-            Method.Parameters[0].Type.NullableAnnotation,
-            sourceType
+        SymbolAccessor.DoesTypeSatisfyTypeParameterConstraints(
+            Method.TypeParameters[_sourceTypeParameterIndex],
+            sourceType,
+            Method.Parameters[0].Type.NullableAnnotation
         )
-        && Method.TypeParameters[_targetTypeParameterIndex].CanConsumeType(
-            _compilation,
-            Method.ReturnType.NullableAnnotation,
-            targetTypeToCreate
+        && SymbolAccessor.DoesTypeSatisfyTypeParameterConstraints(
+            Method.TypeParameters[_targetTypeParameterIndex],
+            targetTypeToCreate,
+            Method.ReturnType.NullableAnnotation
         );
 
     protected override ExpressionSyntax BuildCreateType(ITypeSymbol sourceType, ITypeSymbol targetTypeToCreate, ExpressionSyntax source)

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericTargetObjectFactory.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericTargetObjectFactory.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Riok.Mapperly.Helpers;
 using static Riok.Mapperly.Emit.SyntaxFactoryHelper;
 
 namespace Riok.Mapperly.Descriptors.ObjectFactories;
@@ -12,16 +11,15 @@ namespace Riok.Mapperly.Descriptors.ObjectFactories;
 /// </summary>
 public class GenericTargetObjectFactory : ObjectFactory
 {
-    private readonly Compilation _compilation;
-
-    public GenericTargetObjectFactory(IMethodSymbol method, Compilation compilation)
-        : base(method)
-    {
-        _compilation = compilation;
-    }
+    public GenericTargetObjectFactory(SymbolAccessor symbolAccessor, IMethodSymbol method)
+        : base(symbolAccessor, method) { }
 
     public override bool CanCreateType(ITypeSymbol sourceType, ITypeSymbol targetTypeToCreate) =>
-        Method.TypeParameters[0].CanConsumeType(_compilation, Method.ReturnType.NullableAnnotation, targetTypeToCreate);
+        SymbolAccessor.DoesTypeSatisfyTypeParameterConstraints(
+            Method.TypeParameters[0],
+            targetTypeToCreate,
+            Method.ReturnType.NullableAnnotation
+        );
 
     protected override ExpressionSyntax BuildCreateType(ITypeSymbol sourceType, ITypeSymbol targetTypeToCreate, ExpressionSyntax source) =>
         GenericInvocation(Method.Name, new[] { NonNullableIdentifier(targetTypeToCreate) });

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericTargetObjectFactoryWithSource.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericTargetObjectFactoryWithSource.cs
@@ -11,8 +11,8 @@ namespace Riok.Mapperly.Descriptors.ObjectFactories;
 /// </summary>
 public class GenericTargetObjectFactoryWithSource : GenericTargetObjectFactory
 {
-    public GenericTargetObjectFactoryWithSource(IMethodSymbol method, Compilation compilation)
-        : base(method, compilation) { }
+    public GenericTargetObjectFactoryWithSource(SymbolAccessor symbolAccessor, IMethodSymbol method)
+        : base(symbolAccessor, method) { }
 
     public override bool CanCreateType(ITypeSymbol sourceType, ITypeSymbol targetTypeToCreate) =>
         base.CanCreateType(sourceType, targetTypeToCreate) && SymbolEqualityComparer.Default.Equals(Method.Parameters[0].Type, sourceType);

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/ObjectFactory.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/ObjectFactory.cs
@@ -10,10 +10,13 @@ namespace Riok.Mapperly.Descriptors.ObjectFactories;
 /// </summary>
 public abstract class ObjectFactory
 {
-    protected ObjectFactory(IMethodSymbol method)
+    protected ObjectFactory(SymbolAccessor symbolAccessor, IMethodSymbol method)
     {
         Method = method;
+        SymbolAccessor = symbolAccessor;
     }
+
+    protected SymbolAccessor SymbolAccessor { get; }
 
     protected IMethodSymbol Method { get; }
 
@@ -38,7 +41,7 @@ public abstract class ObjectFactory
         if (!Method.ReturnType.UpgradeNullable().IsNullable())
             return expression;
 
-        ExpressionSyntax nullFallback = typeToCreate.HasAccessibleParameterlessConstructor()
+        ExpressionSyntax nullFallback = SymbolAccessor.HasAccessibleParameterlessConstructor(typeToCreate)
             ? CreateInstance(typeToCreate)
             : ThrowNullReferenceException($"The object factory {Method.Name} returned null");
 

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/ObjectFactoryBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/ObjectFactoryBuilder.cs
@@ -37,8 +37,8 @@ public static class ObjectFactoryBuilder
         if (!methodSymbol.IsGenericMethod)
         {
             return methodSymbol.Parameters.Length == 1
-                ? new SimpleObjectFactoryWithSource(methodSymbol)
-                : new SimpleObjectFactory(methodSymbol);
+                ? new SimpleObjectFactoryWithSource(ctx.SymbolAccessor, methodSymbol)
+                : new SimpleObjectFactory(ctx.SymbolAccessor, methodSymbol);
         }
 
         switch (methodSymbol.TypeParameters.Length)
@@ -76,12 +76,12 @@ public static class ObjectFactoryBuilder
         if (returnTypeIsGeneric)
         {
             return hasSourceParameter
-                ? new GenericTargetObjectFactoryWithSource(methodSymbol, ctx.Compilation)
-                : new GenericTargetObjectFactory(methodSymbol, ctx.Compilation);
+                ? new GenericTargetObjectFactoryWithSource(ctx.SymbolAccessor, methodSymbol)
+                : new GenericTargetObjectFactory(ctx.SymbolAccessor, methodSymbol);
         }
 
         if (hasSourceParameter)
-            return new GenericSourceObjectFactory(methodSymbol, ctx.Compilation);
+            return new GenericSourceObjectFactory(ctx.SymbolAccessor, methodSymbol);
 
         ctx.ReportDiagnostic(DiagnosticDescriptors.InvalidObjectFactorySignature, methodSymbol, methodSymbol.Name);
         return null;
@@ -109,6 +109,6 @@ public static class ObjectFactoryBuilder
             return null;
         }
 
-        return new GenericSourceTargetObjectFactory(methodSymbol, ctx.Compilation, sourceParameterIndex);
+        return new GenericSourceTargetObjectFactory(ctx.SymbolAccessor, methodSymbol, sourceParameterIndex);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/SimpleObjectFactory.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/SimpleObjectFactory.cs
@@ -10,8 +10,8 @@ namespace Riok.Mapperly.Descriptors.ObjectFactories;
 /// </summary>
 public class SimpleObjectFactory : ObjectFactory
 {
-    public SimpleObjectFactory(IMethodSymbol method)
-        : base(method) { }
+    public SimpleObjectFactory(SymbolAccessor symbolAccessor, IMethodSymbol method)
+        : base(symbolAccessor, method) { }
 
     public override bool CanCreateType(ITypeSymbol sourceType, ITypeSymbol targetTypeToCreate) =>
         SymbolEqualityComparer.Default.Equals(Method.ReturnType, targetTypeToCreate);

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/SimpleObjectFactoryWithSource.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/SimpleObjectFactoryWithSource.cs
@@ -11,8 +11,8 @@ namespace Riok.Mapperly.Descriptors.ObjectFactories;
 /// </summary>
 public class SimpleObjectFactoryWithSource : SimpleObjectFactory
 {
-    public SimpleObjectFactoryWithSource(IMethodSymbol method)
-        : base(method) { }
+    public SimpleObjectFactoryWithSource(SymbolAccessor symbolAccessor, IMethodSymbol method)
+        : base(symbolAccessor, method) { }
 
     public override bool CanCreateType(ITypeSymbol sourceType, ITypeSymbol targetTypeToCreate) =>
         base.CanCreateType(sourceType, targetTypeToCreate) && SymbolEqualityComparer.Default.Equals(sourceType, Method.Parameters[0].Type);

--- a/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
@@ -52,6 +52,7 @@ public class SimpleMappingBuilderContext
     public MapperAttribute MapperConfiguration => _configuration.Mapper;
 
     public WellKnownTypes Types { get; }
+
     public SymbolAccessor SymbolAccessor { get; }
 
     protected MappingBuilder MappingBuilder { get; }

--- a/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
+++ b/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
@@ -40,7 +40,7 @@ public class WellKnownTypes
             return typeSymbol;
         }
 
-        typeSymbol = _compilation.GetTypeByMetadataName(typeFullName);
+        typeSymbol = _compilation.GetBestTypeByMetadataName(typeFullName);
         _cachedTypes.Add(typeFullName, typeSymbol);
 
         return typeSymbol;

--- a/src/Riok.Mapperly/Helpers/CompilationExtensions.cs
+++ b/src/Riok.Mapperly/Helpers/CompilationExtensions.cs
@@ -1,0 +1,120 @@
+using Microsoft.CodeAnalysis;
+
+namespace Riok.Mapperly.Helpers;
+
+internal static class CompilationExtensions
+{
+    // Copy from https://github.com/dotnet/roslyn/blob/d2ff1d83e8fde6165531ad83f0e5b1ae95908289/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/CompilationExtensions.cs#L11-L68
+    /// <summary>
+    /// Gets a type by its metadata name to use for code analysis within a <see cref="Compilation"/>. This method
+    /// attempts to find the "best" symbol to use for code analysis, which is the symbol matching the first of the
+    /// following rules.
+    ///
+    /// <list type="number">
+    ///   <item><description>
+    ///     If only one type with the given name is found within the compilation and its referenced assemblies, that
+    ///     type is returned regardless of accessibility.
+    ///   </description></item>
+    ///   <item><description>
+    ///     If the current <paramref name="compilation"/> defines the symbol, that symbol is returned.
+    ///   </description></item>
+    ///   <item><description>
+    ///     If exactly one referenced assembly defines the symbol in a manner that makes it visible to the current
+    ///     <paramref name="compilation"/>, that symbol is returned.
+    ///   </description></item>
+    ///   <item><description>
+    ///     Otherwise, this method returns <see langword="null"/>.
+    ///   </description></item>
+    /// </list>
+    /// </summary>
+    /// <param name="compilation">The <see cref="Compilation"/> to consider for analysis.</param>
+    /// <param name="fullyQualifiedMetadataName">The fully-qualified metadata type name to find.</param>
+    /// <returns>The symbol to use for code analysis; otherwise, <see langword="null"/>.</returns>
+    public static INamedTypeSymbol? GetBestTypeByMetadataName(this Compilation compilation, string fullyQualifiedMetadataName)
+    {
+#if ROSLYN4_4_OR_GREATER
+        INamedTypeSymbol? type = null;
+
+        foreach (var currentType in compilation.GetTypesByMetadataName(fullyQualifiedMetadataName))
+        {
+            if (ReferenceEquals(currentType.ContainingAssembly, compilation.Assembly))
+                return currentType;
+
+            switch (currentType.GetResultantVisibility())
+            {
+                case SymbolVisibility.Public:
+                case SymbolVisibility.Internal when currentType.ContainingAssembly.GivesAccessTo(compilation.Assembly):
+                    break;
+
+                default:
+                    continue;
+            }
+
+            if (type != null)
+                return null;
+
+            type = currentType;
+        }
+
+        return type;
+#else
+        return compilation.GetTypeByMetadataName(fullyQualifiedMetadataName);
+#endif
+    }
+
+    // Copy from https://github.com/dotnet/roslyn/blob/d2ff1d83e8fde6165531ad83f0e5b1ae95908289/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs#L28-L73
+    private static SymbolVisibility GetResultantVisibility(this ISymbol symbol)
+    {
+        while (true)
+        {
+            // Start by assuming it's visible.
+            var visibility = SymbolVisibility.Public;
+            switch (symbol.Kind)
+            {
+                case SymbolKind.Alias:
+                    // Aliases are uber private.  They're only visible in the same file that they
+                    // were declared in.
+                    return SymbolVisibility.Private;
+
+                case SymbolKind.Parameter:
+                    // Parameters are only as visible as their containing symbol
+                    symbol = symbol.ContainingSymbol;
+                    continue;
+
+                case SymbolKind.TypeParameter:
+                    // Type Parameters are private.
+                    return SymbolVisibility.Private;
+            }
+
+            while (symbol != null && symbol.Kind != SymbolKind.Namespace)
+            {
+                switch (symbol.DeclaredAccessibility)
+                {
+                    // If we see anything private, then the symbol is private.
+                    case Accessibility.NotApplicable:
+                    case Accessibility.Private:
+                        return SymbolVisibility.Private;
+
+                    // If we see anything internal, then knock it down from public to
+                    // internal.
+                    case Accessibility.Internal:
+                    case Accessibility.ProtectedAndInternal:
+                        visibility = SymbolVisibility.Internal;
+                        break;
+                    // For anything else (Public, Protected, ProtectedOrInternal), the
+                    // symbol stays at the level we've gotten so far.
+                }
+                symbol = symbol.ContainingSymbol;
+            }
+
+            return visibility;
+        }
+    }
+
+    private enum SymbolVisibility
+    {
+        Public,
+        Internal,
+        Private,
+    }
+}

--- a/src/Riok.Mapperly/MapperGenerator.cs
+++ b/src/Riok.Mapperly/MapperGenerator.cs
@@ -67,7 +67,6 @@ public class MapperGenerator : IIncrementalGenerator
         if (mapperAttributeSymbol == null)
             return MapperResults.Empty;
 
-        var symbolAccessor = new SymbolAccessor(wellKnownTypes);
         var uniqueNameBuilder = new UniqueNameBuilder();
 
         var diagnostics = new List<Diagnostic>();
@@ -80,6 +79,7 @@ public class MapperGenerator : IIncrementalGenerator
             if (mapperModel.GetDeclaredSymbol(mapperSyntax) is not INamedTypeSymbol mapperSymbol)
                 continue;
 
+            var symbolAccessor = new SymbolAccessor(wellKnownTypes, compilation, mapperSymbol);
             if (!symbolAccessor.HasAttribute<MapperAttribute>(mapperSymbol))
                 continue;
 

--- a/src/Riok.Mapperly/Symbols/FieldMember.cs
+++ b/src/Riok.Mapperly/Symbols/FieldMember.cs
@@ -17,8 +17,8 @@ public class FieldMember : IMappableMember
     public ISymbol MemberSymbol => _fieldSymbol;
     public bool IsNullable => _fieldSymbol.NullableAnnotation == NullableAnnotation.Annotated || Type.IsNullable();
     public bool IsIndexer => false;
-    public bool CanGet => !_fieldSymbol.IsReadOnly && _fieldSymbol.IsAccessible();
-    public bool CanSet => _fieldSymbol.IsAccessible();
+    public bool CanGet => !_fieldSymbol.IsReadOnly;
+    public bool CanSet => true;
     public bool IsInitOnly => false;
 
     public bool IsRequired

--- a/src/Riok.Mapperly/Symbols/GenericMappingTypeParameters.cs
+++ b/src/Riok.Mapperly/Symbols/GenericMappingTypeParameters.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Riok.Mapperly.Descriptors;
 using Riok.Mapperly.Helpers;
 
 namespace Riok.Mapperly.Symbols;
@@ -35,9 +36,15 @@ public readonly struct GenericMappingTypeParameters
 
     public bool? TargetNullable { get; }
 
-    public bool CanConsumeTypes(Compilation compilation, ITypeSymbol sourceType, ITypeSymbol targetType)
+    public bool DoesTypesSatisfyTypeParameterConstraints(SymbolAccessor symbolAccessor, ITypeSymbol sourceType, ITypeSymbol targetType)
     {
-        return SourceType?.CanConsumeType(compilation, _sourceNullableAnnotation, sourceType) != false
-            && TargetType?.CanConsumeType(compilation, _targetNullableAnnotation, targetType) != false;
+        return (
+                SourceType == null
+                || symbolAccessor.DoesTypeSatisfyTypeParameterConstraints(SourceType, sourceType, _sourceNullableAnnotation)
+            )
+            && (
+                TargetType == null
+                || symbolAccessor.DoesTypeSatisfyTypeParameterConstraints(TargetType, targetType, _targetNullableAnnotation)
+            );
     }
 }

--- a/src/Riok.Mapperly/Symbols/MappableMember.cs
+++ b/src/Riok.Mapperly/Symbols/MappableMember.cs
@@ -1,14 +1,18 @@
 using Microsoft.CodeAnalysis;
+using Riok.Mapperly.Descriptors;
 
 namespace Riok.Mapperly.Symbols;
 
 internal static class MappableMember
 {
-    public static IMappableMember? Create(ISymbol symbol)
+    public static IMappableMember? Create(SymbolAccessor accessor, ISymbol symbol)
     {
+        if (!accessor.IsAccessible(symbol))
+            return null;
+
         return symbol switch
         {
-            IPropertySymbol property => new PropertyMember(property),
+            IPropertySymbol property => new PropertyMember(property, accessor),
             IFieldSymbol field => new FieldMember(field),
             _ => null,
         };

--- a/src/Riok.Mapperly/Symbols/PropertyMember.cs
+++ b/src/Riok.Mapperly/Symbols/PropertyMember.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Riok.Mapperly.Descriptors;
 using Riok.Mapperly.Helpers;
 
 namespace Riok.Mapperly.Symbols;
@@ -6,10 +7,12 @@ namespace Riok.Mapperly.Symbols;
 internal class PropertyMember : IMappableMember
 {
     private readonly IPropertySymbol _propertySymbol;
+    private readonly SymbolAccessor _symbolAccessor;
 
-    internal PropertyMember(IPropertySymbol propertySymbol)
+    internal PropertyMember(IPropertySymbol propertySymbol, SymbolAccessor symbolAccessor)
     {
         _propertySymbol = propertySymbol;
+        _symbolAccessor = symbolAccessor;
     }
 
     public string Name => _propertySymbol.Name;
@@ -17,8 +20,10 @@ internal class PropertyMember : IMappableMember
     public ISymbol MemberSymbol => _propertySymbol;
     public bool IsNullable => _propertySymbol.NullableAnnotation == NullableAnnotation.Annotated || Type.IsNullable();
     public bool IsIndexer => _propertySymbol.IsIndexer;
-    public bool CanGet => !_propertySymbol.IsWriteOnly && _propertySymbol.GetMethod?.IsAccessible() != false;
-    public bool CanSet => !_propertySymbol.IsReadOnly && _propertySymbol.SetMethod?.IsAccessible() != false;
+    public bool CanGet =>
+        !_propertySymbol.IsWriteOnly && (_propertySymbol.GetMethod == null || _symbolAccessor.IsAccessible(_propertySymbol.GetMethod));
+    public bool CanSet =>
+        !_propertySymbol.IsReadOnly && (_propertySymbol.SetMethod == null || _symbolAccessor.IsAccessible(_propertySymbol.SetMethod));
     public bool IsInitOnly => _propertySymbol.SetMethod?.IsInitOnly == true;
 
     public bool IsRequired

--- a/test/Riok.Mapperly.Tests/Generator/IncrementalGeneratorTest.cs
+++ b/test/Riok.Mapperly.Tests/Generator/IncrementalGeneratorTest.cs
@@ -13,7 +13,7 @@ public class IncrementalGeneratorTest
         var source = TestSourceBuilder.Mapping("string", "string");
 
         var syntaxTree = CSharpSyntaxTree.ParseText(source, CSharpParseOptions.Default);
-        var compilation1 = TestHelper.BuildCompilation(TestHelperOptions.NoDiagnostics.NullableOption, syntaxTree);
+        var compilation1 = TestHelper.BuildCompilation(syntaxTree);
 
         var driver1 = TestHelper.GenerateTracked(compilation1);
 
@@ -49,7 +49,7 @@ public class IncrementalGeneratorTest
         );
 
         var syntaxTree = CSharpSyntaxTree.ParseText(source, CSharpParseOptions.Default);
-        var compilation1 = TestHelper.BuildCompilation(TestHelperOptions.NoDiagnostics.NullableOption, syntaxTree);
+        var compilation1 = TestHelper.BuildCompilation(syntaxTree);
 
         var driver1 = TestHelper.GenerateTracked(compilation1);
 
@@ -65,7 +65,7 @@ public class IncrementalGeneratorTest
     {
         var source = TestSourceBuilder.Mapping("string", "string");
         var syntaxTree = CSharpSyntaxTree.ParseText(source, CSharpParseOptions.Default);
-        var compilation1 = TestHelper.BuildCompilation(TestHelperOptions.NoDiagnostics.NullableOption, syntaxTree);
+        var compilation1 = TestHelper.BuildCompilation(syntaxTree);
 
         var driver1 = TestHelper.GenerateTracked(compilation1);
 
@@ -90,7 +90,7 @@ public class IncrementalGeneratorTest
             "class B { }"
         );
         var syntaxTree = CSharpSyntaxTree.ParseText(source, CSharpParseOptions.Default);
-        var compilation1 = TestHelper.BuildCompilation(TestHelperOptions.NoDiagnostics.NullableOption, syntaxTree);
+        var compilation1 = TestHelper.BuildCompilation(syntaxTree);
 
         var driver1 = TestHelper.GenerateTracked(compilation1);
 

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectVisibilityTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectVisibilityTest.cs
@@ -1,0 +1,193 @@
+using Riok.Mapperly.Diagnostics;
+
+namespace Riok.Mapperly.Tests.Mapping;
+
+public class ObjectVisibilityTest
+{
+    [Fact]
+    public void PrivateToPublicShouldIgnore()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            "class A { private string Value { get; set; } }",
+            "class B { public string Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotFound)
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void PublicToPrivateShouldIgnore()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            "class A { public string Value { get; set; } }",
+            "class B { private string Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotMapped)
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void InternalToInternalShouldMap()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            "class A { internal string Value { get; set; } }",
+            "class B { internal string Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void InternalOtherAssemblyToInternalShouldIgnore()
+    {
+        var aSource = TestSourceBuilder.SyntaxTree("namespace A; public class A { internal string Value { get; set; } }");
+        using var aAssembly = TestHelper.BuildAssembly("A", aSource);
+
+        var source = TestSourceBuilder.Mapping("A.A", "B", "class B { internal string Value { get; set; } }");
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics, new[] { aAssembly })
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotFound)
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void InternalToInternalOtherAssemblyShouldIgnore()
+    {
+        var aSource = TestSourceBuilder.SyntaxTree(
+            """
+            namespace A;
+            public class A { public string PublicValue { get; set; } internal string InternalValue { get; set; } private string PrivateValue { get; set; } }
+            """
+        );
+
+        using var aAssembly = TestHelper.BuildAssembly("A", aSource);
+
+        var source = TestSourceBuilder.Mapping(
+            "A.A",
+            "B",
+            "class B { public string PublicValue { get; set; } internal string InternalValue { get; set; } private string PrivateValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics, new[] { aAssembly })
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotFound)
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.PublicValue = source.PublicValue;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void InternalOtherAssemblyWithGrantedVisibilityToInternalShouldMap()
+    {
+        var aSource = TestSourceBuilder.SyntaxTree(
+            """
+            [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Tests")]
+
+            namespace A;
+            public class A { public string PublicValue { get; set; } internal string InternalValue { get; set; } private string PrivateValue { get; set; } }
+            """
+        );
+
+        using var aAssembly = TestHelper.BuildAssembly("A", aSource);
+
+        var source = TestSourceBuilder.Mapping(
+            "A.A",
+            "B",
+            "class B { public string PublicValue { get; set; } internal string InternalValue { get; set; } private string PrivateValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.NoDiagnostics, new[] { aAssembly })
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.PublicValue = source.PublicValue;
+                target.InternalValue = source.InternalValue;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void InternalClassOtherAssemblyWithGrantedVisibilityToInternalShouldMap()
+    {
+        var aSource = TestSourceBuilder.SyntaxTree(
+            """
+            [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Tests")]
+
+            namespace A;
+            internal class A { public string PublicValue { get; set; } internal string InternalValue { get; set; } private string PrivateValue { get; set; } }
+            """
+        );
+
+        using var aAssembly = TestHelper.BuildAssembly("A", aSource);
+
+        var source = TestSourceBuilder.Mapping(
+            "A.A",
+            "B",
+            "class B { public string PublicValue { get; set; } internal string InternalValue { get; set; } private string PrivateValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.NoDiagnostics, new[] { aAssembly })
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.PublicValue = source.PublicValue;
+                target.InternalValue = source.InternalValue;
+                return target;
+                """
+            );
+    }
+}

--- a/test/Riok.Mapperly.Tests/TestAssembly.cs
+++ b/test/Riok.Mapperly.Tests/TestAssembly.cs
@@ -1,0 +1,20 @@
+using Microsoft.CodeAnalysis;
+
+namespace Riok.Mapperly.Tests;
+
+public class TestAssembly : IDisposable
+{
+    private readonly MemoryStream _data = new();
+
+    internal TestAssembly(Compilation compilation)
+    {
+        compilation.Emit(_data).Success.Should().BeTrue();
+
+        _data.Seek(0, SeekOrigin.Begin);
+        MetadataReference = MetadataReference.CreateFromStream(_data);
+    }
+
+    public MetadataReference MetadataReference { get; }
+
+    public void Dispose() => _data.Dispose();
+}

--- a/test/Riok.Mapperly.Tests/TestHelperOptions.cs
+++ b/test/Riok.Mapperly.Tests/TestHelperOptions.cs
@@ -6,7 +6,8 @@ namespace Riok.Mapperly.Tests;
 public record TestHelperOptions(
     NullableContextOptions NullableOption = NullableContextOptions.Enable,
     LanguageVersion LanguageVersion = LanguageVersion.Default,
-    IReadOnlySet<DiagnosticSeverity>? AllowedDiagnostics = null
+    IReadOnlySet<DiagnosticSeverity>? AllowedDiagnostics = null,
+    string AssemblyName = "Tests"
 )
 {
     public static readonly TestHelperOptions AllowDiagnostics = new();


### PR DESCRIPTION
# Handle internal visibility correctly

## Description

Handles internal visibility including `InternalsVisibleTo` correctly and maps internal members if possible.

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
