### PR TITLE
fix: improve performance for member resolution

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
@@ -34,10 +34,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
 
     private static void BuildInitOnlyMemberMappings(INewInstanceBuilderContext<IMapping> ctx, bool includeAllMembers = false)
     {
-        var memberNameComparer =
-            ctx.BuilderContext.MapperConfiguration.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseSensitive
-                ? StringComparer.Ordinal
-                : StringComparer.OrdinalIgnoreCase;
+        var ignoreCase = ctx.BuilderContext.MapperConfiguration.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseInsensitive;
 
         var initOnlyTargetMembers = includeAllMembers
             ? ctx.TargetMembers.Values.ToArray()
@@ -57,7 +54,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
                     ctx.Mapping.SourceType,
                     MemberPathCandidateBuilder.BuildMemberPathCandidates(targetMember.Name),
                     ctx.IgnoredSourceMemberNames,
-                    memberNameComparer,
+                    ignoreCase,
                     out var sourceMemberPath
                 )
             )
@@ -300,7 +297,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
                 ctx.Mapping.SourceType,
                 MemberPathCandidateBuilder.BuildMemberPathCandidates(parameter.Name),
                 ctx.IgnoredSourceMemberNames,
-                StringComparer.OrdinalIgnoreCase,
+                true,
                 out sourcePath
             );
         }

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewValueTupleMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewValueTupleMappingBodyBuilder.cs
@@ -173,17 +173,14 @@ public static class NewValueTupleMappingBodyBuilder
         out MemberPath? sourcePath
     )
     {
-        var memberNameComparer =
-            ctx.BuilderContext.MapperConfiguration.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseSensitive
-                ? StringComparer.Ordinal
-                : StringComparer.OrdinalIgnoreCase;
+        var ignoreCase = ctx.BuilderContext.MapperConfiguration.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseInsensitive;
 
         if (
             ctx.BuilderContext.SymbolAccessor.TryFindMemberPath(
                 ctx.Mapping.SourceType,
                 MemberPathCandidateBuilder.BuildMemberPathCandidates(field.Name),
                 ctx.IgnoredSourceMemberNames,
-                memberNameComparer,
+                ignoreCase,
                 out sourcePath
             )
         )

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
@@ -22,10 +22,7 @@ public static class ObjectMemberMappingBodyBuilder
 
     public static void BuildMappingBody(IMembersContainerBuilderContext<IMemberAssignmentTypeMapping> ctx)
     {
-        var memberNameComparer =
-            ctx.BuilderContext.MapperConfiguration.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseSensitive
-                ? StringComparer.Ordinal
-                : StringComparer.OrdinalIgnoreCase;
+        var ignoreCase = ctx.BuilderContext.MapperConfiguration.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseInsensitive;
 
         foreach (var targetMember in ctx.TargetMembers.Values)
         {
@@ -47,7 +44,7 @@ public static class ObjectMemberMappingBodyBuilder
                     ctx.Mapping.SourceType,
                     MemberPathCandidateBuilder.BuildMemberPathCandidates(targetMember.Name),
                     ctx.IgnoredSourceMemberNames,
-                    memberNameComparer,
+                    ignoreCase,
                     out var sourceMemberPath
                 )
             )

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/DictionaryMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/DictionaryMappingBuilder.cs
@@ -38,10 +38,6 @@ public static class DictionaryMappingBuilder
                 or CollectionType.IReadOnlyDictionary
         )
         {
-            var sourceHasCount = ctx.SymbolAccessor
-                .GetAllProperties(ctx.Source, CountPropertyName)
-                .Any(x => !x.IsStatic && x is { IsIndexer: false, IsWriteOnly: false, Type.SpecialType: SpecialType.System_Int32 });
-
             var targetDictionarySymbol = ctx.Types.Get(typeof(Dictionary<,>)).Construct(keyMapping.TargetType, valueMapping.TargetType);
             ctx.ObjectFactories.TryFindObjectFactory(ctx.Source, ctx.Target, out var dictionaryObjectFactory);
             return new ForEachSetDictionaryMapping(
@@ -49,7 +45,7 @@ public static class DictionaryMappingBuilder
                 ctx.Target,
                 keyMapping,
                 valueMapping,
-                sourceHasCount,
+                ctx.CollectionInfos.Source.CountIsKnown,
                 targetDictionarySymbol,
                 dictionaryObjectFactory
             );


### PR DESCRIPTION
Use a cache dictionary for the mappable members by name. This increases the performance of mapping classes with lots of members, since the lookup by member name is now constant time instead of linear.