### PR TITLE
fix: nullable arrays use correct element nullability

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
@@ -54,7 +54,12 @@ public static class EnumerableMappingBuilder
             // a single Array.Clone / cast mapping call should be sufficient and fast,
             // use a for loop mapping otherwise.
             if (!elementMapping.IsSynthetic)
-                return new ArrayForMapping(ctx.Source, ctx.Target, elementMapping, elementMapping.TargetType);
+                return new ArrayForMapping(
+                    ctx.Source,
+                    ctx.Types.GetArrayType(elementMapping.TargetType),
+                    elementMapping,
+                    elementMapping.TargetType
+                );
 
             return ctx.MapperConfiguration.UseDeepCloning
                 ? new ArrayCloneMapping(ctx.Source, ctx.Target)

--- a/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ShouldUpgradeNullabilityInDisabledNullableContextInSelectClause#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ShouldUpgradeNullabilityInDisabledNullableContextInSelectClause#Mapper.g.verified.cs
@@ -25,7 +25,7 @@ public partial class Mapper
         return target;
     }
 
-    private global::D[] MapToDArray(global::C[] source)
+    private global::D?[] MapToDArray(global::C[] source)
     {
         var target = new global::D?[source.Length];
         for (var i = 0; i < source.Length; i++)


### PR DESCRIPTION
# fix: Array methods use the correct nullability

## Description
Modified `ArrayForMapping` to use the correct element nullability in the method signature.

This could be fixed in `NullableSymbolExtensions` by making it check for `IEnumerable` types. Doing this would create a dependency on `SymbolAccessor` or `WellKnownTypes` and probably create a small performance hit. If #588 has this problem this approach could be revisited.

Fixes #229 

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Unit tests are added/updated
