### PR TITLE
fix: arrays use correct element nullability

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
@@ -54,7 +54,14 @@ public static class EnumerableMappingBuilder
             // a single Array.Clone / cast mapping call should be sufficient and fast,
             // use a for loop mapping otherwise.
             if (!elementMapping.IsSynthetic)
-                return new ArrayForMapping(ctx.Source, ctx.Target, elementMapping, elementMapping.TargetType);
+            {
+                // upgrade nullability of element type
+                var targetValue =
+                    ctx.CollectionInfos.Target.CollectionType == CollectionType.Array
+                        ? ctx.Types.GetArrayType(elementMapping.TargetType)
+                        : ((INamedTypeSymbol)ctx.Target).ConstructedFrom.Construct(elementMapping.TargetType);
+                return new ArrayForMapping(ctx.Source, targetValue, elementMapping, elementMapping.TargetType);
+            }
 
             return ctx.MapperConfiguration.UseDeepCloning
                 ? new ArrayCloneMapping(ctx.Source, ctx.Target)

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
@@ -467,6 +467,19 @@ public class EnumerableTest
     }
 
     [Fact]
+    public Task ArrayToReadOnlyCollectionShouldUpgradeNullability()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            "class A { public int[] Value { get; set;} }",
+            "class B { public IReadOnlyCollection<string> Value { get; set; } }"
+        );
+
+        return TestHelper.VerifyGenerator(source, TestHelperOptions.DisabledNullable);
+    }
+
+    [Fact]
     public Task ShouldUpgradeNullabilityInDisabledNullableContextInSelectClause()
     {
         var source = TestSourceBuilder.Mapping(

--- a/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ArrayToReadOnlyCollectionShouldUpgradeNullability#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ArrayToReadOnlyCollectionShouldUpgradeNullability#Mapper.g.verified.cs
@@ -10,27 +10,18 @@ public partial class Mapper
         var target = new global::B();
         if (source.Value != null)
         {
-            target.Value = MapToDArray(source.Value);
+            target.Value = MapToIReadOnlyCollection(source.Value);
         }
 
         return target;
     }
 
-    private global::D? MapToD(global::C? source)
+    private global::System.Collections.Generic.IReadOnlyCollection<string?> MapToIReadOnlyCollection(int[] source)
     {
-        if (source == null)
-            return default;
-        var target = new global::D();
-        target.Value = source.Value;
-        return target;
-    }
-
-    private global::D?[] MapToDArray(global::C[] source)
-    {
-        var target = new global::D?[source.Length];
+        var target = new string?[source.Length];
         for (var i = 0; i < source.Length; i++)
         {
-            target[i] = MapToD(source[i]);
+            target[i] = source[i].ToString();
         }
 
         return target;


### PR DESCRIPTION
# fix: Array methods use the correct nullability

## Description
Modified `ArrayForMapping` to use the correct element nullability in the method signature.

This could be fixed in `NullableSymbolExtensions` by making it check for `IEnumerable` types. Doing this would create a dependency on `SymbolAccessor` or `WellKnownTypes` and probably create a small performance hit. If #588 has this problem this approach could be revisited.

Fixes #229 

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Unit tests are added/updated
