### PR TITLE
chore: run sample in ci to ensure it is valid

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,9 +5,19 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - 'global.json'
+      - 'Directory.Build.props'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - 'global.json'
+      - 'Directory.Build.props'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '45 11 * * 6'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - '**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,10 @@ on:
     branches:
       - '**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,22 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  lint:
+  lint-dotnet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3.2.0
+      - run: dotnet tool restore
+      - run: dotnet csharpier --check .
+      # don't run dotnet format for whitespace formatting as this is done by csharpier
+      - run: dotnet format style --verify-no-changes
+      - run: dotnet format analyzers --verify-no-changes
+  superlinter:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -31,6 +45,6 @@ jobs:
           # exclusions:
           # LICENSE: 1:1 copy of the license text
           # sln files: Usually edited by the IDE
-          # AnalyzerReleases.Shipped.md and Analyzer.Unshipped.md: their structure is predefined by it's analyzer
+          # AnalyzerReleases.Shipped.md and Analyzer.Unshipped.md: their structure is predefined by its analyzer
           # _snapshots: Snapshots are generated and should not be linted
           FILTER_REGEX_EXCLUDE: 'LICENSE|.*.sln|src/Riok\.Mapperly/AnalyzerReleases\..*\.md|.*_snapshots.*'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,18 +14,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
+  sample:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3.2.0
-      - run: dotnet tool restore
-      - run: dotnet csharpier --check .
-      # don't run dotnet format for whitespace formatting as this is done by csharpier
-      - run: dotnet format style --verify-no-changes
-      - run: dotnet format analyzers --verify-no-changes
+      - run: dotnet run --project ./samples/Riok.Mapperly.Sample
   test:
-    needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -36,7 +31,6 @@ jobs:
         with:
           fail_ci_if_error: true
   package:
-    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
* Run sample in ci to ensure it is valid
* Run benchmarks only if related files changed
* Cancel in-progress concurrent actions
* Move dotnet lint job to lint workflow to not run it on main
