### PR TITLE
Add AllowMultiple into MapEnumValueAttribute

### DIFF
--- a/src/Riok.Mapperly.Abstractions/MapEnumValueAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapEnumValueAttribute.cs
@@ -3,7 +3,7 @@ namespace Riok.Mapperly.Abstractions;
 /// <summary>
 /// Customizes how enum values are mapped
 /// </summary>
-[AttributeUsage(AttributeTargets.Method)]
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 public sealed class MapEnumValueAttribute : Attribute
 {
     /// <summary>

--- a/test/Riok.Mapperly.IntegrationTests/Dto/TestEnumDtoAdditionalValue.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Dto/TestEnumDtoAdditionalValue.cs
@@ -6,5 +6,6 @@ namespace Riok.Mapperly.IntegrationTests.Dto
         Value20 = 20,
         Value30 = 30,
         Value40 = 40,
+        Value50 = 50,
     }
 }

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/StaticTestMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/StaticTestMapper.cs
@@ -95,10 +95,12 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
 
         [MapEnum(EnumMappingStrategy.ByName)]
         [MapEnumValue(TestEnumDtoAdditionalValue.Value40, TestEnum.Value30)]
+        [MapEnumValue(TestEnumDtoAdditionalValue.Value50, TestEnum.Value30)]
         public static partial TestEnum MapToEnumByNameWithExplicit(TestEnumDtoAdditionalValue v);
 
         [MapEnum(EnumMappingStrategy.ByValue)]
         [MapEnumValue(TestEnumDtoAdditionalValue.Value40, TestEnum.Value30)]
+        [MapEnumValue(TestEnumDtoAdditionalValue.Value50, TestEnum.Value30)]
         public static partial TestEnum MapToEnumByValueWithExplicit(TestEnumDtoAdditionalValue v);
 
         [MapEnum(EnumMappingStrategy.ByName)]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/NET_48/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -527,6 +527,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value20 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value20,
                 global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value30 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
                 global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value40 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
+                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value50 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
                 _ => throw new System.ArgumentOutOfRangeException(nameof(v), v, "The value of enum TestEnumDtoAdditionalValue is not supported"),
             };
         }
@@ -536,6 +537,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             return v switch
             {
                 global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value40 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
+                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value50 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
                 _ => (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)v,
             };
         }

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_4_OR_LOWER/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -527,6 +527,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value20 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value20,
                 global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value30 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
                 global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value40 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
+                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value50 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
                 _ => throw new System.ArgumentOutOfRangeException(nameof(v), v, "The value of enum TestEnumDtoAdditionalValue is not supported"),
             };
         }
@@ -536,6 +537,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             return v switch
             {
                 global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value40 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
+                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value50 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
                 _ => (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)v,
             };
         }

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/Roslyn_4_5/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -536,6 +536,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value20 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value20,
                 global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value30 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
                 global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value40 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
+                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value50 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
                 _ => throw new System.ArgumentOutOfRangeException(nameof(v), v, "The value of enum TestEnumDtoAdditionalValue is not supported"),
             };
         }
@@ -545,6 +546,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             return v switch
             {
                 global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value40 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
+                global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoAdditionalValue.Value50 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
                 _ => (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)v,
             };
         }


### PR DESCRIPTION
# `MapEnumValueAttribute` is missing `AttributeUsageAttribute(AllowMultiple=true)`

When you want to specify multiple `MapEnumValueAttribute` you are not allowed by compiler

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
