### PR TITLE
fix: prevent null initializing readonly members

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
@@ -38,6 +38,10 @@ public class MembersContainerBuilderContext<T> : MembersMappingBuilderContext<T>
         {
             var nullablePath = new MemberPath(nullableTrailPath);
             var type = nullablePath.Member.Type;
+
+            if (!nullablePath.Member.CanSet)
+                continue;
+
             if (!BuilderContext.SymbolAccessor.HasAccessibleParameterlessConstructor(type))
             {
                 BuilderContext.ReportDiagnostic(DiagnosticDescriptors.NoParameterlessConstructorFound, type);

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
@@ -391,6 +391,28 @@ public class ObjectPropertyFlatteningTest
     }
 
     [Fact]
+    public void ManualUnflattenedPropertyReadOnlyNullablePath()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapProperty($\"MyValueId\", \"Value.Id\")] partial B Map(A source);",
+            "class A { public string MyValueId { get; set; } }",
+            "class B { public C? Value { get; } }",
+            "class C { public string Id { get; set; } public string Id2 { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value.Id = source.MyValueId;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public void ManualUnflattenedPropertyDeepNullablePath()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(


### PR DESCRIPTION
# Prevent null initializing readonly members

## Description
- Add check to container builder context for readonly members
- Added test

Fixes #653

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Unit tests are added/updated

