### PR TITLE
feat: add strict mapping

### DIFF
--- a/src/Riok.Mapperly.Abstractions/MapperAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperAttribute.cs
@@ -86,4 +86,10 @@ public class MapperAttribute : Attribute
     /// Defaults to <see cref="IgnoreObsoleteMembersStrategy.None"/>.
     /// </summary>
     public IgnoreObsoleteMembersStrategy IgnoreObsoleteMembersStrategy { get; set; } = IgnoreObsoleteMembersStrategy.None;
+
+    /// <summary>
+    /// Defines the strategy used when emitting warnings for unmapped members.
+    /// By default this is <see cref="RequiredMappingStrategy.Both"/>, emitting warnings for unmapped source and target members.
+    /// </summary>
+    public RequiredMappingStrategy RequiredMappingStrategy { get; set; } = RequiredMappingStrategy.Both;
 }

--- a/src/Riok.Mapperly.Abstractions/MapperRequiredMappingAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperRequiredMappingAttribute.cs
@@ -1,0 +1,22 @@
+﻿namespace Riok.Mapperly.Abstractions;
+
+/// <summary>
+/// Defines the strategy used when emitting warnings for unmapped members.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class MapperRequiredMappingAttribute : Attribute
+{
+    /// <summary>
+    /// Defines the strategy used when emitting warnings for unmapped members.
+    /// </summary>
+    /// <param name="requiredMappingStrategy">The strategy used when emitting warnings for unmapped members.</param>
+    public MapperRequiredMappingAttribute(RequiredMappingStrategy requiredMappingStrategy)
+    {
+        RequiredMappingStrategy = requiredMappingStrategy;
+    }
+
+    /// <summary>
+    /// The strategy used when emitting warnings for unmapped members.
+    /// </summary>
+    public RequiredMappingStrategy RequiredMappingStrategy { get; }
+}

--- a/src/Riok.Mapperly.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Riok.Mapperly.Abstractions/PublicAPI.Shipped.txt
@@ -109,3 +109,13 @@ Riok.Mapperly.Abstractions.UseStaticMapperAttribute
 Riok.Mapperly.Abstractions.UseStaticMapperAttribute.UseStaticMapperAttribute(System.Type! mapperType) -> void
 Riok.Mapperly.Abstractions.UseStaticMapperAttribute<T>
 Riok.Mapperly.Abstractions.UseStaticMapperAttribute<T>.UseStaticMapperAttribute() -> void
+Riok.Mapperly.Abstractions.MapperAttribute.RequiredMappingStrategy.get -> Riok.Mapperly.Abstractions.RequiredMappingStrategy
+Riok.Mapperly.Abstractions.MapperAttribute.RequiredMappingStrategy.set -> void
+Riok.Mapperly.Abstractions.MapperRequiredMappingAttribute
+Riok.Mapperly.Abstractions.MapperRequiredMappingAttribute.MapperRequiredMappingAttribute(Riok.Mapperly.Abstractions.RequiredMappingStrategy requiredMappingStrategy) -> void
+Riok.Mapperly.Abstractions.MapperRequiredMappingAttribute.RequiredMappingStrategy.get -> Riok.Mapperly.Abstractions.RequiredMappingStrategy
+Riok.Mapperly.Abstractions.RequiredMappingStrategy
+Riok.Mapperly.Abstractions.RequiredMappingStrategy.Both = -1 -> Riok.Mapperly.Abstractions.RequiredMappingStrategy
+Riok.Mapperly.Abstractions.RequiredMappingStrategy.None = 0 -> Riok.Mapperly.Abstractions.RequiredMappingStrategy
+Riok.Mapperly.Abstractions.RequiredMappingStrategy.Source = 1 -> Riok.Mapperly.Abstractions.RequiredMappingStrategy
+Riok.Mapperly.Abstractions.RequiredMappingStrategy.Target = 2 -> Riok.Mapperly.Abstractions.RequiredMappingStrategy

--- a/src/Riok.Mapperly.Abstractions/RequiredMappingStrategy.cs
+++ b/src/Riok.Mapperly.Abstractions/RequiredMappingStrategy.cs
@@ -1,0 +1,28 @@
+﻿namespace Riok.Mapperly.Abstractions;
+
+/// <summary>
+/// Defines the strategy used when emitting warnings for unmapped members.
+/// </summary>
+[Flags]
+public enum RequiredMappingStrategy
+{
+    /// <summary>
+    /// Warnings are not emitted for unmapped source or target members.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Warnings are emitted for both unmapped source and target members.
+    /// </summary>
+    Both = ~None,
+
+    /// <summary>
+    /// Warnings are emitted for unmapped source members but not for target members.
+    /// </summary>
+    Source = 1 << 0,
+
+    /// <summary>
+    /// Warnings are emitted for unmapped target members but not for source members.
+    /// </summary>
+    Target = 1 << 1
+}

--- a/src/Riok.Mapperly/Configuration/MapperConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/MapperConfiguration.cs
@@ -92,4 +92,10 @@ public record MapperConfiguration
     /// Defaults to <see cref="IgnoreObsoleteMembersStrategy.None"/>.
     /// </summary>
     public IgnoreObsoleteMembersStrategy? IgnoreObsoleteMembersStrategy { get; init; }
+
+    /// <summary>
+    /// Defines the strategy used when emitting warnings for unmapped members.
+    /// By default this is <see cref="RequiredMappingStrategy.Both"/>, emitting warnings for unmapped source and target members.
+    /// </summary>
+    public RequiredMappingStrategy? RequiredMappingStrategy { get; init; }
 }

--- a/src/Riok.Mapperly/Configuration/MapperConfigurationMerger.cs
+++ b/src/Riok.Mapperly/Configuration/MapperConfigurationMerger.cs
@@ -46,6 +46,11 @@ public static class MapperConfigurationMerger
             ?? defaultMapperConfiguration.IgnoreObsoleteMembersStrategy
             ?? mapper.IgnoreObsoleteMembersStrategy;
 
+        mapper.RequiredMappingStrategy =
+            mapperConfiguration.RequiredMappingStrategy
+            ?? defaultMapperConfiguration.RequiredMappingStrategy
+            ?? mapper.RequiredMappingStrategy;
+
         return mapper;
     }
 }

--- a/src/Riok.Mapperly/Configuration/MapperConfigurationReader.cs
+++ b/src/Riok.Mapperly/Configuration/MapperConfigurationReader.cs
@@ -32,7 +32,8 @@ public class MapperConfigurationReader
                 Array.Empty<string>(),
                 Array.Empty<string>(),
                 Array.Empty<PropertyMappingConfiguration>(),
-                Mapper.IgnoreObsoleteMembersStrategy
+                Mapper.IgnoreObsoleteMembersStrategy,
+                Mapper.RequiredMappingStrategy
             ),
             Array.Empty<DerivedTypeMappingConfiguration>()
         );
@@ -75,8 +76,17 @@ public class MapperConfigurationReader
         var ignoreObsolete = _dataAccessor.Access<MapperIgnoreObsoleteMembersAttribute>(method).FirstOrDefault() is not { } methodIgnore
             ? _defaultConfiguration.Properties.IgnoreObsoleteMembersStrategy
             : methodIgnore.IgnoreObsoleteStrategy;
+        var requiredMapping = _dataAccessor.Access<MapperRequiredMappingAttribute>(method).FirstOrDefault() is not { } methodWarnUnmapped
+            ? _defaultConfiguration.Properties.RequiredMappingStrategy
+            : methodWarnUnmapped.RequiredMappingStrategy;
 
-        return new PropertiesMappingConfiguration(ignoredSourceProperties, ignoredTargetProperties, explicitMappings, ignoreObsolete);
+        return new PropertiesMappingConfiguration(
+            ignoredSourceProperties,
+            ignoredTargetProperties,
+            explicitMappings,
+            ignoreObsolete,
+            requiredMapping
+        );
     }
 
     private EnumMappingConfiguration BuildEnumConfig(MappingConfigurationReference configRef)

--- a/src/Riok.Mapperly/Configuration/PropertiesMappingConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/PropertiesMappingConfiguration.cs
@@ -6,5 +6,6 @@ public record PropertiesMappingConfiguration(
     IReadOnlyCollection<string> IgnoredSources,
     IReadOnlyCollection<string> IgnoredTargets,
     IReadOnlyCollection<PropertyMappingConfiguration> ExplicitMappings,
-    IgnoreObsoleteMembersStrategy IgnoreObsoleteMembersStrategy
+    IgnoreObsoleteMembersStrategy IgnoreObsoleteMembersStrategy,
+    RequiredMappingStrategy RequiredMappingStrategy
 );

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
@@ -166,6 +166,9 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
 
     private void AddUnmatchedSourceMembersDiagnostics()
     {
+        if (!BuilderContext.Configuration.Properties.RequiredMappingStrategy.HasFlag(RequiredMappingStrategy.Source))
+            return;
+
         foreach (var sourceMemberName in _unmappedSourceMemberNames)
         {
             BuilderContext.ReportDiagnostic(

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
@@ -59,12 +59,25 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
                 )
             )
             {
-                ctx.BuilderContext.ReportDiagnostic(
-                    targetMember.IsRequired ? DiagnosticDescriptors.RequiredMemberNotMapped : DiagnosticDescriptors.SourceMemberNotFound,
-                    targetMember.Name,
-                    ctx.Mapping.TargetType,
-                    ctx.Mapping.SourceType
-                );
+                if (targetMember.IsRequired)
+                {
+                    ctx.BuilderContext.ReportDiagnostic(
+                        DiagnosticDescriptors.RequiredMemberNotMapped,
+                        targetMember.Name,
+                        ctx.Mapping.TargetType,
+                        ctx.Mapping.SourceType
+                    );
+                }
+                else if (ctx.BuilderContext.Configuration.Properties.RequiredMappingStrategy.HasFlag(RequiredMappingStrategy.Target))
+                {
+                    ctx.BuilderContext.ReportDiagnostic(
+                        DiagnosticDescriptors.SourceMemberNotFound,
+                        targetMember.Name,
+                        ctx.Mapping.TargetType,
+                        ctx.Mapping.SourceType
+                    );
+                }
+
                 continue;
             }
 
@@ -104,12 +117,16 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
             !ctx.BuilderContext.SymbolAccessor.TryFindMemberPath(ctx.Mapping.SourceType, memberConfig.Source.Path, out var sourceMemberPath)
         )
         {
-            ctx.BuilderContext.ReportDiagnostic(
-                DiagnosticDescriptors.SourceMemberNotFound,
-                targetMember.Name,
-                ctx.Mapping.TargetType,
-                ctx.Mapping.SourceType
-            );
+            if (ctx.BuilderContext.Configuration.Properties.RequiredMappingStrategy.HasFlag(RequiredMappingStrategy.Target))
+            {
+                ctx.BuilderContext.ReportDiagnostic(
+                    DiagnosticDescriptors.SourceMemberNotFound,
+                    targetMember.Name,
+                    ctx.Mapping.TargetType,
+                    ctx.Mapping.SourceType
+                );
+            }
+
             return;
         }
 

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
@@ -54,7 +54,10 @@ public static class ObjectMemberMappingBodyBuilder
                 continue;
             }
 
-            if (targetMember.CanSet)
+            if (
+                targetMember.CanSet
+                && ctx.BuilderContext.Configuration.Properties.RequiredMappingStrategy.HasFlag(RequiredMappingStrategy.Target)
+            )
             {
                 ctx.BuilderContext.ReportDiagnostic(
                     DiagnosticDescriptors.SourceMemberNotFound,

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/StaticTestMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/StaticTestMapper.cs
@@ -30,6 +30,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         [MapperIgnoreSource(nameof(TestObject.IgnoredIntValue))]
         [MapperIgnoreTarget(nameof(TestObjectDto.IgnoredStringValue))]
         [MapperIgnoreObsoleteMembers]
+        [MapperRequiredMapping(RequiredMappingStrategy.Target)]
         public static partial TestObjectDto MapToDtoExt(this TestObject src);
 
         public static TestObjectDto MapToDto(TestObject src)

--- a/test/Riok.Mapperly.IntegrationTests/Models/TestObject.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Models/TestObject.cs
@@ -26,6 +26,8 @@ namespace Riok.Mapperly.IntegrationTests.Models
         public int RequiredValue { get; init; }
 #endif
 
+        public int UnmappedValue => 10;
+
         public string StringValue { get; set; } = string.Empty;
 
         public string RenamedStringValue { get; set; } = string.Empty;

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/DeepCloningMapperTest.RunMappingShouldWork_NET6_0.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/DeepCloningMapperTest.RunMappingShouldWork_NET6_0.verified.txt
@@ -4,6 +4,7 @@
   IntValue: 10,
   IntInitOnlyValue: 3,
   RequiredValue: 4,
+  UnmappedValue: 10,
   StringValue: fooBar,
   RenamedStringValue: fooBar2,
   Flattening: {
@@ -27,6 +28,7 @@
     CtorValue: 5,
     CtorValue2: 100,
     RequiredValue: 4,
+    UnmappedValue: 10,
     StringValue: ,
     RenamedStringValue: ,
     Flattening: {},
@@ -45,6 +47,7 @@
     CtorValue2: 100,
     IntValue: 99,
     RequiredValue: 98,
+    UnmappedValue: 10,
     StringValue: ,
     RenamedStringValue: ,
     Flattening: {},

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.RunMappingShouldWork_NET6_0.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.RunMappingShouldWork_NET6_0.verified.txt
@@ -54,6 +54,7 @@
     CtorValue2: 100,
     IntValue: 99,
     RequiredValue: 98,
+    UnmappedValue: 10,
     StringValue: ,
     RenamedStringValue: ,
     Flattening: {},

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.RunExtensionMappingShouldWork_NET6_0.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.RunExtensionMappingShouldWork_NET6_0.verified.txt
@@ -49,6 +49,7 @@
     CtorValue2: 100,
     IntValue: 99,
     RequiredValue: 98,
+    UnmappedValue: 10,
     StringValue: ,
     RenamedStringValue: ,
     Flattening: {},

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.RunMappingShouldWork_NET6_0.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.RunMappingShouldWork_NET6_0.verified.txt
@@ -54,6 +54,7 @@
     CtorValue2: 100,
     IntValue: 99,
     RequiredValue: 98,
+    UnmappedValue: 10,
     StringValue: ,
     RenamedStringValue: ,
     Flattening: {},

--- a/test/Riok.Mapperly.Tests/Helpers/MapperConfigurationBuilderTest.cs
+++ b/test/Riok.Mapperly.Tests/Helpers/MapperConfigurationBuilderTest.cs
@@ -21,6 +21,7 @@ public class MapperConfigurationBuilderTest
             EnabledConversions = MappingConversionType.Dictionary,
             UseReferenceHandling = false,
             IgnoreObsoleteMembersStrategy = IgnoreObsoleteMembersStrategy.Target,
+            RequiredMappingStrategy = RequiredMappingStrategy.Target,
         };
 
         var mapper = MapperConfigurationMerger.Merge(mapperConfiguration, defaultMapperConfiguration);
@@ -34,6 +35,7 @@ public class MapperConfigurationBuilderTest
         mapper.EnabledConversions.Should().Be(MappingConversionType.Constructor);
         mapper.UseReferenceHandling.Should().BeTrue();
         mapper.IgnoreObsoleteMembersStrategy.Should().Be(IgnoreObsoleteMembersStrategy.Source);
+        mapper.RequiredMappingStrategy.Should().Be(RequiredMappingStrategy.Source);
     }
 
     [Fact]
@@ -51,6 +53,7 @@ public class MapperConfigurationBuilderTest
         mapper.EnabledConversions.Should().Be(MappingConversionType.Constructor);
         mapper.UseReferenceHandling.Should().BeTrue();
         mapper.IgnoreObsoleteMembersStrategy.Should().Be(IgnoreObsoleteMembersStrategy.Source);
+        mapper.RequiredMappingStrategy.Should().Be(RequiredMappingStrategy.Source);
     }
 
     [Fact]
@@ -84,6 +87,7 @@ public class MapperConfigurationBuilderTest
             EnabledConversions = MappingConversionType.Constructor,
             UseReferenceHandling = true,
             IgnoreObsoleteMembersStrategy = IgnoreObsoleteMembersStrategy.Source,
+            RequiredMappingStrategy = RequiredMappingStrategy.Source,
         };
     }
 }

--- a/test/Riok.Mapperly.Tests/Mapping/RequiredMappingTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/RequiredMappingTest.cs
@@ -1,0 +1,242 @@
+﻿using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Diagnostics;
+
+namespace Riok.Mapperly.Tests.Mapping;
+
+[UsesVerify]
+public class RequiredMappingTest
+{
+    [Fact]
+    public void ClassAttributeRequiredMappingSource()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithRequiredMappingStrategy(RequiredMappingStrategy.Source),
+            "class A { public int Value { get; set; } public int UnmappedSource { get; set; } }",
+            "class B { public int Value { get; set; } public int UnmappedTarget { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotMapped)
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ClassAttributeRequiredMappingTarget()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithRequiredMappingStrategy(RequiredMappingStrategy.Target),
+            "class A { public int Value { get; set; } public int UnmappedSource { get; set; } }",
+            "class B { public int Value { get; set; } public int UnmappedTarget { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotFound)
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ClassAttributeRequiredMappingBoth()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithRequiredMappingStrategy(RequiredMappingStrategy.Both),
+            "class A { public int Value { get; set; } public int UnmappedSource { get; set; } }",
+            "class B { public int Value { get; set; } public int UnmappedTarget { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotFound)
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotMapped)
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ClassAttributeRequiredMappingNone()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithRequiredMappingStrategy(RequiredMappingStrategy.None),
+            "class A { public int Value { get; set; } public int UnmappedSource { get; set; } }",
+            "class B { public int Value { get; set; } public int UnmappedTarget { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MethodAttributeRequiredMappingSource()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapperRequiredMappingAttribute(RequiredMappingStrategy.Source)] partial B Map(A source);",
+            "class A { public int Value { get; set; } public int UnmappedSource { get; set; } }",
+            "class B { public int Value { get; set; } public int UnmappedTarget { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotMapped)
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MethodAttributeRequiredMappingTarget()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapperRequiredMappingAttribute(RequiredMappingStrategy.Target)] partial B Map(A source);",
+            "class A { public int Value { get; set; } public int UnmappedSource { get; set; } }",
+            "class B { public int Value { get; set; } public int UnmappedTarget { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotFound)
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MethodAttributeRequiredMappingBoth()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapperRequiredMappingAttribute(RequiredMappingStrategy.Both)] partial B Map(A source);",
+            "class A { public int Value { get; set; } public int UnmappedSource { get; set; } }",
+            "class B { public int Value { get; set; } public int UnmappedTarget { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotFound)
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotMapped)
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MethodAttributeRequiredMappingNone()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapperRequiredMappingAttribute(RequiredMappingStrategy.None)] partial B Map(A source);",
+            "class A { public int Value { get; set; } public int UnmappedSource { get; set; } }",
+            "class B { public int Value { get; set; } public int UnmappedTarget { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MethodAttributeOverridesClass()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapperRequiredMappingAttribute(RequiredMappingStrategy.Target)] partial B Map(A source);",
+            TestSourceBuilderOptions.WithRequiredMappingStrategy(RequiredMappingStrategy.Source),
+            "class A { public int Value { get; set; } public int UnmappedSource { get; set; } }",
+            "class B { public int Value { get; set; } public int UnmappedTarget { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotFound)
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void AllowUnmappedTargetTupleShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "(int MyValue, int Value)",
+            TestSourceBuilderOptions.WithRequiredMappingStrategy(RequiredMappingStrategy.Target),
+            "class A { public int Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowAllDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.NoConstructorFound)
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotFound)
+            .HaveAssertedAllDiagnostics();
+    }
+}

--- a/test/Riok.Mapperly.Tests/TestSourceBuilder.cs
+++ b/test/Riok.Mapperly.Tests/TestSourceBuilder.cs
@@ -90,6 +90,7 @@ public static class TestSourceBuilder
             Attribute(options.EnumMappingStrategy),
             Attribute(options.EnumMappingIgnoreCase),
             Attribute(options.IgnoreObsoleteMembersStrategy),
+            Attribute(options.RequiredMappingStrategy),
         }.WhereNotNull();
 
         return $"[Mapper({string.Join(", ", attrs)})]";

--- a/test/Riok.Mapperly.Tests/TestSourceBuilderOptions.cs
+++ b/test/Riok.Mapperly.Tests/TestSourceBuilderOptions.cs
@@ -14,7 +14,8 @@ public record TestSourceBuilderOptions(
     MappingConversionType? EnabledConversions = null,
     EnumMappingStrategy? EnumMappingStrategy = null,
     bool? EnumMappingIgnoreCase = null,
-    IgnoreObsoleteMembersStrategy? IgnoreObsoleteMembersStrategy = null
+    IgnoreObsoleteMembersStrategy? IgnoreObsoleteMembersStrategy = null,
+    RequiredMappingStrategy? RequiredMappingStrategy = null
 )
 {
     public const string DefaultMapperClassName = "Mapper";
@@ -25,6 +26,9 @@ public record TestSourceBuilderOptions(
 
     public static TestSourceBuilderOptions WithIgnoreObsolete(IgnoreObsoleteMembersStrategy ignoreObsoleteStrategy) =>
         new(IgnoreObsoleteMembersStrategy: ignoreObsoleteStrategy);
+
+    public static TestSourceBuilderOptions WithRequiredMappingStrategy(RequiredMappingStrategy requiredMappingStrategy) =>
+        new(RequiredMappingStrategy: requiredMappingStrategy);
 
     public static TestSourceBuilderOptions WithDisabledMappingConversion(params MappingConversionType[] conversionTypes)
     {


### PR DESCRIPTION
# Add strict mapping support

## Description
Disable the unmapped source/target member warning on a mapper or method level. ie `[MapperAllowUnmapped(AllowUnmapped.Source)]` will not warn about unmapped source members and will still automatically map members.

Currently using `AllowUnmapped` as a placeholder. I haven't done integration tests, documentation, xml docs etc.

Fixes #687 / #677

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
