### PR TITLE
fix: remove unneeded null conditional initializer

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
@@ -27,7 +27,7 @@ public class MembersContainerBuilderContext<T> : MembersMappingBuilderContext<T>
 
     private void AddMemberAssignmentMapping(IMemberAssignmentMappingContainer container, IMemberAssignmentMapping mapping)
     {
-        SetSourceMemberMapped(mapping.SourcePath);
+        SetMembersMapped(mapping);
         AddNullMemberInitializers(container, mapping.TargetPath);
         container.AddMemberMapping(mapping);
     }
@@ -40,6 +40,10 @@ public class MembersContainerBuilderContext<T> : MembersMappingBuilderContext<T>
             var type = nullablePath.Member.Type;
 
             if (!nullablePath.Member.CanSet)
+                continue;
+
+            // if member is initialised with a non null value then skip
+            if (NotNullInitializedTargetMemberNames.Contains(path.Path.First().Name))
                 continue;
 
             if (!BuilderContext.SymbolAccessor.HasAccessibleParameterlessConstructor(type))

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
@@ -1,6 +1,7 @@
 using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.Configuration;
 using Riok.Mapperly.Descriptors.Mappings;
+using Riok.Mapperly.Descriptors.Mappings.MemberMappings;
 using Riok.Mapperly.Diagnostics;
 using Riok.Mapperly.Helpers;
 using Riok.Mapperly.Symbols;
@@ -72,6 +73,8 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
 
     public Dictionary<string, List<PropertyMappingConfiguration>> MemberConfigsByRootTargetName { get; }
 
+    public readonly HashSet<string> NotNullInitializedTargetMemberNames = new();
+
     public void AddDiagnostics()
     {
         AddUnmatchedIgnoredTargetMembersDiagnostics();
@@ -82,7 +85,19 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
         AddMappedAndIgnoredTargetMembersDiagnostics();
     }
 
-    protected void SetSourceMemberMapped(MemberPath sourcePath) => _unmappedSourceMemberNames.Remove(sourcePath.Path.First().Name);
+    protected void SetMembersMapped(IMemberMapping mapping)
+    {
+        _unmappedSourceMemberNames.Remove(mapping.SourcePath.Path.First().Name);
+    }
+
+    protected void SetMembersMapped(IMemberAssignmentMapping assignmentMapping)
+    {
+        _unmappedSourceMemberNames.Remove(assignmentMapping.SourcePath.Path.First().Name);
+        if (!assignmentMapping.TargetType.IsNullable())
+        {
+            NotNullInitializedTargetMemberNames.Add(assignmentMapping.TargetPath.Path.First().Name);
+        }
+    }
 
     private HashSet<string> InitIgnoredUnmatchedProperties(IEnumerable<string> allProperties, IEnumerable<string> mappedProperties)
     {

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewInstanceBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewInstanceBuilderContext.cs
@@ -15,14 +15,14 @@ public class NewInstanceBuilderContext<T> : MembersMappingBuilderContext<T>, INe
 
     public void AddInitMemberMapping(MemberAssignmentMapping mapping)
     {
-        SetSourceMemberMapped(mapping.SourcePath);
+        SetMembersMapped(mapping);
         Mapping.AddInitMemberMapping(mapping);
     }
 
     public void AddConstructorParameterMapping(ConstructorParameterMapping mapping)
     {
         MemberConfigsByRootTargetName.Remove(mapping.Parameter.Name);
-        SetSourceMemberMapped(mapping.DelegateMapping.SourcePath);
+        SetMembersMapped(mapping.DelegateMapping);
         Mapping.AddConstructorParameterMapping(mapping);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewInstanceContainerBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewInstanceContainerBuilderContext.cs
@@ -16,14 +16,14 @@ public class NewInstanceContainerBuilderContext<T> : MembersContainerBuilderCont
 
     public void AddInitMemberMapping(MemberAssignmentMapping mapping)
     {
-        SetSourceMemberMapped(mapping.SourcePath);
+        SetMembersMapped(mapping);
         Mapping.AddInitMemberMapping(mapping);
     }
 
     public void AddConstructorParameterMapping(ConstructorParameterMapping mapping)
     {
         MemberConfigsByRootTargetName.Remove(mapping.Parameter.Name);
-        SetSourceMemberMapped(mapping.DelegateMapping.SourcePath);
+        SetMembersMapped(mapping.DelegateMapping);
         Mapping.AddConstructorParameterMapping(mapping);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewValueTupleConstructorBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewValueTupleConstructorBuilderContext.cs
@@ -16,7 +16,7 @@ public class NewValueTupleConstructorBuilderContext<T> : MembersMappingBuilderCo
     public void AddTupleConstructorParameterMapping(ValueTupleConstructorParameterMapping mapping)
     {
         MemberConfigsByRootTargetName.Remove(mapping.Parameter.Name);
-        SetSourceMemberMapped(mapping.DelegateMapping.SourcePath);
+        SetMembersMapped(mapping.DelegateMapping);
         Mapping.AddConstructorParameterMapping(mapping);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewValueTupleExpressionBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewValueTupleExpressionBuilderContext.cs
@@ -28,7 +28,7 @@ public class NewValueTupleExpressionBuilderContext<T> : MembersContainerBuilderC
             }
         }
 
-        SetSourceMemberMapped(mapping.DelegateMapping.SourcePath);
+        SetMembersMapped(mapping.DelegateMapping);
         Mapping.AddConstructorParameterMapping(mapping);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/MappingCollection.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingCollection.cs
@@ -51,7 +51,7 @@ public class MappingCollection
         return mapping;
     }
 
-    public void EnqueueToBuildBody(IMapping mapping, MappingBuilderContext ctx) =>
+    public void EnqueueToBuildBody(ITypeMapping mapping, MappingBuilderContext ctx) =>
         _mappingsToBuildBody.Enqueue((mapping, ctx), mapping.BodyBuildingPriority);
 
     public void Add(ITypeMapping mapping)

--- a/src/Riok.Mapperly/Descriptors/Mappings/IMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/IMapping.cs
@@ -10,6 +10,4 @@ public interface IMapping
     ITypeSymbol SourceType { get; }
 
     ITypeSymbol TargetType { get; }
-
-    MappingBodyBuildingPriority BodyBuildingPriority { get; }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/ITypeMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ITypeMapping.cs
@@ -15,4 +15,6 @@ public interface ITypeMapping : IMapping
     /// Gets a value indicating whether this mapping produces any code or can be omitted completely (eg. direct assignments or delegate mappings).
     /// </summary>
     bool IsSynthetic { get; }
+
+    MappingBodyBuildingPriority BodyBuildingPriority { get; }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/IMemberAssignmentMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/IMemberAssignmentMapping.cs
@@ -6,7 +6,7 @@ namespace Riok.Mapperly.Descriptors.Mappings.MemberMappings;
 /// <summary>
 /// Represents a member assignment mapping or a container of member assignment mappings.
 /// </summary>
-public interface IMemberAssignmentMapping
+public interface IMemberAssignmentMapping : IMapping
 {
     GetterMemberPath SourcePath { get; }
 

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/IMemberAssignmentMappingContainer.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/IMemberAssignmentMappingContainer.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Symbols;
 
 namespace Riok.Mapperly.Descriptors.Mappings.MemberMappings;
 
@@ -7,6 +8,8 @@ namespace Riok.Mapperly.Descriptors.Mappings.MemberMappings;
 /// </summary>
 public interface IMemberAssignmentMappingContainer
 {
+    IMemberAssignmentMapping? TryGetMemberMapping(MemberPath sourceMemberPath);
+
     bool HasMemberMapping(IMemberAssignmentMapping mapping);
 
     void AddMemberMapping(IMemberAssignmentMapping mapping);

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/IMemberMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/IMemberMapping.cs
@@ -7,7 +7,7 @@ namespace Riok.Mapperly.Descriptors.Mappings.MemberMappings;
 /// Represents a member mapping which accesses a source member and maps it to a certain type.
 /// (eg. <c>MapToC(source.A.B)</c>)
 /// </summary>
-public interface IMemberMapping
+public interface IMemberMapping : IMapping
 {
     GetterMemberPath SourcePath { get; }
 

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberAssignmentMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberAssignmentMapping.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Symbols;
 
@@ -23,6 +24,10 @@ public class MemberAssignmentMapping : IMemberAssignmentMapping
     public GetterMemberPath SourcePath => _mapping.SourcePath;
 
     public MemberPath TargetPath => _targetPath;
+
+    public ITypeSymbol SourceType => _mapping.SourceType;
+
+    public ITypeSymbol TargetType => _mapping.TargetType;
 
     public IEnumerable<StatementSyntax> Build(TypeMappingBuildContext ctx, ExpressionSyntax targetAccess) =>
         ctx.SyntaxFactory.SingleStatement(BuildExpression(ctx, targetAccess));

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberAssignmentMappingContainer.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberAssignmentMappingContainer.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Symbols;
 
 namespace Riok.Mapperly.Descriptors.Mappings.MemberMappings;
 
@@ -41,6 +42,9 @@ public abstract class MemberAssignmentMappingContainer : IMemberAssignmentMappin
             _delegateMappings.Add(mapping);
         }
     }
+
+    public IMemberAssignmentMapping? TryGetMemberMapping(MemberPath sourceMemberPath) =>
+        _delegateMappings.FirstOrDefault(x => x.TargetPath == sourceMemberPath) ?? _parent?.TryGetMemberMapping(sourceMemberPath);
 
     public bool HasMemberMapping(IMemberAssignmentMapping mapping) =>
         _delegateMappings.Contains(mapping) || _parent?.HasMemberMapping(mapping) == true;

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberExistingTargetMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberExistingTargetMapping.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Descriptors.Mappings.ExistingTarget;
 using Riok.Mapperly.Symbols;
@@ -22,6 +23,10 @@ public class MemberExistingTargetMapping : IMemberAssignmentMapping
     public GetterMemberPath SourcePath { get; }
 
     public MemberPath TargetPath => _targetPath;
+
+    public ITypeSymbol SourceType => _delegateMapping.SourceType;
+
+    public ITypeSymbol TargetType => _delegateMapping.TargetType;
 
     public IEnumerable<StatementSyntax> Build(TypeMappingBuildContext ctx, ExpressionSyntax targetAccess)
     {

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberMapping.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Symbols;
 
@@ -10,7 +11,6 @@ namespace Riok.Mapperly.Descriptors.Mappings.MemberMappings;
 public class MemberMapping : IMemberMapping
 {
     private readonly INewInstanceMapping _delegateMapping;
-    private readonly bool _nullConditionalAccess;
     private readonly bool _addValuePropertyOnNullable;
 
     public MemberMapping(
@@ -22,15 +22,21 @@ public class MemberMapping : IMemberMapping
     {
         _delegateMapping = delegateMapping;
         SourcePath = sourcePath;
-        _nullConditionalAccess = nullConditionalAccess;
+        NullConditionalAccess = nullConditionalAccess;
         _addValuePropertyOnNullable = addValuePropertyOnNullable;
     }
 
     public GetterMemberPath SourcePath { get; }
+    public bool NullConditionalAccess { get; }
 
     public ExpressionSyntax Build(TypeMappingBuildContext ctx)
+
+    public ITypeSymbol SourceType => _delegateMapping.SourceType;
+
+    public ITypeSymbol TargetType => _delegateMapping.TargetType;
+
     {
-        ctx = ctx.WithSource(SourcePath.BuildAccess(ctx.Source, _addValuePropertyOnNullable, _nullConditionalAccess));
+        ctx = ctx.WithSource(SourcePath.BuildAccess(ctx.Source, _addValuePropertyOnNullable, NullConditionalAccess));
         return _delegateMapping.Build(ctx);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberMapping.cs
@@ -29,12 +29,11 @@ public class MemberMapping : IMemberMapping
     public GetterMemberPath SourcePath { get; }
     public bool NullConditionalAccess { get; }
 
-    public ExpressionSyntax Build(TypeMappingBuildContext ctx)
-
     public ITypeSymbol SourceType => _delegateMapping.SourceType;
 
     public ITypeSymbol TargetType => _delegateMapping.TargetType;
 
+    public ExpressionSyntax Build(TypeMappingBuildContext ctx)
     {
         ctx = ctx.WithSource(SourcePath.BuildAccess(ctx.Source, _addValuePropertyOnNullable, NullConditionalAccess));
         return _delegateMapping.Build(ctx);

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/NullMemberMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/NullMemberMapping.cs
@@ -36,6 +36,10 @@ public class NullMemberMapping : IMemberMapping
 
     public GetterMemberPath SourcePath { get; }
 
+    public ITypeSymbol SourceType => _delegateMapping.SourceType;
+
+    public ITypeSymbol TargetType => _delegateMapping.TargetType;
+
     public ExpressionSyntax Build(TypeMappingBuildContext ctx)
     {
         // the source type of the delegate mapping is nullable or the source path is not nullable

--- a/src/Riok.Mapperly/Descriptors/Mappings/ObjectMemberMethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ObjectMemberMethodMapping.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Descriptors.Mappings.ExistingTarget;
 using Riok.Mapperly.Descriptors.Mappings.MemberMappings;
+using Riok.Mapperly.Symbols;
 
 namespace Riok.Mapperly.Descriptors.Mappings;
 
@@ -18,6 +19,8 @@ public abstract class ObjectMemberMethodMapping : MethodMapping, IMemberAssignme
     {
         _mapping = new ObjectMemberExistingTargetMapping(sourceType, targetType);
     }
+
+    public IMemberAssignmentMapping? TryGetMemberMapping(MemberPath sourceMemberPath) => _mapping.TryGetMemberMapping(sourceMemberPath);
 
     public bool HasMemberMapping(IMemberAssignmentMapping mapping) => _mapping.HasMemberMapping(mapping);
 

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
@@ -408,6 +408,81 @@ public class ObjectPropertyFlatteningTest
     }
 
     [Fact]
+    public void ManualUnflattenedPropertyNullablePathShouldNotNullInitialize()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapProperty($\"MyValueId\", \"Value.Id\"), MapProperty($\"MyValueId2\", \"Value.Id2\"), MapProperty($\"Value\", \"Value\")] partial B Map(A source);",
+            "class A { public string MyValueId { get; set; } public string MyValueId2 { get; set; } public C Value { get; set; } }",
+            "class B { public C? Value { get; set; } }",
+            "class C { public string Id { get; set; } public string Id2 { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                target.Value.Id = source.MyValueId;
+                target.Value.Id2 = source.MyValueId2;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ManualUnflattenedPropertyNullablePathShouldNullInitialize()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapProperty($\"MyValueId\", \"Value.Id\"), MapProperty($\"MyValueId2\", \"Value.Id2\"), MapProperty($\"Value\", \"Value\")] partial B Map(A source);",
+            "class A { public string MyValueId { get; set; } public string MyValueId2 { get; set; } public C? Value { get; set; } }",
+            "class B { public C? Value { get; set; } }",
+            "class C { public string Id { get; set; } public string Id2 { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value ??= new();
+                target.Value = source.Value;
+                target.Value.Id = source.MyValueId;
+                target.Value.Id2 = source.MyValueId2;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ManualUnflattenedPropertyDeepNullablePathShouldNotNullInitialize()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapProperty($\"MyValueId\", \"My.Value.Id\"), MapProperty($\"MyValueId2\", \"My.Value.Id2\"), MapProperty($\"My\", \"My\"), MapProperty($\"Value\", \"My.Value\")] partial B Map(A source);",
+            "class A { public string MyValueId { get; set; } public string MyValueId2 { get; set; } public C My { get; set; }  public D Value { get; set; } }",
+            "class B { public C? My { get; set; } }",
+            "class C { public D? Value { get; set; } }",
+            "class D { public string Id { get; set; } public string Id2 { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.My = source.My;
+                target.My.Value = source.Value;
+                target.My.Value.Id = source.MyValueId;
+                target.My.Value.Id2 = source.MyValueId2;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public void ManualUnflattenedPropertyDeepNullablePath()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(


### PR DESCRIPTION
## Description
Add check to only insert a null initializer if the root value is uninitialized or initialized by a nullable type.

tbh I feel like mapperly shouldn't insert a null initializer if the root is mapped. Having a nullable path seems like an error and this obscures it.


Partially fixes #640

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
