### PR TITLE
feat: generate diagnostic warning when ignored members are explicitly mapped

### DIFF
--- a/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
@@ -114,4 +114,5 @@ RMG047  | Mapper   | Error    | Cannot map to member path due to modifying a tem
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 RMG048  | Mapper   | Error    | Used mapper members cannot be nullable
-
+RMG049  | Mapper   | Warning  | Source member is ignored and also explicitly mapped
+RMG050  | Mapper   | Warning  | Target member is ignored and also explicitly mapped

--- a/src/Riok.Mapperly/AnalyzerReleases.Unshipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Unshipped.md
@@ -1,2 +1,8 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+RMG049 | Mapper | Warning | DiagnosticDescriptors
+RMG050 | Mapper | Warning | DiagnosticDescriptors

--- a/src/Riok.Mapperly/AnalyzerReleases.Unshipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Unshipped.md
@@ -1,8 +1,2 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-RMG049 | Mapper | Warning | DiagnosticDescriptors
-RMG050 | Mapper | Warning | DiagnosticDescriptors

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
@@ -15,8 +15,8 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
     where T : IMapping
 {
     private readonly HashSet<string> _unmappedSourceMemberNames;
-    private readonly IReadOnlyCollection<string> _mappedAndIgnoredTargetMemberNames;
-    private readonly IReadOnlyCollection<string> _mappedAndIgnoredSourceMemberNames;
+    private readonly HashSet<string> _mappedAndIgnoredTargetMemberNames;
+    private readonly HashSet<string> _mappedAndIgnoredSourceMemberNames;
     private readonly IReadOnlyCollection<string> _ignoredUnmatchedTargetMemberNames;
     private readonly IReadOnlyCollection<string> _ignoredUnmatchedSourceMemberNames;
 
@@ -46,14 +46,14 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
 
         MemberConfigsByRootTargetName = GetMemberConfigurations();
 
-        var mappedSourceMemberNames = MemberConfigsByRootTargetName.Values
-            .SelectMany(v => v.Select(s => s.Source.Path.First()))
-            .Distinct()
-            .ToList();
-
         // source and target properties may have been ignored and mapped explicitly
-        _mappedAndIgnoredSourceMemberNames = IgnoredSourceMemberNames.Intersect(mappedSourceMemberNames).ToList();
-        _mappedAndIgnoredTargetMemberNames = ignoredTargetMemberNames.Intersect(MemberConfigsByRootTargetName.Keys).ToList();
+        _mappedAndIgnoredSourceMemberNames = MemberConfigsByRootTargetName.Values
+            .SelectMany(v => v.Select(s => s.Source.Path.First()))
+            .ToHashSet();
+        _mappedAndIgnoredSourceMemberNames.IntersectWith(IgnoredSourceMemberNames);
+
+        _mappedAndIgnoredTargetMemberNames = new HashSet<string>(ignoredTargetMemberNames);
+        _mappedAndIgnoredTargetMemberNames.IntersectWith(MemberConfigsByRootTargetName.Keys);
 
         // remove explicitly mapped ignored targets from ignoredTargetMemberNames
         // then remove all ignored targets from TargetMembers, leaving unignored and explicitly mapped ignored members

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
@@ -15,6 +15,8 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
     where T : IMapping
 {
     private readonly HashSet<string> _unmappedSourceMemberNames;
+    private readonly IReadOnlyCollection<string> _mappedAndIgnoredTargetMemberNames;
+    private readonly IReadOnlyCollection<string> _mappedAndIgnoredSourceMemberNames;
     private readonly IReadOnlyCollection<string> _ignoredUnmatchedTargetMemberNames;
     private readonly IReadOnlyCollection<string> _ignoredUnmatchedSourceMemberNames;
 
@@ -44,9 +46,19 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
 
         MemberConfigsByRootTargetName = GetMemberConfigurations();
 
+        var mappedSourceMemberNames = MemberConfigsByRootTargetName.Values
+            .SelectMany(v => v.Select(s => s.Source.Path.First()))
+            .Distinct()
+            .ToList();
+
+        // source and target properties may have been ignored and mapped explicitly
+        _mappedAndIgnoredSourceMemberNames = IgnoredSourceMemberNames.Intersect(mappedSourceMemberNames).ToList();
+        _mappedAndIgnoredTargetMemberNames = ignoredTargetMemberNames.Intersect(MemberConfigsByRootTargetName.Keys).ToList();
+
         // remove explicitly mapped ignored targets from ignoredTargetMemberNames
         // then remove all ignored targets from TargetMembers, leaving unignored and explicitly mapped ignored members
-        ignoredTargetMemberNames.ExceptWith(MemberConfigsByRootTargetName.Keys);
+        ignoredTargetMemberNames.ExceptWith(_mappedAndIgnoredTargetMemberNames);
+
         TargetMembers.RemoveRange(ignoredTargetMemberNames);
     }
 
@@ -66,6 +78,8 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
         AddUnmatchedIgnoredSourceMembersDiagnostics();
         AddUnmatchedTargetMembersDiagnostics();
         AddUnmatchedSourceMembersDiagnostics();
+        AddMappedAndIgnoredSourceMembersDiagnostics();
+        AddMappedAndIgnoredTargetMembersDiagnostics();
     }
 
     protected void SetSourceMemberMapped(MemberPath sourcePath) => _unmappedSourceMemberNames.Remove(sourcePath.Path.First().Name);
@@ -159,6 +173,30 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
                 sourceMemberName,
                 Mapping.SourceType,
                 Mapping.TargetType
+            );
+        }
+    }
+
+    private void AddMappedAndIgnoredTargetMembersDiagnostics()
+    {
+        foreach (var targetMemberName in _mappedAndIgnoredTargetMemberNames)
+        {
+            BuilderContext.ReportDiagnostic(
+                DiagnosticDescriptors.IgnoredTargetMemberExplicitlyMapped,
+                targetMemberName,
+                Mapping.TargetType
+            );
+        }
+    }
+
+    private void AddMappedAndIgnoredSourceMembersDiagnostics()
+    {
+        foreach (var sourceMemberName in _mappedAndIgnoredSourceMemberNames)
+        {
+            BuilderContext.ReportDiagnostic(
+                DiagnosticDescriptors.IgnoredSourceMemberExplicitlyMapped,
+                sourceMemberName,
+                Mapping.SourceType
             );
         }
     }

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -428,4 +428,22 @@ public static class DiagnosticDescriptors
         DiagnosticSeverity.Error,
         true
     );
+
+    public static readonly DiagnosticDescriptor IgnoredSourceMemberExplicitlyMapped = new DiagnosticDescriptor(
+        "RMG049",
+        "Source member is ignored and also explicitly mapped",
+        "The source member {0} on {1} is ignored, but is also mapped by the " + nameof(MapPropertyAttribute),
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Warning,
+        true
+    );
+
+    public static readonly DiagnosticDescriptor IgnoredTargetMemberExplicitlyMapped = new DiagnosticDescriptor(
+        "RMG050",
+        "Target member is ignored and also explicitly mapped",
+        "The target member {0} on {1} is ignored, but is also mapped by the " + nameof(MapPropertyAttribute),
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Warning,
+        true
+    );
 }

--- a/test/Riok.Mapperly.Tests/Mapping/IgnoreObsoleteTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/IgnoreObsoleteTest.cs
@@ -1,4 +1,4 @@
-﻿using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.Diagnostics;
 
 namespace Riok.Mapperly.Tests.Mapping;
@@ -245,7 +245,7 @@ public class IgnoreObsoleteTest
         );
 
         TestHelper
-            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
             .HaveSingleMethodBody(
                 """
@@ -254,7 +254,16 @@ public class IgnoreObsoleteTest
                 target.Ignored = source.Ignored;
                 return target;
                 """
-            );
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.IgnoredSourceMemberExplicitlyMapped,
+                "The source member Ignored on A is ignored, but is also mapped by the MapPropertyAttribute"
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.IgnoredTargetMemberExplicitlyMapped,
+                "The target member Ignored on B is ignored, but is also mapped by the MapPropertyAttribute"
+            )
+            .HaveAssertedAllDiagnostics();
     }
 
     [Fact]
@@ -271,7 +280,7 @@ public class IgnoreObsoleteTest
         );
 
         TestHelper
-            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
             .HaveSingleMethodBody(
                 """
@@ -280,7 +289,12 @@ public class IgnoreObsoleteTest
                 target.Ignored = source.Ignored;
                 return target;
                 """
-            );
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.IgnoredSourceMemberExplicitlyMapped,
+                "The source member Ignored on A is ignored, but is also mapped by the MapPropertyAttribute"
+            )
+            .HaveAssertedAllDiagnostics();
     }
 
     [Fact]
@@ -297,7 +311,7 @@ public class IgnoreObsoleteTest
         );
 
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
             .HaveSingleMethodBody(
                 """
@@ -306,7 +320,12 @@ public class IgnoreObsoleteTest
                 target.Ignored = source.Ignored;
                 return target;
                 """
-            );
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.IgnoredTargetMemberExplicitlyMapped,
+                "The target member Ignored on B is ignored, but is also mapped by the MapPropertyAttribute"
+            )
+            .HaveAssertedAllDiagnostics();
     }
 
     [Fact]
@@ -331,7 +350,7 @@ public class IgnoreObsoleteTest
         );
 
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
             .HaveSingleMethodBody(
                 """
@@ -342,7 +361,12 @@ public class IgnoreObsoleteTest
                 target.Value = source.Value;
                 return target;
                 """
-            );
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.IgnoredTargetMemberExplicitlyMapped,
+                "The target member Ignored on B is ignored, but is also mapped by the MapPropertyAttribute"
+            )
+            .HaveAssertedAllDiagnostics();
     }
 
     [Fact]
@@ -367,7 +391,7 @@ public class IgnoreObsoleteTest
         );
 
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
             .HaveSingleMethodBody(
                 """
@@ -378,6 +402,11 @@ public class IgnoreObsoleteTest
                 target.Value = source.Value;
                 return target;
                 """
-            );
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.IgnoredTargetMemberExplicitlyMapped,
+                "The target member Ignored on B is ignored, but is also mapped by the MapPropertyAttribute"
+            )
+            .HaveAssertedAllDiagnostics();
     }
 }

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyInitPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyInitPropertyTest.cs
@@ -328,7 +328,7 @@ public class ObjectPropertyInitPropertyTest
         );
 
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
             .HaveSingleMethodBody(
                 """
@@ -339,7 +339,12 @@ public class ObjectPropertyInitPropertyTest
                 target.IntValue = source.IntValue;
                 return target;
                 """
-            );
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.IgnoredTargetMemberExplicitlyMapped,
+                "The target member StringValue on B is ignored, but is also mapped by the MapPropertyAttribute"
+            )
+            .HaveAssertedAllDiagnostics();
     }
 
     [Fact]
@@ -358,7 +363,7 @@ public class ObjectPropertyInitPropertyTest
         );
 
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
             .HaveSingleMethodBody(
                 """
@@ -369,7 +374,12 @@ public class ObjectPropertyInitPropertyTest
                 target.IntValue = source.IntValue;
                 return target;
                 """
-            );
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.IgnoredTargetMemberExplicitlyMapped,
+                "The target member StringValue on B is ignored, but is also mapped by the MapPropertyAttribute"
+            )
+            .HaveAssertedAllDiagnostics();
     }
 
     [Fact]


### PR DESCRIPTION
# Add a diagnostic if an explicitly ignored member is mapped explicitly

## Description

Ignored members could also be explicitly mapped, but this may not be intended. This change adds warning level diagnostic messages when either a source or a target member is in that situation, but should not alter the behaviour of the library.

Fixes #512 (using the approach specified in its description)

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
