### PR TITLE
fix: generate correct nullability for external array elements

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Enumerables/CollectionInfoBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/CollectionInfoBuilder.cs
@@ -110,6 +110,11 @@ public static class CollectionInfoBuilder
 
     private static ITypeSymbol? GetEnumeratedType(WellKnownTypes types, ITypeSymbol type)
     {
+        // if type is array return element type
+        // otherwise using the IEnumerable element type can erase the null annotation for external types
+        if (type.IsArrayType())
+            return ((IArrayTypeSymbol)type).ElementType;
+
         if (type.ImplementsGeneric(types.Get(typeof(IEnumerable<>)), out var enumerableIntf))
             return enumerableIntf.TypeArguments[0];
 


### PR DESCRIPTION
# Generate correct nullability for external array elements

## Description
Using `ImplementsGeneric` on external types will erase the nullable annotation of an array element type. This is used in  `CollectionInfosBuilder.GetEnumeratedType` where the resulting enumerated type is used by `EnumerableMappingBuilder` to map the element types of two collections.

This caused a rare issue where an array collection would be treated as if it had a nullable element type.

Fixes #690

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
