### PR TITLE
feat: C#12 primary constructors support

### DIFF
--- a/test/Riok.Mapperly.Tests/Mapping/CtorTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/CtorTest.cs
@@ -20,6 +20,13 @@ public class CtorTest
     }
 
     [Fact]
+    public void PrimaryCtorCustomClass()
+    {
+        var source = TestSourceBuilder.Mapping("string", "A", "class A(string x) {}");
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return new global::A(source);");
+    }
+
+    [Fact]
     public void CtorMappingDisabledShouldDiagnostic()
     {
         var source = TestSourceBuilder.Mapping(

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyConstructorResolverTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyConstructorResolverTest.cs
@@ -485,6 +485,27 @@ public class ObjectPropertyConstructorResolverTest
     }
 
     [Fact]
+    public void CanResolveToClassPrimaryConstructor()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            "class A(string? id, bool value) { public string? Id => id; public bool Value => value; }",
+            "class B(string? id, bool value) {}"
+        );
+
+        var result = TestHelper.GenerateMapper(source);
+        result
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B(source.Id, source.Value);
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public void RecordToRecordNullableToNullableEnum()
     {
         var source = TestSourceBuilder.CSharp(


### PR DESCRIPTION
# Support C#12 primary constructors

## Description

Adds support for C#12 primary constructors.
Depends on https://github.com/riok/mapperly/pull/718. Probably await .NET 8.0 RC1.

Fixes #684 

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
