### PR TITLE
fix: fix spacing for casts and enum parse mappings

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Mappings/Enums/EnumFromStringSwitchMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/Enums/EnumFromStringSwitchMapping.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Emit.Syntax;
 using Riok.Mapperly.Helpers;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Riok.Mapperly.Emit.Syntax.SyntaxFactoryHelper;
@@ -55,7 +56,7 @@ public class EnumFromStringSwitchMapping : MethodMapping
     {
         // { } s
         var pattern = RecursivePattern()
-            .WithPropertyPatternClause(PropertyPatternClause())
+            .WithPropertyPatternClause(PropertyPatternClause().AddTrailingSpace())
             .WithDesignation(SingleVariableDesignation(Identifier(ignoreCaseSwitchDesignatedVariableName)));
 
         // source.Value1

--- a/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/ForEachSetDictionaryExistingTargetMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/ForEachSetDictionaryExistingTargetMapping.cs
@@ -48,7 +48,7 @@ public class ForEachSetDictionaryExistingTargetMapping : ExistingTargetMapping
             var castedVariable = ctx.NameBuilder.New(ExplicitCastVariableName);
             target = IdentifierName(castedVariable);
 
-            yield return LocalDeclarationStatement(DeclareVariable(castedVariable, cast));
+            yield return ctx.SyntaxFactory.DeclareLocalVariable(castedVariable, cast);
         }
 
         if (_ensureCapacity != null)

--- a/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Condition.cs
+++ b/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Condition.cs
@@ -30,7 +30,7 @@ public partial struct SyntaxFactoryHelper
         ElseClauseSyntax? elseClause = null;
         if (elseStatements != null)
         {
-            elseClause = ElseClause(Block(elseStatements)).AddLeadingLineFeed(Indentation).AddTrailingLineFeed(Indentation);
+            elseClause = ElseClause(Block(elseStatements)).AddLeadingLineFeed(Indentation);
         }
 
         return IfStatement(

--- a/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Null.cs
+++ b/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Null.cs
@@ -51,7 +51,7 @@ public partial struct SyntaxFactoryHelper
     {
         StatementSyntax ifExpression = returnOrThrowExpression switch
         {
-            ThrowExpressionSyntax throwSyntax => ThrowStatement(throwSyntax.Expression),
+            ThrowExpressionSyntax throwSyntax => AddIndentation().ThrowStatement(throwSyntax.Expression),
             _ => AddIndentation().Return(returnOrThrowExpression),
         };
 

--- a/test/Riok.Mapperly.Tests/GeneratedMethod.cs
+++ b/test/Riok.Mapperly.Tests/GeneratedMethod.cs
@@ -1,12 +1,9 @@
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Riok.Mapperly.Tests;
 
 public class GeneratedMethod
 {
-    private const string MethodIndentation = "    ";
-
     public GeneratedMethod(MethodDeclarationSyntax declarationSyntax)
     {
         Name = declarationSyntax.Identifier.ToString();
@@ -27,17 +24,19 @@ public class GeneratedMethod
     /// <returns>The cleaned body.</returns>
     private static string ExtractBody(MethodDeclarationSyntax declarationSyntax)
     {
-        var body =
-            declarationSyntax.Body
-                ?.NormalizeWhitespace()
-                .ToFullString()
-                .Trim(' ', '\r', '\n')
-                .Trim('{', '}')
-                .Trim(' ', '\r', '\n')
-                .ReplaceLineEndings() ?? string.Empty;
-        var lines = body.Split(Environment.NewLine);
-        return lines.Length == 0
-            ? string.Empty
-            : string.Join(Environment.NewLine, lines.Select(l => l.StartsWith(MethodIndentation) ? l[MethodIndentation.Length..] : l));
+        if (declarationSyntax.Body == null)
+            return string.Empty;
+
+        var body = declarationSyntax.Body
+            .ToFullString()
+            .Trim(' ', '\r', '\n')
+            .TrimStart('{')
+            .TrimEnd('}')
+            .Trim('\r', '\n')
+            .ReplaceLineEndings();
+        var lines = body.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        var indentionCount = lines[0].TakeWhile(x => x == ' ').Count();
+        var indention = lines[0][..indentionCount];
+        return string.Join(Environment.NewLine, lines.Select(l => l.StartsWith(indention) ? l[indentionCount..] : l)).Trim(' ', '\r', '\n');
     }
 }

--- a/test/Riok.Mapperly.Tests/Mapping/DictionaryTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/DictionaryTest.cs
@@ -31,7 +31,6 @@ public class DictionaryTest
                 {
                     target[item.Key] = item.Value;
                 }
-
                 return target;
                 """
             );
@@ -51,7 +50,6 @@ public class DictionaryTest
                 {
                     target[item.Key] = (int)item.Value;
                 }
-
                 return target;
                 """
             );
@@ -71,7 +69,6 @@ public class DictionaryTest
                 {
                     target[item.Key] = item.Value == null ? throw new System.ArgumentNullException(nameof(item.Value)) : item.Value.Value;
                 }
-
                 return target;
                 """
             );
@@ -98,7 +95,6 @@ public class DictionaryTest
                 {
                     target[item.Key] = item.Value == null ? default : item.Value.Value;
                 }
-
                 return target;
                 """
             );
@@ -118,7 +114,6 @@ public class DictionaryTest
                 {
                     target[item.Key] = (int)item.Value;
                 }
-
                 return target;
                 """
             );
@@ -138,7 +133,6 @@ public class DictionaryTest
                 {
                     target[item.Key] = item.Value;
                 }
-
                 return target;
                 """
             );
@@ -158,7 +152,6 @@ public class DictionaryTest
                 {
                     target[item.Key] = item.Value;
                 }
-
                 return target;
                 """
             );
@@ -178,7 +171,6 @@ public class DictionaryTest
                 {
                     target[item.Key] = item.Value;
                 }
-
                 return target;
                 """
             );
@@ -199,7 +191,6 @@ public class DictionaryTest
                 {
                     target[item.Key] = item.Value;
                 }
-
                 return target;
                 """
             );
@@ -223,7 +214,6 @@ public class DictionaryTest
                 {
                     target[item.Key] = item.Value;
                 }
-
                 return target;
                 """
             );
@@ -285,7 +275,6 @@ public class DictionaryTest
                 {
                     target.EnsureCapacity(sourceCount + target.Count);
                 }
-
                 foreach (var item in source)
                 {
                     target[item.Key] = item.Value;
@@ -323,7 +312,6 @@ public class DictionaryTest
                 {
                     targetDict[item.Key] = item.Value;
                 }
-
                 return target;
                 """
             );
@@ -357,7 +345,6 @@ public class DictionaryTest
                 {
                     target[item.Key] = item.Value;
                 }
-
                 return target;
                 """
             );
@@ -394,7 +381,6 @@ public class DictionaryTest
                 {
                     targetDict[item.Key] = item.Value;
                 }
-
                 return target;
                 """
             );
@@ -428,7 +414,6 @@ public class DictionaryTest
                 {
                     targetDict[item.Key] = item.Value;
                 }
-
                 return target;
                 """
             );
@@ -461,7 +446,6 @@ public class DictionaryTest
                 {
                     target[item.Key] = item.Value;
                 }
-
                 return target;
                 """
             );

--- a/test/Riok.Mapperly.Tests/Mapping/EnumFallbackValueTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumFallbackValueTest.cs
@@ -100,9 +100,9 @@ public class EnumFallbackValueTest
                 """
                 return source switch
                 {
-                    { } s when s.Equals(nameof(global::E1.A), System.StringComparison.OrdinalIgnoreCase) => global::E1.A,
-                    { } s when s.Equals(nameof(global::E1.B), System.StringComparison.OrdinalIgnoreCase) => global::E1.B,
-                    { } s when s.Equals(nameof(global::E1.C), System.StringComparison.OrdinalIgnoreCase) => global::E1.C,
+                    {} s when s.Equals(nameof(global::E1.A), System.StringComparison.OrdinalIgnoreCase) => global::E1.A,
+                    {} s when s.Equals(nameof(global::E1.B), System.StringComparison.OrdinalIgnoreCase) => global::E1.B,
+                    {} s when s.Equals(nameof(global::E1.C), System.StringComparison.OrdinalIgnoreCase) => global::E1.C,
                     _ => global::E1.Unknown,
                 };
                 """

--- a/test/Riok.Mapperly.Tests/Mapping/EnumTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumTest.cs
@@ -216,14 +216,14 @@ enum E2 {A = 100, B, C}
         TestHelper
             .GenerateMapper(source)
             .Should()
-            .HaveSingleMethodBody("return source == null ? default(global::E2? ) : (global::E2)source.Value;");
+            .HaveSingleMethodBody("return source == null ? default(global::E2?) : (global::E2)source.Value;");
     }
 
     [Fact]
     public void EnumToOtherNullableEnumShouldCast()
     {
         var source = TestSourceBuilder.Mapping("E1", "E2?", "enum E1 {A, B, C}", "enum E2 {A, B, C}");
-        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::E2? )(global::E2)source;");
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::E2?)(global::E2)source;");
     }
 
     [Fact]
@@ -260,9 +260,9 @@ enum E2 {A = 100, B, C}
                 """
                 return source switch
                 {
-                    { } s when s.Equals(nameof(global::E1.A), System.StringComparison.OrdinalIgnoreCase) => global::E1.A,
-                    { } s when s.Equals(nameof(global::E1.B), System.StringComparison.OrdinalIgnoreCase) => global::E1.B,
-                    { } s when s.Equals(nameof(global::E1.C), System.StringComparison.OrdinalIgnoreCase) => global::E1.C,
+                    {} s when s.Equals(nameof(global::E1.A), System.StringComparison.OrdinalIgnoreCase) => global::E1.A,
+                    {} s when s.Equals(nameof(global::E1.B), System.StringComparison.OrdinalIgnoreCase) => global::E1.B,
+                    {} s when s.Equals(nameof(global::E1.C), System.StringComparison.OrdinalIgnoreCase) => global::E1.C,
                     _ => System.Enum.Parse<global::E1>(source, true),
                 };
                 """

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableDeepCloningTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableDeepCloningTest.cs
@@ -43,7 +43,6 @@ public class EnumerableDeepCloningTest
                 {
                     target[i] = source[i] == null ? throw new System.NullReferenceException($"Sequence {nameof(source)}, contained a null value at index {i}.") : source[i].Value;
                 }
-
                 return target;
                 """
             );
@@ -58,12 +57,11 @@ public class EnumerableDeepCloningTest
             .Should()
             .HaveSingleMethodBody(
                 """
-                var target = new int? [source.Length];
+                var target = new int?[source.Length];
                 for (var i = 0; i < source.Length; i++)
                 {
-                    target[i] = (int? )source[i];
+                    target[i] = (int?)source[i];
                 }
-
                 return target;
                 """
             );
@@ -88,7 +86,6 @@ public class EnumerableDeepCloningTest
                 {
                     target[i] = MapToB(source[i]);
                 }
-
                 return target;
                 """
             );
@@ -105,7 +102,7 @@ public class EnumerableDeepCloningTest
     public void ArrayToArrayOfNullableStringDeepCloning()
     {
         var source = TestSourceBuilder.Mapping("string[]", "string?[]", TestSourceBuilderOptions.WithDeepCloning);
-        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (string? [])source.Clone();");
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (string?[])source.Clone();");
     }
 
     [Fact]
@@ -134,7 +131,6 @@ public class EnumerableDeepCloningTest
                 {
                     target[i] = MapToA(source[i]);
                 }
-
                 return target;
                 """
             );
@@ -168,7 +164,6 @@ public class EnumerableDeepCloningTest
                     target[i] = MapToA(item);
                     i++;
                 }
-
                 return target;
                 """
             );
@@ -199,7 +194,6 @@ public class EnumerableDeepCloningTest
                 {
                     target[i1] = MapToA(i[i1]);
                 }
-
                 return target;
                 """
             );
@@ -223,7 +217,6 @@ public class EnumerableDeepCloningTest
                 {
                     target1[i] = MapToA(target[i]);
                 }
-
                 return target1;
                 """
             );

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableExistingTargetTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableExistingTargetTest.cs
@@ -32,7 +32,6 @@ public class EnumerableExistingTargetTest
                 {
                     target.EnsureCapacity(sourceCount + target.Count);
                 }
-
                 foreach (var item in source)
                 {
                     target.Add(item);

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableSetTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableSetTest.cs
@@ -77,7 +77,6 @@ public class EnumerableSetTest
                 {
                     target.Values.Add(item);
                 }
-
                 return target;
                 """
             );
@@ -102,12 +101,10 @@ public class EnumerableSetTest
                 {
                     target.Values.EnsureCapacity(sourceCount + target.Values.Count);
                 }
-
                 foreach (var item in source.Values)
                 {
                     target.Values.Add(item);
                 }
-
                 return target;
                 """
             );

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
@@ -37,7 +37,6 @@ public class EnumerableTest
                 {
                     target[i] = source[i] == null ? throw new System.NullReferenceException($"Sequence {nameof(source)}, contained a null value at index {i}.") : source[i].Value;
                 }
-
                 return target;
                 """
             );
@@ -52,12 +51,11 @@ public class EnumerableTest
             .Should()
             .HaveSingleMethodBody(
                 """
-                var target = new int? [source.Length];
+                var target = new int?[source.Length];
                 for (var i = 0; i < source.Length; i++)
                 {
-                    target[i] = (int? )source[i];
+                    target[i] = (int?)source[i];
                 }
-
                 return target;
                 """
             );
@@ -84,7 +82,6 @@ public class EnumerableTest
                 {
                     target[i] = source[i] == null ? throw new System.NullReferenceException($"Sequence {nameof(source)}, contained a null value at index {i}.") : source[i]!;
                 }
-
                 return target;
                 """
             );
@@ -94,7 +91,7 @@ public class EnumerableTest
     public void ArrayCustomClassNonNullableToArrayCustomClassNullable()
     {
         var source = TestSourceBuilder.Mapping("B[]", "B?[]", "class B { public int Value {get; set; }}");
-        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::B? [])source;");
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::B?[])source;");
     }
 
     [Fact]
@@ -108,7 +105,7 @@ public class EnumerableTest
     public void ArrayToArrayOfNullableString()
     {
         var source = TestSourceBuilder.Mapping("string[]", "string?[]");
-        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (string? [])source;");
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (string?[])source;");
     }
 
     [Fact]
@@ -139,7 +136,6 @@ public class EnumerableTest
                 {
                     target[i] = (int)source[i];
                 }
-
                 return target;
                 """
             );
@@ -201,7 +197,6 @@ public class EnumerableTest
                 {
                     target.Add((long)item);
                 }
-
                 return target;
                 """
             );
@@ -223,7 +218,6 @@ public class EnumerableTest
                     target[i] = item.ToString();
                     i++;
                 }
-
                 return target;
                 """
             );
@@ -276,7 +270,6 @@ public class EnumerableTest
                     target[i] = (long)item;
                     i++;
                 }
-
                 return target;
                 """
             );
@@ -332,7 +325,6 @@ public class EnumerableTest
                 {
                     target.Add((int)item);
                 }
-
                 return target;
                 """
             );
@@ -378,7 +370,6 @@ public class EnumerableTest
                 {
                     target.Value.Add(item);
                 }
-
                 return target;
                 """
             );
@@ -403,12 +394,10 @@ public class EnumerableTest
                 {
                     target.Value.EnsureCapacity(sourceCount + target.Value.Count);
                 }
-
                 foreach (var item in source.Value)
                 {
                     target.Value.Push((long)item);
                 }
-
                 return target;
                 """
             );
@@ -433,12 +422,10 @@ public class EnumerableTest
                 {
                     target.Value.EnsureCapacity(sourceCount + target.Value.Count);
                 }
-
                 foreach (var item in source.Value)
                 {
                     target.Value.Enqueue((long)item);
                 }
-
                 return target;
                 """
             );
@@ -545,7 +532,6 @@ public class EnumerableTest
                 {
                     target.Add((int)item);
                 }
-
                 return target;
                 """
             );

--- a/test/Riok.Mapperly.Tests/Mapping/MemoryTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/MemoryTest.cs
@@ -299,14 +299,13 @@ public class MemoryTest
             .Should()
             .HaveMapMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -343,15 +342,14 @@ public class MemoryTest
             .Should()
             .HaveMapMethodBody(
                 """
-            var target = new global::B();
-            target.Value.EnsureCapacity(source.Value.Span.Length + target.Value.Count);
-            foreach (var item in source.Value.Span)
-            {
-                target.Value.Add(item);
-            }
-
-            return target;
-            """
+                var target = new global::B();
+                target.Value.EnsureCapacity(source.Value.Span.Length + target.Value.Count);
+                foreach (var item in source.Value.Span)
+                {
+                    target.Value.Add(item);
+                }
+                return target;
+                """
             );
     }
 

--- a/test/Riok.Mapperly.Tests/Mapping/NullableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/NullableTest.cs
@@ -43,8 +43,7 @@ public class NullableTest
     public void NullablePrimitiveToOtherNullablePrimitiveShouldWork()
     {
         var source = TestSourceBuilder.Mapping("decimal?", "int?");
-
-        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody(@"return source == null ? default(int? ) : (int)source.Value;");
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return source == null ? default(int?) : (int)source.Value;");
     }
 
     [Fact]
@@ -140,8 +139,7 @@ public class NullableTest
     public void NonNullableToNullableValueType()
     {
         var source = TestSourceBuilder.Mapping("DateTime", "DateTime?");
-
-        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::System.DateTime? )source;");
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::System.DateTime?)source;");
     }
 
     [Fact]

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyConstructorResolverTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyConstructorResolverTest.cs
@@ -510,7 +510,7 @@ public class ObjectPropertyConstructorResolverTest
             .Should()
             .HaveMapMethodBody(
                 """
-                var target = new global::TargetRecord(record.EnumValue != null ? MapToTargetEnum(record.EnumValue.Value) : default(global::TargetEnum? ));
+                var target = new global::TargetRecord(record.EnumValue != null ? MapToTargetEnum(record.EnumValue.Value) : default(global::TargetEnum?));
                 return target;
                 """
             );
@@ -542,7 +542,7 @@ public class ObjectPropertyConstructorResolverTest
             .Should()
             .HaveMapMethodBody(
                 """
-                var target = new global::TargetRecord(record.StructValue != null ? MapToTargetStruct(record.StructValue.Value) : default(global::TargetStruct? ));
+                var target = new global::TargetRecord(record.StructValue != null ? MapToTargetStruct(record.StructValue.Value) : default(global::TargetStruct?));
                 return target;
                 """
             );

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
@@ -138,7 +138,6 @@ public class ObjectPropertyFlatteningTest
                 {
                     target.ValueId = source.Value.Id;
                 }
-
                 return target;
                 """
             );
@@ -166,7 +165,6 @@ public class ObjectPropertyFlatteningTest
                     target.ValueId = source.Value.Id.ToString();
                     target.ValueName = source.Value.Name;
                 }
-
                 return target;
                 """
             );
@@ -192,7 +190,6 @@ public class ObjectPropertyFlatteningTest
                 {
                     target.IdValue = source.Id.Value.Value;
                 }
-
                 return target;
                 """
             );
@@ -218,7 +215,6 @@ public class ObjectPropertyFlatteningTest
                 {
                     target.PropInteger = source.Prop.Value.Integer.ToString();
                 }
-
                 return target;
                 """
             );
@@ -268,7 +264,6 @@ public class ObjectPropertyFlatteningTest
                 {
                     target.ValueId = source.Value.Id.ToString();
                 }
-
                 target.ValueName = source.Value?.Name;
                 return target;
                 """
@@ -521,10 +516,8 @@ public class ObjectPropertyFlatteningTest
                         target.Value2.Value2.Id2 = source.Value1.Value1.Id1;
                         target.Value2.Value2.Id20 = source.Value1.Value1.Id10;
                     }
-
                     target.Value2.Id200 = source.Value1.Id100;
                 }
-
                 return target;
                 """
             );

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
@@ -45,7 +45,6 @@ public class ObjectPropertyNullableTest
                 {
                     target.Value = source.Value.Value;
                 }
-
                 return target;
                 """
             );
@@ -75,7 +74,6 @@ public class ObjectPropertyNullableTest
                 {
                     target.Value = source.Value.Value;
                 }
-
                 return target;
                 """
             );
@@ -110,7 +108,6 @@ public class ObjectPropertyNullableTest
                 {
                     throw new System.ArgumentNullException(nameof(source.Value.Value));
                 }
-
                 return target;
                 """
             );
@@ -136,7 +133,6 @@ public class ObjectPropertyNullableTest
                 {
                     target.Value = source.Value;
                 }
-
                 return target;
                 """
             );
@@ -164,7 +160,6 @@ public class ObjectPropertyNullableTest
                 {
                     target.Value = MapToD(source.Value);
                 }
-
                 return target;
                 """
             );
@@ -216,7 +211,6 @@ public class ObjectPropertyNullableTest
                 {
                     target.Value = source.Value;
                 }
-
                 return target;
                 """
             );
@@ -251,7 +245,6 @@ public class ObjectPropertyNullableTest
                 {
                     throw new System.ArgumentNullException(nameof(source.Value));
                 }
-
                 return target;
                 """
             );
@@ -326,7 +319,6 @@ public class ObjectPropertyNullableTest
                 {
                     target.Value = MapToD(source.Value);
                 }
-
                 return target;
                 """
             );
@@ -358,7 +350,6 @@ public class ObjectPropertyNullableTest
                 {
                     target.Value = MapToD(source.Value);
                 }
-
                 return target;
                 """
             );
@@ -395,7 +386,6 @@ public class ObjectPropertyNullableTest
                 {
                     throw new System.ArgumentNullException(nameof(source.Value));
                 }
-
                 return target;
                 """
             );
@@ -423,7 +413,6 @@ public class ObjectPropertyNullableTest
                 {
                     target.Value = MapToD(source.Value);
                 }
-
                 return target;
                 """
             );
@@ -451,7 +440,6 @@ public class ObjectPropertyNullableTest
                 {
                     target.Value = MapToD(source.Value);
                 }
-
                 return target;
                 """
             );
@@ -487,7 +475,6 @@ public class ObjectPropertyNullableTest
                 {
                     throw new System.ArgumentNullException(nameof(source.Value));
                 }
-
                 return target;
                 """
             );
@@ -586,7 +573,6 @@ public class ObjectPropertyNullableTest
                 {
                     target.Test = Map(y.Test.Value);
                 }
-
                 return target;
                 """
             );

--- a/test/Riok.Mapperly.Tests/Mapping/ParseTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ParseTest.cs
@@ -23,7 +23,7 @@ public class ParseTest
     public void ParseableBuiltNullableInClass()
     {
         var source = TestSourceBuilder.Mapping("string?", "int?");
-        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return source == null ? default(int? ) : int.Parse(source);");
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return source == null ? default(int?) : int.Parse(source);");
     }
 
     [Fact]

--- a/test/Riok.Mapperly.Tests/Mapping/SpanTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/SpanTest.cs
@@ -43,14 +43,13 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -63,14 +62,13 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -83,14 +81,13 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -103,14 +100,13 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -151,14 +147,13 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -171,14 +166,13 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -191,14 +185,13 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -211,14 +204,13 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -260,15 +252,14 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new global::System.Collections.Generic.List<int>();
-            target.EnsureCapacity(source.Length + target.Count);
-            foreach (var item in source)
-            {
-                target.Add(item);
-            }
-
-            return target;
-            """
+                var target = new global::System.Collections.Generic.List<int>();
+                target.EnsureCapacity(source.Length + target.Count);
+                foreach (var item in source)
+                {
+                    target.Add(item);
+                }
+                return target;
+                """
             );
     }
 
@@ -281,15 +272,14 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new global::System.Collections.Generic.Stack<int>();
-            target.EnsureCapacity(source.Length + target.Count);
-            foreach (var item in source)
-            {
-                target.Push(item);
-            }
-
-            return target;
-            """
+                var target = new global::System.Collections.Generic.Stack<int>();
+                target.EnsureCapacity(source.Length + target.Count);
+                foreach (var item in source)
+                {
+                    target.Push(item);
+                }
+                return target;
+                """
             );
     }
 
@@ -302,15 +292,14 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new global::System.Collections.Generic.Queue<int>();
-            target.EnsureCapacity(source.Length + target.Count);
-            foreach (var item in source)
-            {
-                target.Enqueue(item);
-            }
-
-            return target;
-            """
+                var target = new global::System.Collections.Generic.Queue<int>();
+                target.EnsureCapacity(source.Length + target.Count);
+                foreach (var item in source)
+                {
+                    target.Enqueue(item);
+                }
+                return target;
+                """
             );
     }
 
@@ -382,14 +371,13 @@ public class SpanTest
             .Should()
             .HaveMapMethodBody(
                 """
-            var target = new global::A[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = MapToA(source[i]);
-            }
-
-            return target;
-            """
+                var target = new global::A[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = MapToA(source[i]);
+                }
+                return target;
+                """
             );
     }
 
@@ -402,14 +390,13 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -422,14 +409,13 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -442,14 +428,13 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -462,14 +447,13 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -494,14 +478,13 @@ public class SpanTest
             .Should()
             .HaveMapMethodBody(
                 """
-            var target = new global::A[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = MapToA(source[i]);
-            }
-
-            return target;
-            """
+                var target = new global::A[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = MapToA(source[i]);
+                }
+                return target;
+                """
             );
     }
 
@@ -514,14 +497,13 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -546,14 +528,13 @@ public class SpanTest
             .Should()
             .HaveMapMethodBody(
                 """
-            var target = new global::A[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = MapToA(source[i]);
-            }
-
-            return target;
-            """
+                var target = new global::A[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = MapToA(source[i]);
+                }
+                return target;
+                """
             );
     }
 
@@ -566,14 +547,13 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new long[source.Length];
-            for (var i = 0; i < source.Length; i++)
-            {
-                target[i] = (long)source[i];
-            }
-
-            return target;
-            """
+                var target = new long[source.Length];
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target[i] = (long)source[i];
+                }
+                return target;
+                """
             );
     }
 
@@ -643,15 +623,14 @@ public class SpanTest
             .Should()
             .HaveSingleMethodBody(
                 """
-            var target = new global::B();
-            target.Value.EnsureCapacity(source.Value.Length + target.Value.Count);
-            foreach (var item in source.Value)
-            {
-                target.Value.Add(item);
-            }
-
-            return target;
-            """
+                var target = new global::B();
+                target.Value.EnsureCapacity(source.Value.Length + target.Value.Count);
+                foreach (var item in source.Value)
+                {
+                    target.Value.Add(item);
+                }
+                return target;
+                """
             );
     }
 

--- a/test/Riok.Mapperly.Tests/Mapping/ValueTupleTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ValueTupleTest.cs
@@ -574,7 +574,7 @@ public class ValueTupleTest
             .HaveSingleMethodBody(
                 """
                 #nullable disable
-                return System.Linq.Queryable.Select(source, x => new global::System.ValueTuple<int, string>(x.A, x.B));
+                        return System.Linq.Queryable.Select(source, x => new global::System.ValueTuple<int, string>(x.A, x.B));
                 #nullable enable
                 """
             );
@@ -594,7 +594,7 @@ public class ValueTupleTest
             .HaveSingleMethodBody(
                 """
                 #nullable disable
-                return System.Linq.Queryable.Select(source, x => new global::System.ValueTuple<int, string>(x.A, x.B));
+                        return System.Linq.Queryable.Select(source, x => new global::System.ValueTuple<int, string>(x.A, x.B));
                 #nullable enable
                 """
             );


### PR DESCRIPTION
Remove `NoramlizeWhitespace` in unit tests to ensure correct formatting in unit tests.

Rel. https://github.com/riok/mapperly/pull/746#discussion_r1322993775
Additional changes in formatting to https://github.com/riok/mapperly/pull/706:
* Enum parsing mapping: space in braces is removed: `{} s when s.Equals(nameof(source.Value1), StringComparison.OrdinalIgnoreCase) => ...` instead of `{ } s when s.Equals(nameof(source.Value1), StringComparison.OrdinalIgnoreCase) => ...`.
 
Changes to fix formatting introduced in #706:
* Enum parsing mapping: Adds a space between `{}` and `s`
* Dictionary mapping if only explicit interface implementation: indent variable declaration correctly
* Indent throw argument null exception throws correctly
