### PR TITLE
chore: add diffplex to render test snapshot diffs

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -28,6 +28,7 @@
     </PackageReference>
     <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" Version="2.1.0"/>
     <PackageReference Include="Verify.XUnit" Version="21.1.1" />
+    <PackageReference Include="Verify.DiffPlex" Version="2.2.1" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Riok.Mapperly.Tests/ModuleInitializer.cs
+++ b/test/Riok.Mapperly.Tests/ModuleInitializer.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using VerifyTests.DiffPlex;
 
 namespace Riok.Mapperly.Tests;
 
@@ -13,5 +14,6 @@ public static class ModuleInitializer
         DerivePathInfo((file, _, type, method) => new(Path.Join(Path.GetDirectoryName(file), "_snapshots"), type.Name, method.Name));
 
         VerifySourceGenerators.Initialize();
+        VerifyDiffPlex.Initialize(OutputType.Compact);
     }
 }


### PR DESCRIPTION
Use DiffPlex for snapshot diffs to get compacter, better readable results.