### PR TITLE
feat: use `IEnumerable` `Dictionary` constructor

### DIFF
--- a/test/Riok.Mapperly.Tests/Mapping/DictionaryTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/DictionaryTest.cs
@@ -24,16 +24,7 @@ public class DictionaryTest
         TestHelper
             .GenerateMapper(source)
             .Should()
-            .HaveSingleMethodBody(
-                """
-                var target = new global::System.Collections.Generic.Dictionary<string, long>(source.Count);
-                foreach (var item in source)
-                {
-                    target[item.Key] = item.Value;
-                }
-                return target;
-                """
-            );
+            .HaveSingleMethodBody("return new global::System.Collections.Generic.Dictionary<string, long>(source);");
     }
 
     [Fact]
@@ -126,16 +117,7 @@ public class DictionaryTest
         TestHelper
             .GenerateMapper(source)
             .Should()
-            .HaveSingleMethodBody(
-                """
-                var target = new global::System.Collections.Generic.Dictionary<string, int>();
-                foreach (var item in source)
-                {
-                    target[item.Key] = item.Value;
-                }
-                return target;
-                """
-            );
+            .HaveSingleMethodBody("return new global::System.Collections.Generic.Dictionary<string, int>(source);");
     }
 
     [Fact]
@@ -145,16 +127,7 @@ public class DictionaryTest
         TestHelper
             .GenerateMapper(source)
             .Should()
-            .HaveSingleMethodBody(
-                """
-                var target = new global::System.Collections.Generic.Dictionary<string, int>(source.Count);
-                foreach (var item in source)
-                {
-                    target[item.Key] = item.Value;
-                }
-                return target;
-                """
-            );
+            .HaveSingleMethodBody("return new global::System.Collections.Generic.Dictionary<string, int>(source);");
     }
 
     [Fact]
@@ -164,16 +137,7 @@ public class DictionaryTest
         TestHelper
             .GenerateMapper(source)
             .Should()
-            .HaveSingleMethodBody(
-                """
-                var target = new global::System.Collections.Generic.Dictionary<string, int>(source.Count);
-                foreach (var item in source)
-                {
-                    target[item.Key] = item.Value;
-                }
-                return target;
-                """
-            );
+            .HaveSingleMethodBody("return new global::System.Collections.Generic.Dictionary<string, int>(source);");
     }
 
     [Fact]


### PR DESCRIPTION
# Use `IEnumerable` `Dictionary` constructor

## Description
Use the `IEnumerable` constructor if key and value mapping is synthetic. 

```C#
// New
return new global::System.Collections.Generic.Enumerable.Dictionary<string, long>(source);

// Old
var target = new global::System.Collections.Generic.Dictionary<string, long>(source.Count);
foreach (var item in source)
{
    target[item.Key] = item.Value;
}
return target;
```

See #689 

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
