### PR TITLE
fix: check for arguments with restricted keywords

### DIFF
--- a/src/Riok.Mapperly/Symbols/MethodParameter.cs
+++ b/src/Riok.Mapperly/Symbols/MethodParameter.cs
@@ -6,8 +6,14 @@ namespace Riok.Mapperly.Symbols;
 
 public readonly record struct MethodParameter(int Ordinal, string Name, ITypeSymbol Type)
 {
+    private static readonly SymbolDisplayFormat _parameterNameFormat =
+        new(
+            parameterOptions: SymbolDisplayParameterOptions.IncludeName,
+            miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers
+        );
+
     public MethodParameter(IParameterSymbol symbol)
-        : this(symbol.Ordinal, symbol.Name, symbol.Type.UpgradeNullable()) { }
+        : this(symbol.Ordinal, symbol.ToDisplayString(_parameterNameFormat), symbol.Type.UpgradeNullable()) { }
 
     public MethodArgument WithArgument(ExpressionSyntax? argument) =>
         new(this, argument ?? throw new ArgumentNullException(nameof(argument)));

--- a/test/Riok.Mapperly.Tests/Mapping/MapperTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/MapperTest.cs
@@ -147,4 +147,11 @@ public class MapperTest
 
         return TestHelper.VerifyGenerator(source);
     }
+
+    [Fact]
+    public void RestrictedKeywordParametersShouldBeEscaped()
+    {
+        var source = TestSourceBuilder.MapperWithBody("public partial string Map(int @object);");
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return @object.ToString();");
+    }
 }


### PR DESCRIPTION
## Description
- Added `RestrictedNameHelper` which is called by the `MethodParameter` constructor
   - `ToSafeName` checks the input for every restricted keyword. This should be really fast in .Net 8 but I doubt it will make any impact in prior versions
- Added tests

Fixes #402

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] Unit tests are added/updated
