### PR TITLE
feat: add diagnostic for nested ignores

### DIFF
--- a/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
@@ -116,3 +116,12 @@ Rule ID | Category | Severity | Notes
 RMG048  | Mapper   | Error    | Used mapper members cannot be nullable
 RMG049  | Mapper   | Warning  | Source member is ignored and also explicitly mapped
 RMG050  | Mapper   | Warning  | Target member is ignored and also explicitly mapped
+
+## Release 3.3
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+RMG051  | Mapper   | Warning  | Invalid ignore source member found, nested ignores are not supported
+RMG052  | Mapper   | Warning  | Invalid ignore target member found, nested ignores are not supported

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
@@ -140,6 +140,11 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
     {
         foreach (var notFoundIgnoredMember in _ignoredUnmatchedTargetMemberNames)
         {
+            if (notFoundIgnoredMember.Contains(StringMemberPath.PropertyAccessSeparator, StringComparison.Ordinal))
+            {
+                BuilderContext.ReportDiagnostic(DiagnosticDescriptors.NestedIgnoredTargetMember, notFoundIgnoredMember, Mapping.TargetType);
+                continue;
+            }
             BuilderContext.ReportDiagnostic(DiagnosticDescriptors.IgnoredTargetMemberNotFound, notFoundIgnoredMember, Mapping.TargetType);
         }
     }
@@ -148,6 +153,11 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
     {
         foreach (var notFoundIgnoredMember in _ignoredUnmatchedSourceMemberNames)
         {
+            if (notFoundIgnoredMember.Contains(StringMemberPath.PropertyAccessSeparator, StringComparison.Ordinal))
+            {
+                BuilderContext.ReportDiagnostic(DiagnosticDescriptors.NestedIgnoredSourceMember, notFoundIgnoredMember, Mapping.TargetType);
+                continue;
+            }
             BuilderContext.ReportDiagnostic(DiagnosticDescriptors.IgnoredSourceMemberNotFound, notFoundIgnoredMember, Mapping.SourceType);
         }
     }

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -446,4 +446,22 @@ public static class DiagnosticDescriptors
         DiagnosticSeverity.Warning,
         true
     );
+
+    public static readonly DiagnosticDescriptor NestedIgnoredSourceMember = new DiagnosticDescriptor(
+        "RMG051",
+        "Invalid ignore source member found, nested ignores are not supported",
+        "Invalid ignore source member {0} found for type {1}, nested ignores are not supported",
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Warning,
+        true
+    );
+
+    public static readonly DiagnosticDescriptor NestedIgnoredTargetMember = new DiagnosticDescriptor(
+        "RMG052",
+        "Invalid ignore target member found, nested ignores are not supported",
+        "Invalid ignore target member {0} found for type {1}, nested ignores are not supported",
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Warning,
+        true
+    );
 }

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyIgnoreTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyIgnoreTest.cs
@@ -145,4 +145,28 @@ public class ObjectPropertyIgnoreTest
                 """
             );
     }
+
+    [Fact]
+    public void WithNestedIgnoredSourceAndTargetPropertyShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapperIgnoreSource(\"StringValue.Value\")] [MapperIgnoreTarget(\"StringValue.Value\")] partial B Map(A source);",
+            "class A { public string StringValue { get; set; } }",
+            "class B { public string StringValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.NestedIgnoredSourceMember)
+            .HaveDiagnostic(DiagnosticDescriptors.NestedIgnoredTargetMember)
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.StringValue = source.StringValue;
+                return target;
+                """
+            );
+    }
 }


### PR DESCRIPTION
# Add diagnostic for nested ignores

## Description
Mapperly does not support nested ignores. To prevent confusion, I've added 2 diagnostics that will warn the user when one is found.

- This could be one single diagnostic for both source and target ignores, not sure if a slightly more specific warning is worth it.
- If a nested ignore is found the usual `IgnoredTargetMemberNotFound`/`IgnoredSourceMemberNotFound` diagnostics will not be emitted.

Fixes #815, #814

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Unit tests are added/updated
