### PR TITLE
Use pattern matching for null guards

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberMapping.cs
@@ -30,7 +30,12 @@ public class MemberMapping : IMemberMapping
 
     public ExpressionSyntax Build(TypeMappingBuildContext ctx)
     {
-        ctx = ctx.WithSource(SourcePath.BuildAccess(ctx.Source, _addValuePropertyOnNullable, _nullConditionalAccess));
+        if (!GetterMemberPath.TryBuild(ctx, SourcePath, out var sourcePath))
+        {
+            sourcePath = SourcePath;
+        }
+
+        ctx = ctx.WithSource(sourcePath.BuildAccess(ctx.Source, _addValuePropertyOnNullable, _nullConditionalAccess));
         return _delegateMapping.Build(ctx);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberNullDelegateAssignmentMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberNullDelegateAssignmentMapping.cs
@@ -34,11 +34,16 @@ public class MemberNullDelegateAssignmentMapping : MemberAssignmentMappingContai
         //   target.Value = Map(sourceValue);
         // else
         //   throw ...
-        var sourceNullConditionalAccess = _nullConditionalSourcePath.BuildAccess(ctx.Source, false, _needsNullSafeAccess, true);
-        var nameofSourceAccess = _nullConditionalSourcePath.BuildAccess(ctx.Source, false, false, true);
+        if (!GetterMemberPath.TryBuild(ctx, _nullConditionalSourcePath, out var nullConditionalSourcePath))
+        {
+            nullConditionalSourcePath = _nullConditionalSourcePath;
+        }
+
+        var sourceNullConditionalAccess = nullConditionalSourcePath.BuildAccess(ctx.Source, false, _needsNullSafeAccess, true);
+        var nameofSourceAccess = nullConditionalSourcePath.BuildAccess(ctx.Source, false, false, true);
 
         var (conditionCtx, nullGuardedValue) = ctx.AddIndentation()
-            .WithTrimSourcePath(_nullConditionalSourcePath.Path)
+            .WithTrimSourcePath(nullConditionalSourcePath.Path)
             .WithNewSource(sourceNullConditionalAccess.ToFullString().Replace(".", ""));
 
         var condition = IsNotNullWithPattern(sourceNullConditionalAccess, nullGuardedValue);

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberNullDelegateAssignmentMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberNullDelegateAssignmentMapping.cs
@@ -44,7 +44,14 @@ public class MemberNullDelegateAssignmentMapping : MemberAssignmentMappingContai
 
         var (conditionCtx, nullGuardedValue) = ctx.AddIndentation()
             .WithTrimSourcePath(nullConditionalSourcePath.Path)
-            .WithNewSource(sourceNullConditionalAccess.ToFullString().Replace(".", ""));
+            .WithNewSource(
+                sourceNullConditionalAccess
+                    .ToFullString()
+                    .Replace(".", string.Empty, StringComparison.InvariantCultureIgnoreCase)
+                    .Replace("?", string.Empty, StringComparison.InvariantCultureIgnoreCase)
+                    .Replace("(", string.Empty, StringComparison.InvariantCultureIgnoreCase)
+                    .Replace(")", string.Empty, StringComparison.InvariantCultureIgnoreCase)
+            );
 
         var condition = IsNotNullWithPattern(sourceNullConditionalAccess, nullGuardedValue);
 

--- a/src/Riok.Mapperly/Descriptors/Mappings/TypeMappingBuildContext.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/TypeMappingBuildContext.cs
@@ -82,6 +82,6 @@ public readonly record struct TypeMappingBuildContext
     public TypeMappingBuildContext WithTrimSourcePath(IReadOnlyList<IMappableMember> trimSourcePath) =>
         this with
         {
-            TrimSourcePath = trimSourcePath
+            TrimSourcePath = TrimSourcePath.Concat(trimSourcePath).ToArray()
         };
 }

--- a/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Condition.cs
+++ b/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Condition.cs
@@ -75,6 +75,13 @@ public partial struct SyntaxFactoryHelper
     public static BinaryExpressionSyntax IsNotNull(ExpressionSyntax expression) =>
         BinaryExpression(SyntaxKind.NotEqualsExpression, expression, NullLiteral());
 
+    public static ExpressionSyntax IsNotNullWithPattern(ExpressionSyntax expression, string nullGuardedValue) =>
+        IsPatternExpression(
+                expression.WithTrailingTrivia(TriviaList(Space)),
+                PropertyPatternClause().WithDesignation(SingleVariableDesignation(Identifier(nullGuardedValue)))
+            )
+            .WithIsKeyword(Token(TriviaList(), SyntaxKind.IsKeyword, TriviaList(Space)));
+
     public static BinaryExpressionSyntax Is(ExpressionSyntax left, ExpressionSyntax right) =>
         BinaryExpression(SyntaxKind.IsExpression, left, right);
 
@@ -97,4 +104,13 @@ public partial struct SyntaxFactoryHelper
 
     private static ExpressionSyntax BinaryExpression(SyntaxKind kind, IEnumerable<ExpressionSyntax?> values) =>
         values.WhereNotNull().Aggregate((left, right) => BinaryExpression(kind, left, right));
+
+    private static RecursivePatternSyntax PropertyPatternClause() =>
+        RecursivePattern()
+            .WithPropertyPatternClause(
+                SyntaxFactory
+                    .PropertyPatternClause()
+                    .WithOpenBraceToken(Token(TriviaList(), SyntaxKind.OpenBraceToken, TriviaList(Space)))
+                    .WithCloseBraceToken(Token(TriviaList(), SyntaxKind.CloseBraceToken, TriviaList(Space)))
+            );
 }

--- a/src/Riok.Mapperly/Symbols/GetterMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/GetterMemberPath.cs
@@ -1,7 +1,9 @@
+﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Descriptors;
+using Riok.Mapperly.Descriptors.Mappings;
 using Riok.Mapperly.Emit.Syntax;
 using Riok.Mapperly.Helpers;
 
@@ -16,6 +18,26 @@ public class GetterMemberPath : MemberPath
     {
         var memberPathArray = memberPath.Path.Select(item => BuildMappableMember(ctx, item)).ToArray();
         return new GetterMemberPath(memberPathArray);
+    }
+
+    public static bool TryBuild(
+        TypeMappingBuildContext ctx,
+        MemberPath memberPath,
+        [NotNullWhen(true)] out GetterMemberPath? getterMemberPath
+    )
+    {
+        if (
+            ctx.TrimSourcePath.Count > 0
+            && memberPath.Path.Count >= ctx.TrimSourcePath.Count
+            && memberPath.Path.Take(ctx.TrimSourcePath.Count).SequenceEqual(ctx.TrimSourcePath)
+        )
+        {
+            getterMemberPath = new GetterMemberPath(memberPath.Path.Skip(ctx.TrimSourcePath.Count).ToArray());
+            return true;
+        }
+
+        getterMemberPath = null;
+        return false;
     }
 
     public static IEnumerable<IMappableMember> Build(MappingBuilderContext ctx, IEnumerable<IMappableMember> path)

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/CircularReferenceMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/CircularReferenceMapperTest.SnapshotGeneratedSource.verified.cs
@@ -15,9 +15,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 return existingTargetReference;
             var target = new global::Riok.Mapperly.IntegrationTests.Dto.CircularReferenceDto();
             refHandler.SetReference<global::Riok.Mapperly.IntegrationTests.Models.CircularReferenceObject, global::Riok.Mapperly.IntegrationTests.Dto.CircularReferenceDto>(source, target);
-            if (source.Parent != null)
+            if (source.Parent is { } sourceParent)
             {
-                target.Parent = MapToCircularReferenceDto(source.Parent, refHandler);
+                target.Parent = MapToCircularReferenceDto(sourceParent, refHandler);
             }
             target.Value = source.Value;
             return target;

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/DeepCloningMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/DeepCloningMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
@@ -18,37 +18,37 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 IntInitOnlyValue = src.IntInitOnlyValue,
                 RequiredValue = src.RequiredValue,
             };
-            if (src.NullableFlattening != null)
+            if (src.NullableFlattening is { } srcNullableFlattening)
             {
-                target.NullableFlattening = Copy(src.NullableFlattening);
+                target.NullableFlattening = Copy(srcNullableFlattening);
             }
-            if (src.NestedNullable != null)
+            if (src.NestedNullable is { } srcNestedNullable)
             {
-                target.NestedNullable = MapToTestObjectNested(src.NestedNullable);
+                target.NestedNullable = MapToTestObjectNested(srcNestedNullable);
             }
-            if (src.NestedNullableTargetNotNullable != null)
+            if (src.NestedNullableTargetNotNullable is { } srcNestedNullableTargetNotNullable)
             {
-                target.NestedNullableTargetNotNullable = MapToTestObjectNested(src.NestedNullableTargetNotNullable);
+                target.NestedNullableTargetNotNullable = MapToTestObjectNested(srcNestedNullableTargetNotNullable);
             }
-            if (src.TupleValue != null)
+            if (src.TupleValue is { } srcTupleValue)
             {
-                target.TupleValue = MapToValueTuple(src.TupleValue.Value);
+                target.TupleValue = MapToValueTuple(srcTupleValue);
             }
-            if (src.RecursiveObject != null)
+            if (src.RecursiveObject is { } srcRecursiveObject)
             {
-                target.RecursiveObject = Copy(src.RecursiveObject);
+                target.RecursiveObject = Copy(srcRecursiveObject);
             }
-            if (src.SourceTargetSameObjectType != null)
+            if (src.SourceTargetSameObjectType is { } srcSourceTargetSameObjectType)
             {
-                target.SourceTargetSameObjectType = Copy(src.SourceTargetSameObjectType);
+                target.SourceTargetSameObjectType = Copy(srcSourceTargetSameObjectType);
             }
-            if (src.NullableReadOnlyObjectCollection != null)
+            if (src.NullableReadOnlyObjectCollection is { } srcNullableReadOnlyObjectCollection)
             {
-                target.NullableReadOnlyObjectCollection = MapToIReadOnlyCollection(src.NullableReadOnlyObjectCollection);
+                target.NullableReadOnlyObjectCollection = MapToIReadOnlyCollection(srcNullableReadOnlyObjectCollection);
             }
-            if (src.SubObject != null)
+            if (src.SubObject is { } srcSubObject)
             {
-                target.SubObject = MapToInheritanceSubObject(src.SubObject);
+                target.SubObject = MapToInheritanceSubObject(srcSubObject);
             }
             target.IntValue = src.IntValue;
             target.StringValue = src.StringValue;

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
@@ -51,43 +51,43 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 IntInitOnlyValue = DirectInt(testObject.IntInitOnlyValue),
                 RequiredValue = DirectInt(testObject.RequiredValue),
             };
-            if (testObject.NullableFlattening != null)
+            if (testObject.NullableFlattening is { } testObjectNullableFlattening)
             {
-                target.NullableFlatteningIdValue = CastIntNullable(testObject.NullableFlattening.IdValue);
+                target.NullableFlatteningIdValue = CastIntNullable(testObjectNullableFlattening.IdValue);
             }
-            if (testObject.NullableUnflatteningIdValue != null)
+            if (testObject.NullableUnflatteningIdValue is { } testObjectNullableUnflatteningIdValue)
             {
                 target.NullableUnflattening ??= new();
-                target.NullableUnflattening.IdValue = DirectInt(testObject.NullableUnflatteningIdValue.Value);
+                target.NullableUnflattening.IdValue = DirectInt(testObjectNullableUnflatteningIdValue);
             }
-            if (testObject.NestedNullable != null)
+            if (testObject.NestedNullable is { } testObjectNestedNullable)
             {
-                target.NestedNullableIntValue = DirectInt(testObject.NestedNullable.IntValue);
-                target.NestedNullable = MapToTestObjectNestedDto(testObject.NestedNullable);
+                target.NestedNullableIntValue = DirectInt(testObjectNestedNullable.IntValue);
+                target.NestedNullable = MapToTestObjectNestedDto(testObjectNestedNullable);
             }
-            if (testObject.NestedNullableTargetNotNullable != null)
+            if (testObject.NestedNullableTargetNotNullable is { } testObjectNestedNullableTargetNotNullable)
             {
-                target.NestedNullableTargetNotNullable = MapToTestObjectNestedDto(testObject.NestedNullableTargetNotNullable);
+                target.NestedNullableTargetNotNullable = MapToTestObjectNestedDto(testObjectNestedNullableTargetNotNullable);
             }
-            if (testObject.StringNullableTargetNotNullable != null)
+            if (testObject.StringNullableTargetNotNullable is { } testObjectStringNullableTargetNotNullable)
             {
-                target.StringNullableTargetNotNullable = testObject.StringNullableTargetNotNullable;
+                target.StringNullableTargetNotNullable = testObjectStringNullableTargetNotNullable;
             }
-            if (testObject.TupleValue != null)
+            if (testObject.TupleValue is { } testObjectTupleValue)
             {
-                target.TupleValue = MapToValueTuple(testObject.TupleValue.Value);
+                target.TupleValue = MapToValueTuple(testObjectTupleValue);
             }
-            if (testObject.RecursiveObject != null)
+            if (testObject.RecursiveObject is { } testObjectRecursiveObject)
             {
-                target.RecursiveObject = MapToDto(testObject.RecursiveObject);
+                target.RecursiveObject = MapToDto(testObjectRecursiveObject);
             }
-            if (testObject.NullableReadOnlyObjectCollection != null)
+            if (testObject.NullableReadOnlyObjectCollection is { } testObjectNullableReadOnlyObjectCollection)
             {
-                target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(testObject.NullableReadOnlyObjectCollection);
+                target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(testObjectNullableReadOnlyObjectCollection);
             }
-            if (testObject.SubObject != null)
+            if (testObject.SubObject is { } testObjectSubObject)
             {
-                target.SubObject = MapToInheritanceSubObjectDto(testObject.SubObject);
+                target.SubObject = MapToInheritanceSubObjectDto(testObjectSubObject);
             }
             target.IntValue = DirectInt(testObject.IntValue);
             target.StringValue = testObject.StringValue;
@@ -148,29 +148,29 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 IntInitOnlyValue = DirectInt(dto.IntInitOnlyValue),
                 RequiredValue = DirectInt(dto.RequiredValue),
             };
-            if (dto.NullableUnflattening != null)
+            if (dto.NullableUnflattening is { } dtoNullableUnflattening)
             {
-                target.NullableUnflatteningIdValue = CastIntNullable(dto.NullableUnflattening.IdValue);
+                target.NullableUnflatteningIdValue = CastIntNullable(dtoNullableUnflattening.IdValue);
             }
-            if (dto.NestedNullable != null)
+            if (dto.NestedNullable is { } dtoNestedNullable)
             {
-                target.NestedNullable = MapToTestObjectNested(dto.NestedNullable);
+                target.NestedNullable = MapToTestObjectNested(dtoNestedNullable);
             }
-            if (dto.TupleValue != null)
+            if (dto.TupleValue is { } dtoTupleValue)
             {
-                target.TupleValue = MapToValueTuple1(dto.TupleValue.Value);
+                target.TupleValue = MapToValueTuple1(dtoTupleValue);
             }
-            if (dto.RecursiveObject != null)
+            if (dto.RecursiveObject is { } dtoRecursiveObject)
             {
-                target.RecursiveObject = MapFromDto(dto.RecursiveObject);
+                target.RecursiveObject = MapFromDto(dtoRecursiveObject);
             }
-            if (dto.NullableReadOnlyObjectCollection != null)
+            if (dto.NullableReadOnlyObjectCollection is { } dtoNullableReadOnlyObjectCollection)
             {
-                target.NullableReadOnlyObjectCollection = MapToIReadOnlyCollection(dto.NullableReadOnlyObjectCollection);
+                target.NullableReadOnlyObjectCollection = MapToIReadOnlyCollection(dtoNullableReadOnlyObjectCollection);
             }
-            if (dto.SubObject != null)
+            if (dto.SubObject is { } dtoSubObject)
             {
-                target.SubObject = MapToInheritanceSubObject(dto.SubObject);
+                target.SubObject = MapToInheritanceSubObject(dtoSubObject);
             }
             target.IntValue = DirectInt(dto.IntValue);
             target.StringValue = dto.StringValue;
@@ -223,38 +223,38 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
 
         public partial void UpdateDto(global::Riok.Mapperly.IntegrationTests.Models.TestObject source, global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto target)
         {
-            if (source.NullableFlattening != null)
+            if (source.NullableFlattening is { } sourceNullableFlattening)
             {
-                target.NullableFlatteningIdValue = CastIntNullable(source.NullableFlattening.IdValue);
+                target.NullableFlatteningIdValue = CastIntNullable(sourceNullableFlattening.IdValue);
             }
-            if (source.NestedNullable != null)
+            if (source.NestedNullable is { } sourceNestedNullable)
             {
-                target.NestedNullableIntValue = DirectInt(source.NestedNullable.IntValue);
-                target.NestedNullable = MapToTestObjectNestedDto(source.NestedNullable);
+                target.NestedNullableIntValue = DirectInt(sourceNestedNullable.IntValue);
+                target.NestedNullable = MapToTestObjectNestedDto(sourceNestedNullable);
             }
-            if (source.NestedNullableTargetNotNullable != null)
+            if (source.NestedNullableTargetNotNullable is { } sourceNestedNullableTargetNotNullable)
             {
-                target.NestedNullableTargetNotNullable = MapToTestObjectNestedDto(source.NestedNullableTargetNotNullable);
+                target.NestedNullableTargetNotNullable = MapToTestObjectNestedDto(sourceNestedNullableTargetNotNullable);
             }
-            if (source.StringNullableTargetNotNullable != null)
+            if (source.StringNullableTargetNotNullable is { } sourceStringNullableTargetNotNullable)
             {
-                target.StringNullableTargetNotNullable = source.StringNullableTargetNotNullable;
+                target.StringNullableTargetNotNullable = sourceStringNullableTargetNotNullable;
             }
-            if (source.TupleValue != null)
+            if (source.TupleValue is { } sourceTupleValue)
             {
-                target.TupleValue = MapToValueTuple(source.TupleValue.Value);
+                target.TupleValue = MapToValueTuple(sourceTupleValue);
             }
-            if (source.RecursiveObject != null)
+            if (source.RecursiveObject is { } sourceRecursiveObject)
             {
-                target.RecursiveObject = MapToDto(source.RecursiveObject);
+                target.RecursiveObject = MapToDto(sourceRecursiveObject);
             }
-            if (source.NullableReadOnlyObjectCollection != null)
+            if (source.NullableReadOnlyObjectCollection is { } sourceNullableReadOnlyObjectCollection)
             {
-                target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(source.NullableReadOnlyObjectCollection);
+                target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(sourceNullableReadOnlyObjectCollection);
             }
-            if (source.SubObject != null)
+            if (source.SubObject is { } sourceSubObject)
             {
-                target.SubObject = MapToInheritanceSubObjectDto(source.SubObject);
+                target.SubObject = MapToInheritanceSubObjectDto(sourceSubObject);
             }
             target.CtorValue = DirectInt(source.CtorValue);
             target.CtorValue2 = DirectInt(source.CtorValue2);

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/ProjectionMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/ProjectionMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
@@ -73,26 +73,26 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 IntInitOnlyValue = testObject.IntInitOnlyValue,
                 RequiredValue = testObject.RequiredValue,
             };
-            if (testObject.NestedNullable != null)
+            if (testObject.NestedNullable is { } testObjectNestedNullable)
             {
-                target.NestedNullableIntValue = testObject.NestedNullable.IntValue;
-                target.NestedNullable = MapToTestObjectNestedDto(testObject.NestedNullable);
+                target.NestedNullableIntValue = testObjectNestedNullable.IntValue;
+                target.NestedNullable = MapToTestObjectNestedDto(testObjectNestedNullable);
             }
-            if (testObject.NestedNullableTargetNotNullable != null)
+            if (testObject.NestedNullableTargetNotNullable is { } testObjectNestedNullableTargetNotNullable)
             {
-                target.NestedNullableTargetNotNullable = MapToTestObjectNestedDto(testObject.NestedNullableTargetNotNullable);
+                target.NestedNullableTargetNotNullable = MapToTestObjectNestedDto(testObjectNestedNullableTargetNotNullable);
             }
-            if (testObject.StringNullableTargetNotNullable != null)
+            if (testObject.StringNullableTargetNotNullable is { } testObjectStringNullableTargetNotNullable)
             {
-                target.StringNullableTargetNotNullable = testObject.StringNullableTargetNotNullable;
+                target.StringNullableTargetNotNullable = testObjectStringNullableTargetNotNullable;
             }
-            if (testObject.NullableReadOnlyObjectCollection != null)
+            if (testObject.NullableReadOnlyObjectCollection is { } testObjectNullableReadOnlyObjectCollection)
             {
-                target.NullableReadOnlyObjectCollection = MapToIReadOnlyCollection(testObject.NullableReadOnlyObjectCollection);
+                target.NullableReadOnlyObjectCollection = MapToIReadOnlyCollection(testObjectNullableReadOnlyObjectCollection);
             }
-            if (testObject.SubObject != null)
+            if (testObject.SubObject is { } testObjectSubObject)
             {
-                target.SubObject = MapToInheritanceSubObjectDto(testObject.SubObject);
+                target.SubObject = MapToInheritanceSubObjectDto(testObjectSubObject);
             }
             target.IntValue = testObject.IntValue;
             target.StringValue = testObject.StringValue;

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
@@ -56,38 +56,38 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 IntInitOnlyValue = DirectInt(src.IntInitOnlyValue),
                 RequiredValue = DirectInt(src.RequiredValue),
             };
-            if (src.NullableFlattening != null)
+            if (src.NullableFlattening is { } srcNullableFlattening)
             {
-                target.NullableFlatteningIdValue = CastIntNullable(src.NullableFlattening.IdValue);
+                target.NullableFlatteningIdValue = CastIntNullable(srcNullableFlattening.IdValue);
             }
-            if (src.NestedNullable != null)
+            if (src.NestedNullable is { } srcNestedNullable)
             {
-                target.NestedNullableIntValue = DirectInt(src.NestedNullable.IntValue);
-                target.NestedNullable = MapToTestObjectNestedDto(src.NestedNullable);
+                target.NestedNullableIntValue = DirectInt(srcNestedNullable.IntValue);
+                target.NestedNullable = MapToTestObjectNestedDto(srcNestedNullable);
             }
-            if (src.NestedNullableTargetNotNullable != null)
+            if (src.NestedNullableTargetNotNullable is { } srcNestedNullableTargetNotNullable)
             {
-                target.NestedNullableTargetNotNullable = MapToTestObjectNestedDto(src.NestedNullableTargetNotNullable);
+                target.NestedNullableTargetNotNullable = MapToTestObjectNestedDto(srcNestedNullableTargetNotNullable);
             }
-            if (src.StringNullableTargetNotNullable != null)
+            if (src.StringNullableTargetNotNullable is { } srcStringNullableTargetNotNullable)
             {
-                target.StringNullableTargetNotNullable = src.StringNullableTargetNotNullable;
+                target.StringNullableTargetNotNullable = srcStringNullableTargetNotNullable;
             }
-            if (src.TupleValue != null)
+            if (src.TupleValue is { } srcTupleValue)
             {
-                target.TupleValue = MapToValueTuple(src.TupleValue.Value);
+                target.TupleValue = MapToValueTuple(srcTupleValue);
             }
-            if (src.RecursiveObject != null)
+            if (src.RecursiveObject is { } srcRecursiveObject)
             {
-                target.RecursiveObject = MapToDtoExt(src.RecursiveObject);
+                target.RecursiveObject = MapToDtoExt(srcRecursiveObject);
             }
-            if (src.NullableReadOnlyObjectCollection != null)
+            if (src.NullableReadOnlyObjectCollection is { } srcNullableReadOnlyObjectCollection)
             {
-                target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(src.NullableReadOnlyObjectCollection);
+                target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(srcNullableReadOnlyObjectCollection);
             }
-            if (src.SubObject != null)
+            if (src.SubObject is { } srcSubObject)
             {
-                target.SubObject = MapToInheritanceSubObjectDto(src.SubObject);
+                target.SubObject = MapToInheritanceSubObjectDto(srcSubObject);
             }
             target.IntValue = DirectInt(src.IntValue);
             target.StringValue = src.StringValue;
@@ -141,43 +141,43 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 IntInitOnlyValue = DirectInt(testObject.IntInitOnlyValue),
                 RequiredValue = DirectInt(testObject.RequiredValue),
             };
-            if (testObject.NullableFlattening != null)
+            if (testObject.NullableFlattening is { } testObjectNullableFlattening)
             {
-                target.NullableFlatteningIdValue = CastIntNullable(testObject.NullableFlattening.IdValue);
+                target.NullableFlatteningIdValue = CastIntNullable(testObjectNullableFlattening.IdValue);
             }
-            if (testObject.NullableUnflatteningIdValue != null)
+            if (testObject.NullableUnflatteningIdValue is { } testObjectNullableUnflatteningIdValue)
             {
                 target.NullableUnflattening ??= new();
-                target.NullableUnflattening.IdValue = DirectInt(testObject.NullableUnflatteningIdValue.Value);
+                target.NullableUnflattening.IdValue = DirectInt(testObjectNullableUnflatteningIdValue);
             }
-            if (testObject.NestedNullable != null)
+            if (testObject.NestedNullable is { } testObjectNestedNullable)
             {
-                target.NestedNullableIntValue = DirectInt(testObject.NestedNullable.IntValue);
-                target.NestedNullable = MapToTestObjectNestedDto(testObject.NestedNullable);
+                target.NestedNullableIntValue = DirectInt(testObjectNestedNullable.IntValue);
+                target.NestedNullable = MapToTestObjectNestedDto(testObjectNestedNullable);
             }
-            if (testObject.NestedNullableTargetNotNullable != null)
+            if (testObject.NestedNullableTargetNotNullable is { } testObjectNestedNullableTargetNotNullable)
             {
-                target.NestedNullableTargetNotNullable = MapToTestObjectNestedDto(testObject.NestedNullableTargetNotNullable);
+                target.NestedNullableTargetNotNullable = MapToTestObjectNestedDto(testObjectNestedNullableTargetNotNullable);
             }
-            if (testObject.StringNullableTargetNotNullable != null)
+            if (testObject.StringNullableTargetNotNullable is { } testObjectStringNullableTargetNotNullable)
             {
-                target.StringNullableTargetNotNullable = testObject.StringNullableTargetNotNullable;
+                target.StringNullableTargetNotNullable = testObjectStringNullableTargetNotNullable;
             }
-            if (testObject.TupleValue != null)
+            if (testObject.TupleValue is { } testObjectTupleValue)
             {
-                target.TupleValue = MapToValueTuple(testObject.TupleValue.Value);
+                target.TupleValue = MapToValueTuple(testObjectTupleValue);
             }
-            if (testObject.RecursiveObject != null)
+            if (testObject.RecursiveObject is { } testObjectRecursiveObject)
             {
-                target.RecursiveObject = MapToDtoExt(testObject.RecursiveObject);
+                target.RecursiveObject = MapToDtoExt(testObjectRecursiveObject);
             }
-            if (testObject.NullableReadOnlyObjectCollection != null)
+            if (testObject.NullableReadOnlyObjectCollection is { } testObjectNullableReadOnlyObjectCollection)
             {
-                target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(testObject.NullableReadOnlyObjectCollection);
+                target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(testObjectNullableReadOnlyObjectCollection);
             }
-            if (testObject.SubObject != null)
+            if (testObject.SubObject is { } testObjectSubObject)
             {
-                target.SubObject = MapToInheritanceSubObjectDto(testObject.SubObject);
+                target.SubObject = MapToInheritanceSubObjectDto(testObjectSubObject);
             }
             target.IntValue = DirectInt(testObject.IntValue);
             target.StringValue = testObject.StringValue;
@@ -233,29 +233,29 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 IntInitOnlyValue = DirectInt(dto.IntInitOnlyValue),
                 RequiredValue = DirectInt(dto.RequiredValue),
             };
-            if (dto.NullableUnflattening != null)
+            if (dto.NullableUnflattening is { } dtoNullableUnflattening)
             {
-                target.NullableUnflatteningIdValue = CastIntNullable(dto.NullableUnflattening.IdValue);
+                target.NullableUnflatteningIdValue = CastIntNullable(dtoNullableUnflattening.IdValue);
             }
-            if (dto.NestedNullable != null)
+            if (dto.NestedNullable is { } dtoNestedNullable)
             {
-                target.NestedNullable = MapToTestObjectNested(dto.NestedNullable);
+                target.NestedNullable = MapToTestObjectNested(dtoNestedNullable);
             }
-            if (dto.TupleValue != null)
+            if (dto.TupleValue is { } dtoTupleValue)
             {
-                target.TupleValue = MapToValueTuple1(dto.TupleValue.Value);
+                target.TupleValue = MapToValueTuple1(dtoTupleValue);
             }
-            if (dto.RecursiveObject != null)
+            if (dto.RecursiveObject is { } dtoRecursiveObject)
             {
-                target.RecursiveObject = MapFromDto(dto.RecursiveObject);
+                target.RecursiveObject = MapFromDto(dtoRecursiveObject);
             }
-            if (dto.NullableReadOnlyObjectCollection != null)
+            if (dto.NullableReadOnlyObjectCollection is { } dtoNullableReadOnlyObjectCollection)
             {
-                target.NullableReadOnlyObjectCollection = MapToIReadOnlyCollection(dto.NullableReadOnlyObjectCollection);
+                target.NullableReadOnlyObjectCollection = MapToIReadOnlyCollection(dtoNullableReadOnlyObjectCollection);
             }
-            if (dto.SubObject != null)
+            if (dto.SubObject is { } dtoSubObject)
             {
-                target.SubObject = MapToInheritanceSubObject(dto.SubObject);
+                target.SubObject = MapToInheritanceSubObject(dtoSubObject);
             }
             target.IntValue = DirectInt(dto.IntValue);
             target.StringValue = dto.StringValue;
@@ -307,38 +307,38 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
 
         public static partial void UpdateDto(global::Riok.Mapperly.IntegrationTests.Models.TestObject source, global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto target)
         {
-            if (source.NullableFlattening != null)
+            if (source.NullableFlattening is { } sourceNullableFlattening)
             {
-                target.NullableFlatteningIdValue = CastIntNullable(source.NullableFlattening.IdValue);
+                target.NullableFlatteningIdValue = CastIntNullable(sourceNullableFlattening.IdValue);
             }
-            if (source.NestedNullable != null)
+            if (source.NestedNullable is { } sourceNestedNullable)
             {
-                target.NestedNullableIntValue = DirectInt(source.NestedNullable.IntValue);
-                target.NestedNullable = MapToTestObjectNestedDto(source.NestedNullable);
+                target.NestedNullableIntValue = DirectInt(sourceNestedNullable.IntValue);
+                target.NestedNullable = MapToTestObjectNestedDto(sourceNestedNullable);
             }
-            if (source.NestedNullableTargetNotNullable != null)
+            if (source.NestedNullableTargetNotNullable is { } sourceNestedNullableTargetNotNullable)
             {
-                target.NestedNullableTargetNotNullable = MapToTestObjectNestedDto(source.NestedNullableTargetNotNullable);
+                target.NestedNullableTargetNotNullable = MapToTestObjectNestedDto(sourceNestedNullableTargetNotNullable);
             }
-            if (source.StringNullableTargetNotNullable != null)
+            if (source.StringNullableTargetNotNullable is { } sourceStringNullableTargetNotNullable)
             {
-                target.StringNullableTargetNotNullable = source.StringNullableTargetNotNullable;
+                target.StringNullableTargetNotNullable = sourceStringNullableTargetNotNullable;
             }
-            if (source.TupleValue != null)
+            if (source.TupleValue is { } sourceTupleValue)
             {
-                target.TupleValue = MapToValueTuple(source.TupleValue.Value);
+                target.TupleValue = MapToValueTuple(sourceTupleValue);
             }
-            if (source.RecursiveObject != null)
+            if (source.RecursiveObject is { } sourceRecursiveObject)
             {
-                target.RecursiveObject = MapToDtoExt(source.RecursiveObject);
+                target.RecursiveObject = MapToDtoExt(sourceRecursiveObject);
             }
-            if (source.NullableReadOnlyObjectCollection != null)
+            if (source.NullableReadOnlyObjectCollection is { } sourceNullableReadOnlyObjectCollection)
             {
-                target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(source.NullableReadOnlyObjectCollection);
+                target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(sourceNullableReadOnlyObjectCollection);
             }
-            if (source.SubObject != null)
+            if (source.SubObject is { } sourceSubObject)
             {
-                target.SubObject = MapToInheritanceSubObjectDto(source.SubObject);
+                target.SubObject = MapToInheritanceSubObjectDto(sourceSubObject);
             }
             target.CtorValue = DirectInt(source.CtorValue);
             target.CtorValue2 = DirectInt(source.CtorValue2);

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
@@ -134,9 +134,9 @@ public class ObjectPropertyFlatteningTest
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.ValueId = source.Value.Id;
+                    target.ValueId = sourceValue.Id;
                 }
                 return target;
                 """
@@ -160,10 +160,10 @@ public class ObjectPropertyFlatteningTest
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.ValueId = source.Value.Id.ToString();
-                    target.ValueName = source.Value.Name;
+                    target.ValueId = sourceValue.Id.ToString();
+                    target.ValueName = sourceValue.Name;
                 }
                 return target;
                 """
@@ -186,9 +186,9 @@ public class ObjectPropertyFlatteningTest
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();
-                if (source.Id.Value != null)
+                if (source.Id.Value is { } sourceIdValue)
                 {
-                    target.IdValue = source.Id.Value.Value;
+                    target.IdValue = sourceIdValue;
                 }
                 return target;
                 """
@@ -211,9 +211,9 @@ public class ObjectPropertyFlatteningTest
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();
-                if (source.Prop != null)
+                if (source.Prop is { } sourceProp)
                 {
-                    target.PropInteger = source.Prop.Value.Integer.ToString();
+                    target.PropInteger = sourceProp.Integer.ToString();
                 }
                 return target;
                 """
@@ -260,9 +260,9 @@ public class ObjectPropertyFlatteningTest
                 if (source == null)
                     return default;
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.ValueId = source.Value.Id.ToString();
+                    target.ValueId = sourceValue.Id.ToString();
                 }
                 target.ValueName = source.Value?.Name;
                 return target;
@@ -489,10 +489,12 @@ public class ObjectPropertyFlatteningTest
     public void ManualNestedPropertyNullablePath()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
-            "[MapProperty(\"Value1.Value1.Id1\", \"Value2.Value2.Id2\")]"
-                + "[MapProperty(\"Value1.Value1.Id10\", \"Value2.Value2.Id20\")]"
-                + "[MapProperty(new[] { \"Value1\", \"Id100\" }, new[] { \"Value2\", \"Id200\" })]"
-                + "partial B Map(A source);",
+            """
+            [MapProperty("Value1.Value1.Id1", "Value2.Value2.Id2")]
+            [MapProperty("Value1.Value1.Id10", "Value2.Value2.Id20")]
+            [MapProperty(new[] { "Value1", "Id100" }, new[] { "Value2", "Id200" })]
+            partial B Map(A source);
+            """,
             "class A { public C? Value1 { get; set; } }",
             "class B { public E? Value2 { get; set; } }",
             "class C { public D? Value1 { get; set; } public string Id100 { get; set; } }",
@@ -507,16 +509,16 @@ public class ObjectPropertyFlatteningTest
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value1 != null)
+                if (source.Value1 is { } sourceValue1)
                 {
                     target.Value2 ??= new();
-                    if (source.Value1.Value1 != null)
+                    if (sourceValue1.Value1 is { } sourceValue1Value1)
                     {
                         target.Value2.Value2 ??= new();
-                        target.Value2.Value2.Id2 = source.Value1.Value1.Id1;
-                        target.Value2.Value2.Id20 = source.Value1.Value1.Id10;
+                        target.Value2.Value2.Id2 = sourceValue1Value1.Id1;
+                        target.Value2.Value2.Id20 = sourceValue1Value1.Id10;
                     }
-                    target.Value2.Id200 = source.Value1.Id100;
+                    target.Value2.Id200 = sourceValue1.Id100;
                 }
                 return target;
                 """

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
@@ -41,9 +41,9 @@ public class ObjectPropertyNullableTest
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.Value = source.Value.Value;
+                    target.Value = sourceValue;
                 }
                 return target;
                 """
@@ -70,9 +70,9 @@ public class ObjectPropertyNullableTest
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.Value = source.Value.Value;
+                    target.Value = sourceValue;
                 }
                 return target;
                 """
@@ -100,9 +100,9 @@ public class ObjectPropertyNullableTest
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.Value = source.Value.Value;
+                    target.Value = sourceValue;
                 }
                 else
                 {
@@ -129,9 +129,9 @@ public class ObjectPropertyNullableTest
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.Value = source.Value;
+                    target.Value = sourceValue;
                 }
                 return target;
                 """
@@ -156,9 +156,9 @@ public class ObjectPropertyNullableTest
             .HaveMapMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.Value = MapToD(source.Value);
+                    target.Value = MapToD(sourceValue);
                 }
                 return target;
                 """
@@ -207,9 +207,9 @@ public class ObjectPropertyNullableTest
             .HaveMapMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.Value = source.Value;
+                    target.Value = sourceValue;
                 }
                 return target;
                 """
@@ -237,9 +237,9 @@ public class ObjectPropertyNullableTest
             .HaveMapMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.Value = source.Value;
+                    target.Value = sourceValue;
                 }
                 else
                 {
@@ -315,9 +315,9 @@ public class ObjectPropertyNullableTest
             .HaveMapMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.Value = MapToD(source.Value);
+                    target.Value = MapToD(sourceValue);
                 }
                 return target;
                 """
@@ -346,9 +346,9 @@ public class ObjectPropertyNullableTest
             .HaveMapMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.Value = MapToD(source.Value);
+                    target.Value = MapToD(sourceValue);
                 }
                 return target;
                 """
@@ -378,9 +378,9 @@ public class ObjectPropertyNullableTest
             .HaveMapMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.Value = MapToD(source.Value);
+                    target.Value = MapToD(sourceValue);
                 }
                 else
                 {
@@ -409,9 +409,9 @@ public class ObjectPropertyNullableTest
             .HaveMapMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.Value = MapToD(source.Value);
+                    target.Value = MapToD(sourceValue);
                 }
                 return target;
                 """
@@ -436,9 +436,9 @@ public class ObjectPropertyNullableTest
             .HaveMapMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.Value = MapToD(source.Value);
+                    target.Value = MapToD(sourceValue);
                 }
                 return target;
                 """
@@ -467,9 +467,9 @@ public class ObjectPropertyNullableTest
             .HaveMapMethodBody(
                 """
                 var target = new global::B();
-                if (source.Value != null)
+                if (source.Value is { } sourceValue)
                 {
-                    target.Value = MapToD(source.Value);
+                    target.Value = MapToD(sourceValue);
                 }
                 else
                 {
@@ -569,9 +569,9 @@ public class ObjectPropertyNullableTest
                 if (y == null)
                     return default;
                 var target = new global::NotNullableType();
-                if (y.Test != null)
+                if (y.Test is { } yTest)
                 {
-                    target.Test = Map(y.Test.Value);
+                    target.Test = Map(yTest);
                 }
                 return target;
                 """

--- a/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ArrayToCollectionShouldUpgradeNullability#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ArrayToCollectionShouldUpgradeNullability#Mapper.g.verified.cs
@@ -8,9 +8,9 @@ public partial class Mapper
         if (source == null)
             return default;
         var target = new global::B();
-        if (source.Value != null)
+        if (source.Value is { } sourceValue)
         {
-            target.Value = MapToICollection(source.Value);
+            target.Value = MapToICollection(sourceValue);
         }
         return target;
     }

--- a/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ArrayToReadOnlyCollectionShouldUpgradeNullability#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ArrayToReadOnlyCollectionShouldUpgradeNullability#Mapper.g.verified.cs
@@ -8,9 +8,9 @@ public partial class Mapper
         if (source == null)
             return default;
         var target = new global::B();
-        if (source.Value != null)
+        if (source.Value is { } sourceValue)
         {
-            target.Value = MapToIReadOnlyCollection(source.Value);
+            target.Value = MapToIReadOnlyCollection(sourceValue);
         }
         return target;
     }

--- a/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.CollectionToReadOnlyCollectionShouldUpgradeNullability#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.CollectionToReadOnlyCollectionShouldUpgradeNullability#Mapper.g.verified.cs
@@ -8,9 +8,9 @@ public partial class Mapper
         if (source == null)
             return default;
         var target = new global::B();
-        if (source.Value != null)
+        if (source.Value is { } sourceValue)
         {
-            target.Value = MapToIReadOnlyCollection(source.Value);
+            target.Value = MapToIReadOnlyCollection(sourceValue);
         }
         return target;
     }

--- a/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ShouldUpgradeNullabilityInDisabledNullableContextInSelectClause#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ShouldUpgradeNullabilityInDisabledNullableContextInSelectClause#Mapper.g.verified.cs
@@ -8,9 +8,9 @@ public partial class Mapper
         if (source == null)
             return default;
         var target = new global::B();
-        if (source.Value != null)
+        if (source.Value is { } sourceValue)
         {
-            target.Value = MapToDArray(source.Value);
+            target.Value = MapToDArray(sourceValue);
         }
         return target;
     }

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyNullableTest.NullableIntWithAdditionalFlattenedValueToNonNullableIntProperties#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyNullableTest.NullableIntWithAdditionalFlattenedValueToNonNullableIntProperties#Mapper.g.verified.cs
@@ -6,13 +6,13 @@ public partial class Mapper
     private partial global::B Map(global::A source)
     {
         var target = new global::B();
-        if (source.Nested != null)
+        if (source.Nested is { } sourceNested)
         {
-            if (source.Nested.Value2 != null)
+            if (sourceNested.Value2 is { } sourceNestedValue2)
             {
-                target.NestedValue2 = source.Nested.Value2.Value;
+                target.NestedValue2 = sourceNestedValue2;
             }
-            target.Nested = MapToD(source.Nested);
+            target.Nested = MapToD(sourceNested);
         }
         return target;
     }
@@ -20,9 +20,9 @@ public partial class Mapper
     private global::D MapToD(global::C source)
     {
         var target = new global::D();
-        if (source.Value1 != null)
+        if (source.Value1 is { } sourceValue1)
         {
-            target.Value1 = source.Value1.Value;
+            target.Value1 = sourceValue1;
         }
         return target;
     }

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyNullableTest.ShouldUpgradeNullabilityInDisabledNullableContextInNestedProperty#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyNullableTest.ShouldUpgradeNullabilityInDisabledNullableContextInNestedProperty#Mapper.g.verified.cs
@@ -8,9 +8,9 @@ public partial class Mapper
         if (source == null)
             return default;
         var target = new global::B();
-        if (source.Value != null)
+        if (source.Value is { } sourceValue)
         {
-            target.Value = MapToD(source.Value);
+            target.Value = MapToD(sourceValue);
         }
         return target;
     }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourcePathManuallyFlatten#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourcePathManuallyFlatten#Mapper.g.verified.cs
@@ -16,9 +16,9 @@ public partial class Mapper
     private partial global::B Map(global::A source)
     {
         var target = new global::B();
-        if (source.Nested?.Nested2 != null)
+        if (source.Nested?.Nested2 is { } sourceNestedNested2)
         {
-            target.NestedValue4 = source.Nested.Nested2.Value3;
+            target.NestedValue4 = sourceNestedNested2.Value3;
         }
         return target;
     }

--- a/test/Riok.Mapperly.Tests/_snapshots/UnsafeAccessorTest.PrivateNestedNullableProperty#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/UnsafeAccessorTest.PrivateNestedNullableProperty#Mapper.g.verified.cs
@@ -6,9 +6,9 @@ public partial class Mapper
     partial global::B Map(global::A source)
     {
         var target = new global::B();
-        if (source.GetNested()?.GetValue() != null)
+        if (source.GetNested()?.GetValue() is { } sourceGetNestedGetValue)
         {
-            target.SetValue(source.GetNested().GetValue().Value);
+            target.SetValue(sourceGetNestedGetValue);
         }
         return target;
     }


### PR DESCRIPTION
# Use pattern matching for null guards

## Description

Generate null guards using pattern matching:
```cs
if (source.MayBeNull is {} sourceMayBeNull)
{
    target.NonNullableValue = sourceMayBeNull;
}
```

Fixes #843

## Checklist

- [x] The existing code style is followed
- [ ] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [ ] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
