### PR TITLE
Apply `dotnet format`

### DIFF
--- a/Riok.Mapperly.sln
+++ b/Riok.Mapperly.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33424.131

--- a/benchmarks/Riok.Mapperly.Benchmarks/MappingBenchmarks.cs
+++ b/benchmarks/Riok.Mapperly.Benchmarks/MappingBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 using Riok.Mapperly.IntegrationTests;
 using Riok.Mapperly.IntegrationTests.Dto;
 using Riok.Mapperly.IntegrationTests.Mapper;

--- a/benchmarks/Riok.Mapperly.Benchmarks/Program.cs
+++ b/benchmarks/Riok.Mapperly.Benchmarks/Program.cs
@@ -1,3 +1,3 @@
-﻿using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Running;
 
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/benchmarks/Riok.Mapperly.Benchmarks/SourceGeneratorBenchmarks.cs
+++ b/benchmarks/Riok.Mapperly.Benchmarks/SourceGeneratorBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Loggers;
 using Microsoft.Build.Locator;

--- a/samples/Riok.Mapperly.Sample/Program.cs
+++ b/samples/Riok.Mapperly.Sample/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Riok.Mapperly.Sample;
 
 var car = new Car

--- a/src/Riok.Mapperly.Abstractions/IgnoreObsoleteMembersStrategy.cs
+++ b/src/Riok.Mapperly.Abstractions/IgnoreObsoleteMembersStrategy.cs
@@ -1,4 +1,4 @@
-﻿namespace Riok.Mapperly.Abstractions;
+namespace Riok.Mapperly.Abstractions;
 
 /// <summary>
 /// Defines the strategy to use when mapping members marked with <see cref="ObsoleteAttribute"/>.

--- a/src/Riok.Mapperly.Abstractions/MapperIgnoreObsoleteMembersAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperIgnoreObsoleteMembersAttribute.cs
@@ -1,4 +1,4 @@
-﻿namespace Riok.Mapperly.Abstractions;
+namespace Riok.Mapperly.Abstractions;
 
 /// <summary>
 /// Specifies options for obsolete ignoring strategy.

--- a/src/Riok.Mapperly.Abstractions/MapperRequiredMappingAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperRequiredMappingAttribute.cs
@@ -1,4 +1,4 @@
-﻿namespace Riok.Mapperly.Abstractions;
+namespace Riok.Mapperly.Abstractions;
 
 /// <summary>
 /// Defines the strategy used when emitting warnings for unmapped members.

--- a/src/Riok.Mapperly.Abstractions/MemberVisibility.cs
+++ b/src/Riok.Mapperly.Abstractions/MemberVisibility.cs
@@ -1,4 +1,4 @@
-﻿namespace Riok.Mapperly.Abstractions;
+namespace Riok.Mapperly.Abstractions;
 
 /// <summary>
 /// Determines what member accessibility Mapperly will attempt to map.

--- a/src/Riok.Mapperly.Abstractions/RequiredMappingStrategy.cs
+++ b/src/Riok.Mapperly.Abstractions/RequiredMappingStrategy.cs
@@ -1,4 +1,4 @@
-﻿namespace Riok.Mapperly.Abstractions;
+namespace Riok.Mapperly.Abstractions;
 
 /// <summary>
 /// Defines the strategy used when emitting warnings for unmapped members.

--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 
 namespace Riok.Mapperly.Descriptors.Enumerables.EnsureCapacity;
 

--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityInfo.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityInfo.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Descriptors.Mappings;
 using Riok.Mapperly.Emit.Syntax;
 using static Riok.Mapperly.Emit.Syntax.SyntaxFactoryHelper;

--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityMember.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityMember.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Descriptors.Mappings;
 using static Riok.Mapperly.Emit.Syntax.SyntaxFactoryHelper;
 

--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityNonEnumerated.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityNonEnumerated.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Descriptors.Mappings;

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewValueTupleExpressionBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewValueTupleExpressionBuilderContext.cs
@@ -1,4 +1,4 @@
-﻿using Riok.Mapperly.Descriptors.Mappings;
+using Riok.Mapperly.Descriptors.Mappings;
 using Riok.Mapperly.Descriptors.Mappings.MemberMappings;
 
 namespace Riok.Mapperly.Descriptors.MappingBodyBuilders.BuilderContext;

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/DateTimeToDateOnlyMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/DateTimeToDateOnlyMappingBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.Descriptors.Mappings;
 

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/DateTimeToTimeOnlyMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/DateTimeToTimeOnlyMappingBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.Descriptors.Mappings;
 

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/MemoryMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/MemoryMappingBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.Descriptors.Enumerables;
 using Riok.Mapperly.Descriptors.Mappings;
 using Riok.Mapperly.Descriptors.Mappings.ExistingTarget;

--- a/src/Riok.Mapperly/Descriptors/Mappings/DelegateMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/DelegateMapping.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Riok.Mapperly.Descriptors.Mappings;

--- a/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/SourceObjectMemberDelegateExistingTargetMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/SourceObjectMemberDelegateExistingTargetMapping.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Riok.Mapperly.Emit.Syntax.SyntaxFactoryHelper;
 

--- a/src/Riok.Mapperly/Descriptors/Mappings/ITypeMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ITypeMapping.cs
@@ -1,4 +1,4 @@
-﻿namespace Riok.Mapperly.Descriptors.Mappings;
+namespace Riok.Mapperly.Descriptors.Mappings;
 
 /// <summary>
 /// Represents a mapping from one type to another.

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MethodMemberNullAssignmentInitializerMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MethodMemberNullAssignmentInitializerMapping.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Emit.Syntax;

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/UnsafeAccess/IUnsafeAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/UnsafeAccess/IUnsafeAccessor.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Emit;
 
 namespace Riok.Mapperly.Descriptors.Mappings.MemberMappings.UnsafeAccess;

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/UnsafeAccess/UnsafeFieldAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/UnsafeAccess/UnsafeFieldAccessor.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Emit;

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/UnsafeAccess/UnsafeGetPropertyAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/UnsafeAccess/UnsafeGetPropertyAccessor.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Emit;
 using Riok.Mapperly.Emit.Syntax;

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/UnsafeAccess/UnsafeSetPropertyAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/UnsafeAccess/UnsafeSetPropertyAccessor.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Emit;

--- a/src/Riok.Mapperly/Descriptors/Mappings/NewValueTupleConstructorMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/NewValueTupleConstructorMapping.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Descriptors.Mappings.MemberMappings;
 using static Riok.Mapperly.Emit.Syntax.SyntaxFactoryHelper;

--- a/src/Riok.Mapperly/Descriptors/Mappings/SourceObjectMemberMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/SourceObjectMemberMapping.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Riok.Mapperly.Emit.Syntax.SyntaxFactoryHelper;
 

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserImplementedExistingTargetMethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserImplementedExistingTargetMethodMapping.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Descriptors.Mappings.ExistingTarget;
 using Riok.Mapperly.Helpers;

--- a/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Riok.Mapperly/Descriptors/UnsafeAccessorContext.cs
+++ b/src/Riok.Mapperly/Descriptors/UnsafeAccessorContext.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using Microsoft.CodeAnalysis;
 using Riok.Mapperly.Descriptors.Mappings.MemberMappings.UnsafeAccess;
 using Riok.Mapperly.Helpers;

--- a/src/Riok.Mapperly/Helpers/ImmutableEquatableArray.cs
+++ b/src/Riok.Mapperly/Helpers/ImmutableEquatableArray.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;

--- a/src/Riok.Mapperly/MapperGenerator.cs
+++ b/src/Riok.Mapperly/MapperGenerator.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.Configuration;

--- a/src/Riok.Mapperly/Output/MapperNode.cs
+++ b/src/Riok.Mapperly/Output/MapperNode.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Riok.Mapperly.Output;
 

--- a/src/Riok.Mapperly/Symbols/GetterMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/GetterMemberPath.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Descriptors;

--- a/src/Riok.Mapperly/Symbols/SetterMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/SetterMemberPath.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/Riok.Mapperly/SyntaxProvider.Roslyn4.0.cs
+++ b/src/Riok.Mapperly/SyntaxProvider.Roslyn4.0.cs
@@ -1,4 +1,4 @@
-﻿#if !ROSLYN4_4_OR_GREATER
+#if !ROSLYN4_4_OR_GREATER
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/Riok.Mapperly/SyntaxProvider.Roslyn4.4.cs
+++ b/src/Riok.Mapperly/SyntaxProvider.Roslyn4.4.cs
@@ -1,4 +1,4 @@
-﻿#if ROSLYN4_4_OR_GREATER
+#if ROSLYN4_4_OR_GREATER
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/test/Riok.Mapperly.IntegrationTests/DeepCloningMapperTest.cs
+++ b/test/Riok.Mapperly.IntegrationTests/DeepCloningMapperTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Riok.Mapperly.IntegrationTests.Helpers;
 using Riok.Mapperly.IntegrationTests.Mapper;

--- a/test/Riok.Mapperly.IntegrationTests/Helpers/PortableDateOnlyConverter.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Helpers/PortableDateOnlyConverter.cs
@@ -1,4 +1,4 @@
-﻿#if !NET6_0_OR_GREATER
+#if !NET6_0_OR_GREATER
 using System;
 using System.Globalization;
 using VerifyTests;

--- a/test/Riok.Mapperly.IntegrationTests/Helpers/PortableTimeOnlyConverter.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Helpers/PortableTimeOnlyConverter.cs
@@ -1,4 +1,4 @@
-﻿#if !NET6_0_OR_GREATER
+#if !NET6_0_OR_GREATER
 using System;
 using System.Globalization;
 using VerifyTests;

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/DeepCloningMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/DeepCloningMapper.cs
@@ -1,4 +1,4 @@
-﻿using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.IntegrationTests.Models;
 
 namespace Riok.Mapperly.IntegrationTests.Mapper

--- a/test/Riok.Mapperly.IntegrationTests/UseExternalMapperTest.cs
+++ b/test/Riok.Mapperly.IntegrationTests/UseExternalMapperTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Riok.Mapperly.IntegrationTests.Mapper;
 using Riok.Mapperly.IntegrationTests.Models;

--- a/test/Riok.Mapperly.Tests/Generator/IncrementalGeneratorTest.cs
+++ b/test/Riok.Mapperly.Tests/Generator/IncrementalGeneratorTest.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;

--- a/test/Riok.Mapperly.Tests/Mapping/DateTimeTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/DateTimeTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Riok.Mapperly.Tests.Mapping;
+namespace Riok.Mapperly.Tests.Mapping;
 
 [UsesVerify]
 public class DateTimeTest

--- a/test/Riok.Mapperly.Tests/Mapping/MemoryTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/MemoryTest.cs
@@ -1,4 +1,4 @@
-﻿using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.Diagnostics;
 
 namespace Riok.Mapperly.Tests.Mapping;

--- a/test/Riok.Mapperly.Tests/Mapping/RequiredMappingTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/RequiredMappingTest.cs
@@ -1,4 +1,4 @@
-﻿using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.Diagnostics;
 
 namespace Riok.Mapperly.Tests.Mapping;

--- a/test/Riok.Mapperly.Tests/Mapping/UnsafeAccessorTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/UnsafeAccessorTest.cs
@@ -1,4 +1,4 @@
-﻿using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.Diagnostics;
 
 namespace Riok.Mapperly.Tests.Mapping;


### PR DESCRIPTION
# Apply `dotnet format`

## Description

File encoding was not uniform. Now it honors configuration from `.editorconfig`

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
