### PR TITLE
feat: fix incorrect `private set` when `~MemberVisibility.Accessible` is used

### DIFF
--- a/src/Riok.Mapperly/Symbols/SetterMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/SetterMemberPath.cs
@@ -34,10 +34,8 @@ public class SetterMemberPath : MemberPath
 
     private static (IMappableMember, bool) BuildMemberSetter(MappingBuilderContext ctx, IMappableMember member)
     {
-        if (ctx.SymbolAccessor.IsDirectlyAccessible(member.MemberSymbol))
-        {
+        if (ctx.SymbolAccessor.IsDirectlyAccessible(member.MemberSymbol) && member.CanSetDirectly)
             return (member, false);
-        }
 
         if (member.MemberSymbol.Kind == SymbolKind.Field)
         {


### PR DESCRIPTION
# feat: fix incorrect `private set` when `~MemberVisibility.Accessible` is used

## Description
Prevents the invalid generation of set to a `private set` property if `~MemberVisibility.Accessible` is used.

Fixes #932

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated