### PR TITLE
fix: Respect AllowNullPropertyAssignment correctly when mapping code is not a direct assignment

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
@@ -1,5 +1,6 @@
 using Riok.Mapperly.Descriptors.Mappings.MemberMappings;
 using Riok.Mapperly.Diagnostics;
+using Riok.Mapperly.Helpers;
 using Riok.Mapperly.Symbols;
 
 namespace Riok.Mapperly.Descriptors.MappingBodyBuilders.BuilderContext;
@@ -22,6 +23,13 @@ public class MembersContainerBuilderContext<T>(MappingBuilderContext builderCont
         var nullConditionSourcePath = new MemberPath(memberMapping.SourcePath.PathWithoutTrailingNonNullable().ToList());
         var container = GetOrCreateNullDelegateMappingForPath(nullConditionSourcePath);
         AddMemberAssignmentMapping(container, memberMapping);
+
+        // set target member to null if null assignments are allowed
+        // and the source is null
+        if (BuilderContext.MapperConfiguration.AllowNullPropertyAssignment && memberMapping.TargetPath.Member.Type.IsNullable())
+        {
+            container.AddNullMemberAssignment(SetterMemberPath.Build(BuilderContext, memberMapping.TargetPath));
+        }
     }
 
     private void AddMemberAssignmentMapping(IMemberAssignmentMappingContainer container, IMemberAssignmentMapping mapping)

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberNullDelegateAssignmentMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberNullDelegateAssignmentMapping.cs
@@ -18,6 +18,7 @@ public class MemberNullDelegateAssignmentMapping(
 {
     private readonly GetterMemberPath _nullConditionalSourcePath = nullConditionalSourcePath;
     private readonly bool _throwInsteadOfConditionalNullMapping = throwInsteadOfConditionalNullMapping;
+    private readonly List<SetterMemberPath> _targetsToSetNull = new();
 
     public override IEnumerable<StatementSyntax> Build(TypeMappingBuildContext ctx, ExpressionSyntax targetAccess)
     {
@@ -26,16 +27,15 @@ public class MemberNullDelegateAssignmentMapping(
         // else
         //   throw ...
         var sourceNullConditionalAccess = _nullConditionalSourcePath.BuildAccess(ctx.Source, false, needsNullSafeAccess, true);
-        var nameofSourceAccess = _nullConditionalSourcePath.BuildAccess(ctx.Source, false, false, true);
         var condition = IsNotNull(sourceNullConditionalAccess);
         var conditionCtx = ctx.AddIndentation();
         var trueClause = base.Build(conditionCtx, targetAccess);
-        var elseClause = _throwInsteadOfConditionalNullMapping
-            ? new[] { conditionCtx.SyntaxFactory.ExpressionStatement(ThrowArgumentNullException(nameofSourceAccess)) }
-            : null;
+        var elseClause = BuildElseClause(conditionCtx, targetAccess);
         var ifExpression = ctx.SyntaxFactory.If(condition, trueClause, elseClause);
         return new[] { ifExpression };
     }
+
+    public void AddNullMemberAssignment(SetterMemberPath targetPath) => _targetsToSetNull.Add(targetPath);
 
     public override bool Equals(object? obj)
     {
@@ -69,5 +69,20 @@ public class MemberNullDelegateAssignmentMapping(
     {
         return _nullConditionalSourcePath.Equals(other._nullConditionalSourcePath)
             && _throwInsteadOfConditionalNullMapping == other._throwInsteadOfConditionalNullMapping;
+    }
+
+    private IEnumerable<StatementSyntax>? BuildElseClause(TypeMappingBuildContext ctx, ExpressionSyntax targetAccess)
+    {
+        if (_throwInsteadOfConditionalNullMapping)
+        {
+            // throw new ArgumentNullException
+            var nameofSourceAccess = _nullConditionalSourcePath.BuildAccess(ctx.Source, false, false, true);
+            return new[] { ctx.SyntaxFactory.ExpressionStatement(ThrowArgumentNullException(nameofSourceAccess)) };
+        }
+
+        // target.A = null;
+        return _targetsToSetNull.Count == 0
+            ? null
+            : _targetsToSetNull.Select(x => ctx.SyntaxFactory.ExpressionStatement(x.BuildAssignment(targetAccess, NullLiteral())));
     }
 }

--- a/src/Riok.Mapperly/Symbols/SetterMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/SetterMemberPath.cs
@@ -55,7 +55,7 @@ public class SetterMemberPath : MemberPath
         return (new MethodAccessorMember(member, unsafeGetAccessor.MethodName, methodRequiresParameter: true), true);
     }
 
-    public ExpressionSyntax BuildAssignment(ExpressionSyntax? baseAccess, ExpressionSyntax sourceValue, bool coalesceAssignment = false)
+    public ExpressionSyntax BuildAssignment(ExpressionSyntax? baseAccess, ExpressionSyntax valueToAssign, bool coalesceAssignment = false)
     {
         IEnumerable<IMappableMember> path = Path;
 
@@ -73,16 +73,16 @@ public class SetterMemberPath : MemberPath
             Debug.Assert(!IsMethod);
 
             // target.Value ??= mappedValue;
-            return CoalesceAssignment(memberPath, sourceValue);
+            return CoalesceAssignment(memberPath, valueToAssign);
         }
 
         if (IsMethod)
         {
             // target.SetValue(source.Value);
-            return Invocation(memberPath, sourceValue);
+            return Invocation(memberPath, valueToAssign);
         }
 
         // target.Value = source.Value;
-        return Assignment(memberPath, sourceValue);
+        return Assignment(memberPath, valueToAssign);
     }
 }

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/CircularReferenceMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/CircularReferenceMapperTest.SnapshotGeneratedSource.verified.cs
@@ -19,6 +19,10 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.Parent = MapToCircularReferenceDto(source.Parent, refHandler);
             }
+            else
+            {
+                target.Parent = null;
+            }
             target.Value = source.Value;
             return target;
         }

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/DeepCloningMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/DeepCloningMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
@@ -22,33 +22,65 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.NullableFlattening = Copy(src.NullableFlattening);
             }
+            else
+            {
+                target.NullableFlattening = null;
+            }
             if (src.NestedNullable != null)
             {
                 target.NestedNullable = MapToTestObjectNested(src.NestedNullable);
+            }
+            else
+            {
+                target.NestedNullable = null;
             }
             if (src.NestedNullableTargetNotNullable != null)
             {
                 target.NestedNullableTargetNotNullable = MapToTestObjectNested(src.NestedNullableTargetNotNullable);
             }
+            else
+            {
+                target.NestedNullableTargetNotNullable = null;
+            }
             if (src.TupleValue != null)
             {
                 target.TupleValue = MapToValueTuple(src.TupleValue.Value);
+            }
+            else
+            {
+                target.TupleValue = null;
             }
             if (src.RecursiveObject != null)
             {
                 target.RecursiveObject = Copy(src.RecursiveObject);
             }
+            else
+            {
+                target.RecursiveObject = null;
+            }
             if (src.SourceTargetSameObjectType != null)
             {
                 target.SourceTargetSameObjectType = Copy(src.SourceTargetSameObjectType);
+            }
+            else
+            {
+                target.SourceTargetSameObjectType = null;
             }
             if (src.NullableReadOnlyObjectCollection != null)
             {
                 target.NullableReadOnlyObjectCollection = MapToIReadOnlyCollection(src.NullableReadOnlyObjectCollection);
             }
+            else
+            {
+                target.NullableReadOnlyObjectCollection = null;
+            }
             if (src.SubObject != null)
             {
                 target.SubObject = MapToInheritanceSubObject(src.SubObject);
+            }
+            else
+            {
+                target.SubObject = null;
             }
             target.IntValue = src.IntValue;
             target.StringValue = src.StringValue;

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
@@ -55,6 +55,10 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.NullableFlatteningIdValue = CastIntNullable(testObject.NullableFlattening.IdValue);
             }
+            else
+            {
+                target.NullableFlatteningIdValue = null;
+            }
             if (testObject.NullableUnflatteningIdValue != null)
             {
                 target.NullableUnflattening ??= new();
@@ -64,6 +68,10 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.NestedNullableIntValue = DirectInt(testObject.NestedNullable.IntValue);
                 target.NestedNullable = MapToTestObjectNestedDto(testObject.NestedNullable);
+            }
+            else
+            {
+                target.NestedNullable = null;
             }
             if (testObject.NestedNullableTargetNotNullable != null)
             {
@@ -77,17 +85,33 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.TupleValue = MapToValueTuple(testObject.TupleValue.Value);
             }
+            else
+            {
+                target.TupleValue = null;
+            }
             if (testObject.RecursiveObject != null)
             {
                 target.RecursiveObject = MapToDto(testObject.RecursiveObject);
+            }
+            else
+            {
+                target.RecursiveObject = null;
             }
             if (testObject.NullableReadOnlyObjectCollection != null)
             {
                 target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(testObject.NullableReadOnlyObjectCollection);
             }
+            else
+            {
+                target.NullableReadOnlyObjectCollection = null;
+            }
             if (testObject.SubObject != null)
             {
                 target.SubObject = MapToInheritanceSubObjectDto(testObject.SubObject);
+            }
+            else
+            {
+                target.SubObject = null;
             }
             target.IntValue = DirectInt(testObject.IntValue);
             target.StringValue = testObject.StringValue;
@@ -154,25 +178,49 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.NullableUnflatteningIdValue = CastIntNullable(dto.NullableUnflattening.IdValue);
             }
+            else
+            {
+                target.NullableUnflatteningIdValue = null;
+            }
             if (dto.NestedNullable != null)
             {
                 target.NestedNullable = MapToTestObjectNested(dto.NestedNullable);
+            }
+            else
+            {
+                target.NestedNullable = null;
             }
             if (dto.TupleValue != null)
             {
                 target.TupleValue = MapToValueTuple1(dto.TupleValue.Value);
             }
+            else
+            {
+                target.TupleValue = null;
+            }
             if (dto.RecursiveObject != null)
             {
                 target.RecursiveObject = MapFromDto(dto.RecursiveObject);
+            }
+            else
+            {
+                target.RecursiveObject = null;
             }
             if (dto.NullableReadOnlyObjectCollection != null)
             {
                 target.NullableReadOnlyObjectCollection = MapToIReadOnlyCollection(dto.NullableReadOnlyObjectCollection);
             }
+            else
+            {
+                target.NullableReadOnlyObjectCollection = null;
+            }
             if (dto.SubObject != null)
             {
                 target.SubObject = MapToInheritanceSubObject(dto.SubObject);
+            }
+            else
+            {
+                target.SubObject = null;
             }
             target.IntValue = DirectInt(dto.IntValue);
             target.StringValue = dto.StringValue;
@@ -229,10 +277,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.NullableFlatteningIdValue = CastIntNullable(source.NullableFlattening.IdValue);
             }
+            else
+            {
+                target.NullableFlatteningIdValue = null;
+            }
             if (source.NestedNullable != null)
             {
                 target.NestedNullableIntValue = DirectInt(source.NestedNullable.IntValue);
                 target.NestedNullable = MapToTestObjectNestedDto(source.NestedNullable);
+            }
+            else
+            {
+                target.NestedNullable = null;
             }
             if (source.NestedNullableTargetNotNullable != null)
             {
@@ -246,17 +302,33 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.TupleValue = MapToValueTuple(source.TupleValue.Value);
             }
+            else
+            {
+                target.TupleValue = null;
+            }
             if (source.RecursiveObject != null)
             {
                 target.RecursiveObject = MapToDto(source.RecursiveObject);
+            }
+            else
+            {
+                target.RecursiveObject = null;
             }
             if (source.NullableReadOnlyObjectCollection != null)
             {
                 target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(source.NullableReadOnlyObjectCollection);
             }
+            else
+            {
+                target.NullableReadOnlyObjectCollection = null;
+            }
             if (source.SubObject != null)
             {
                 target.SubObject = MapToInheritanceSubObjectDto(source.SubObject);
+            }
+            else
+            {
+                target.SubObject = null;
             }
             target.CtorValue = DirectInt(source.CtorValue);
             target.CtorValue2 = DirectInt(source.CtorValue2);

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/ProjectionMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/ProjectionMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
@@ -78,6 +78,10 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.NestedNullableIntValue = testObject.NestedNullable.IntValue;
                 target.NestedNullable = MapToTestObjectNestedDto(testObject.NestedNullable);
             }
+            else
+            {
+                target.NestedNullable = null;
+            }
             if (testObject.NestedNullableTargetNotNullable != null)
             {
                 target.NestedNullableTargetNotNullable = MapToTestObjectNestedDto(testObject.NestedNullableTargetNotNullable);
@@ -90,9 +94,17 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.NullableReadOnlyObjectCollection = MapToIReadOnlyCollection(testObject.NullableReadOnlyObjectCollection);
             }
+            else
+            {
+                target.NullableReadOnlyObjectCollection = null;
+            }
             if (testObject.SubObject != null)
             {
                 target.SubObject = MapToInheritanceSubObjectDto(testObject.SubObject);
+            }
+            else
+            {
+                target.SubObject = null;
             }
             target.IntValue = testObject.IntValue;
             target.StringValue = testObject.StringValue;

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
@@ -60,10 +60,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.NullableFlatteningIdValue = CastIntNullable(src.NullableFlattening.IdValue);
             }
+            else
+            {
+                target.NullableFlatteningIdValue = null;
+            }
             if (src.NestedNullable != null)
             {
                 target.NestedNullableIntValue = DirectInt(src.NestedNullable.IntValue);
                 target.NestedNullable = MapToTestObjectNestedDto(src.NestedNullable);
+            }
+            else
+            {
+                target.NestedNullable = null;
             }
             if (src.NestedNullableTargetNotNullable != null)
             {
@@ -77,17 +85,33 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.TupleValue = MapToValueTuple(src.TupleValue.Value);
             }
+            else
+            {
+                target.TupleValue = null;
+            }
             if (src.RecursiveObject != null)
             {
                 target.RecursiveObject = MapToDtoExt(src.RecursiveObject);
+            }
+            else
+            {
+                target.RecursiveObject = null;
             }
             if (src.NullableReadOnlyObjectCollection != null)
             {
                 target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(src.NullableReadOnlyObjectCollection);
             }
+            else
+            {
+                target.NullableReadOnlyObjectCollection = null;
+            }
             if (src.SubObject != null)
             {
                 target.SubObject = MapToInheritanceSubObjectDto(src.SubObject);
+            }
+            else
+            {
+                target.SubObject = null;
             }
             target.IntValue = DirectInt(src.IntValue);
             target.StringValue = src.StringValue;
@@ -145,6 +169,10 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.NullableFlatteningIdValue = CastIntNullable(testObject.NullableFlattening.IdValue);
             }
+            else
+            {
+                target.NullableFlatteningIdValue = null;
+            }
             if (testObject.NullableUnflatteningIdValue != null)
             {
                 target.NullableUnflattening ??= new();
@@ -154,6 +182,10 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.NestedNullableIntValue = DirectInt(testObject.NestedNullable.IntValue);
                 target.NestedNullable = MapToTestObjectNestedDto(testObject.NestedNullable);
+            }
+            else
+            {
+                target.NestedNullable = null;
             }
             if (testObject.NestedNullableTargetNotNullable != null)
             {
@@ -167,17 +199,33 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.TupleValue = MapToValueTuple(testObject.TupleValue.Value);
             }
+            else
+            {
+                target.TupleValue = null;
+            }
             if (testObject.RecursiveObject != null)
             {
                 target.RecursiveObject = MapToDtoExt(testObject.RecursiveObject);
+            }
+            else
+            {
+                target.RecursiveObject = null;
             }
             if (testObject.NullableReadOnlyObjectCollection != null)
             {
                 target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(testObject.NullableReadOnlyObjectCollection);
             }
+            else
+            {
+                target.NullableReadOnlyObjectCollection = null;
+            }
             if (testObject.SubObject != null)
             {
                 target.SubObject = MapToInheritanceSubObjectDto(testObject.SubObject);
+            }
+            else
+            {
+                target.SubObject = null;
             }
             target.IntValue = DirectInt(testObject.IntValue);
             target.StringValue = testObject.StringValue;
@@ -237,25 +285,49 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.NullableUnflatteningIdValue = CastIntNullable(dto.NullableUnflattening.IdValue);
             }
+            else
+            {
+                target.NullableUnflatteningIdValue = null;
+            }
             if (dto.NestedNullable != null)
             {
                 target.NestedNullable = MapToTestObjectNested(dto.NestedNullable);
+            }
+            else
+            {
+                target.NestedNullable = null;
             }
             if (dto.TupleValue != null)
             {
                 target.TupleValue = MapToValueTuple1(dto.TupleValue.Value);
             }
+            else
+            {
+                target.TupleValue = null;
+            }
             if (dto.RecursiveObject != null)
             {
                 target.RecursiveObject = MapFromDto(dto.RecursiveObject);
+            }
+            else
+            {
+                target.RecursiveObject = null;
             }
             if (dto.NullableReadOnlyObjectCollection != null)
             {
                 target.NullableReadOnlyObjectCollection = MapToIReadOnlyCollection(dto.NullableReadOnlyObjectCollection);
             }
+            else
+            {
+                target.NullableReadOnlyObjectCollection = null;
+            }
             if (dto.SubObject != null)
             {
                 target.SubObject = MapToInheritanceSubObject(dto.SubObject);
+            }
+            else
+            {
+                target.SubObject = null;
             }
             target.IntValue = DirectInt(dto.IntValue);
             target.StringValue = dto.StringValue;
@@ -311,10 +383,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.NullableFlatteningIdValue = CastIntNullable(source.NullableFlattening.IdValue);
             }
+            else
+            {
+                target.NullableFlatteningIdValue = null;
+            }
             if (source.NestedNullable != null)
             {
                 target.NestedNullableIntValue = DirectInt(source.NestedNullable.IntValue);
                 target.NestedNullable = MapToTestObjectNestedDto(source.NestedNullable);
+            }
+            else
+            {
+                target.NestedNullable = null;
             }
             if (source.NestedNullableTargetNotNullable != null)
             {
@@ -328,17 +408,33 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.TupleValue = MapToValueTuple(source.TupleValue.Value);
             }
+            else
+            {
+                target.TupleValue = null;
+            }
             if (source.RecursiveObject != null)
             {
                 target.RecursiveObject = MapToDtoExt(source.RecursiveObject);
+            }
+            else
+            {
+                target.RecursiveObject = null;
             }
             if (source.NullableReadOnlyObjectCollection != null)
             {
                 target.NullableReadOnlyObjectCollection = MapToTestObjectNestedDtoArray(source.NullableReadOnlyObjectCollection);
             }
+            else
+            {
+                target.NullableReadOnlyObjectCollection = null;
+            }
             if (source.SubObject != null)
             {
                 target.SubObject = MapToInheritanceSubObjectDto(source.SubObject);
+            }
+            else
+            {
+                target.SubObject = null;
             }
             target.CtorValue = DirectInt(source.CtorValue);
             target.CtorValue2 = DirectInt(source.CtorValue2);

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
@@ -264,6 +264,10 @@ public class ObjectPropertyFlatteningTest
                 {
                     target.ValueId = source.Value.Id.ToString();
                 }
+                else
+                {
+                    target.ValueId = null;
+                }
                 target.ValueName = source.Value?.Name;
                 return target;
                 """

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
@@ -319,6 +319,10 @@ public class ObjectPropertyNullableTest
                 {
                     target.Value = MapToD(source.Value);
                 }
+                else
+                {
+                    target.Value = null;
+                }
                 return target;
                 """
             );
@@ -439,6 +443,39 @@ public class ObjectPropertyNullableTest
                 if (source.Value != null)
                 {
                     target.Value = MapToD(source.Value);
+                }
+                else
+                {
+                    target.Value = null;
+                }
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void NullableValueTypeToOtherNullableValueType()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            "class A { public float? Value { get; set; } }",
+            "class B { public decimal? Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                if (source.Value != null)
+                {
+                    target.Value = new decimal(source.Value.Value);
+                }
+                else
+                {
+                    target.Value = null;
                 }
                 return target;
                 """

--- a/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ArrayToCollectionShouldUpgradeNullability#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ArrayToCollectionShouldUpgradeNullability#Mapper.g.verified.cs
@@ -12,6 +12,10 @@ public partial class Mapper
         {
             target.Value = MapToICollection(source.Value);
         }
+        else
+        {
+            target.Value = null;
+        }
         return target;
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ArrayToReadOnlyCollectionShouldUpgradeNullability#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ArrayToReadOnlyCollectionShouldUpgradeNullability#Mapper.g.verified.cs
@@ -12,6 +12,10 @@ public partial class Mapper
         {
             target.Value = MapToIReadOnlyCollection(source.Value);
         }
+        else
+        {
+            target.Value = null;
+        }
         return target;
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.CollectionToReadOnlyCollectionShouldUpgradeNullability#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.CollectionToReadOnlyCollectionShouldUpgradeNullability#Mapper.g.verified.cs
@@ -12,6 +12,10 @@ public partial class Mapper
         {
             target.Value = MapToIReadOnlyCollection(source.Value);
         }
+        else
+        {
+            target.Value = null;
+        }
         return target;
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ShouldUpgradeNullabilityInDisabledNullableContextInSelectClause#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/EnumerableTest.ShouldUpgradeNullabilityInDisabledNullableContextInSelectClause#Mapper.g.verified.cs
@@ -12,6 +12,10 @@ public partial class Mapper
         {
             target.Value = MapToDArray(source.Value);
         }
+        else
+        {
+            target.Value = null;
+        }
         return target;
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyNullableTest.ShouldUpgradeNullabilityInDisabledNullableContextInNestedProperty#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyNullableTest.ShouldUpgradeNullabilityInDisabledNullableContextInNestedProperty#Mapper.g.verified.cs
@@ -12,6 +12,10 @@ public partial class Mapper
         {
             target.Value = MapToD(source.Value);
         }
+        else
+        {
+            target.Value = null;
+        }
         return target;
     }
 


### PR DESCRIPTION
# Respect AllowNullPropertyAssignment correctly when mapping code is not a direct assignment

## Description

If `AllowNullPropertyAssignment` is `true`, respect it correctly (set target members to null) if the mapping for the property is not accepting `null` values and is not synthetic.

This could have a big impact, we should probably release this as breaking change 🤔 
Fixes #803

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
