### PR TITLE
feat: support `MapProperty` with `nameof` for CtorMapping

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/INewInstanceBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/INewInstanceBuilderContext.cs
@@ -13,4 +13,11 @@ public interface INewInstanceBuilderContext<out T> : IMembersBuilderContext<T>
     void AddConstructorParameterMapping(ConstructorParameterMapping mapping);
 
     void AddInitMemberMapping(MemberAssignmentMapping mapping);
+
+    /// <summary>
+    /// Maps case insensitive target root member names to their real case sensitive names.
+    /// For example id => Id. The real name can then be used as key for <see cref="IMembersBuilderContext{T}.MemberConfigsByRootTargetName"/>.
+    /// This allows resolving case insensitive configuration member names (eg. when mapping to constructor parameters).
+    /// </summary>
+    IReadOnlyDictionary<string, string> RootTargetNameCasingMapping { get; }
 }

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewInstanceBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewInstanceBuilderContext.cs
@@ -7,11 +7,17 @@ namespace Riok.Mapperly.Descriptors.MappingBodyBuilders.BuilderContext;
 /// An implementation of <see cref="INewInstanceBuilderContext{T}"/>.
 /// </summary>
 /// <typeparam name="T">The type of the mapping.</typeparam>
-public class NewInstanceBuilderContext<T>(MappingBuilderContext builderContext, T mapping)
-    : MembersMappingBuilderContext<T>(builderContext, mapping),
-        INewInstanceBuilderContext<T>
+public class NewInstanceBuilderContext<T> : MembersMappingBuilderContext<T>, INewInstanceBuilderContext<T>
     where T : INewInstanceObjectMemberMapping
 {
+    public IReadOnlyDictionary<string, string> RootTargetNameCasingMapping { get; }
+
+    public NewInstanceBuilderContext(MappingBuilderContext builderContext, T mapping)
+        : base(builderContext, mapping)
+    {
+        RootTargetNameCasingMapping = MemberConfigsByRootTargetName.ToDictionary(x => x.Key, x => x.Key, StringComparer.OrdinalIgnoreCase);
+    }
+
     public void AddInitMemberMapping(MemberAssignmentMapping mapping)
     {
         SetSourceMemberMapped(mapping.SourcePath);
@@ -20,7 +26,8 @@ public class NewInstanceBuilderContext<T>(MappingBuilderContext builderContext, 
 
     public void AddConstructorParameterMapping(ConstructorParameterMapping mapping)
     {
-        MemberConfigsByRootTargetName.Remove(mapping.Parameter.Name);
+        var paramName = RootTargetNameCasingMapping.GetValueOrDefault(mapping.Parameter.Name, defaultValue: mapping.Parameter.Name);
+        MemberConfigsByRootTargetName.Remove(paramName);
         SetSourceMemberMapped(mapping.DelegateMapping.SourcePath);
         Mapping.AddConstructorParameterMapping(mapping);
     }

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewInstanceContainerBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewInstanceContainerBuilderContext.cs
@@ -8,11 +8,17 @@ namespace Riok.Mapperly.Descriptors.MappingBodyBuilders.BuilderContext;
 /// which supports containers (<seealso cref="MembersContainerBuilderContext{T}"/>).
 /// </summary>
 /// <typeparam name="T"></typeparam>
-public class NewInstanceContainerBuilderContext<T>(MappingBuilderContext builderContext, T mapping)
-    : MembersContainerBuilderContext<T>(builderContext, mapping),
-        INewInstanceBuilderContext<T>
+public class NewInstanceContainerBuilderContext<T> : MembersContainerBuilderContext<T>, INewInstanceBuilderContext<T>
     where T : INewInstanceObjectMemberMapping, IMemberAssignmentTypeMapping
 {
+    public IReadOnlyDictionary<string, string> RootTargetNameCasingMapping { get; }
+
+    public NewInstanceContainerBuilderContext(MappingBuilderContext builderContext, T mapping)
+        : base(builderContext, mapping)
+    {
+        RootTargetNameCasingMapping = MemberConfigsByRootTargetName.ToDictionary(x => x.Key, x => x.Key, StringComparer.OrdinalIgnoreCase);
+    }
+
     public void AddInitMemberMapping(MemberAssignmentMapping mapping)
     {
         SetSourceMemberMapped(mapping.SourcePath);
@@ -21,7 +27,8 @@ public class NewInstanceContainerBuilderContext<T>(MappingBuilderContext builder
 
     public void AddConstructorParameterMapping(ConstructorParameterMapping mapping)
     {
-        MemberConfigsByRootTargetName.Remove(mapping.Parameter.Name);
+        var paramName = RootTargetNameCasingMapping.GetValueOrDefault(mapping.Parameter.Name, defaultValue: mapping.Parameter.Name);
+        MemberConfigsByRootTargetName.Remove(paramName);
         SetSourceMemberMapped(mapping.DelegateMapping.SourcePath);
         Mapping.AddConstructorParameterMapping(mapping);
     }

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
@@ -320,7 +320,10 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
         sourcePath = null;
         memberConfig = null;
 
-        if (!ctx.MemberConfigsByRootTargetName.TryGetValue(parameter.Name, out var memberConfigs))
+        if (
+            !ctx.RootTargetNameCasingMapping.TryGetValue(parameter.Name, out var parameterName)
+            || !ctx.MemberConfigsByRootTargetName.TryGetValue(parameterName, out var memberConfigs)
+        )
         {
             return ctx.BuilderContext
                 .SymbolAccessor

--- a/test/Riok.Mapperly.Tests/Mapping/CtorTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/CtorTest.cs
@@ -79,4 +79,33 @@ public class CtorTest
                 """
             );
     }
+
+    [Fact]
+    public void MapPropertyCtorMapping()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapProperty(nameof(A.BId), nameof(B.Id))]
+            private partial B Map(A source);
+            """,
+            "class A { public long BId { get; } }",
+            """
+            class B
+            {
+                public long Id { get; }
+
+                public B(long id) { Id = id; }
+            }
+            """
+        );
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B(source.BId);
+                return target;
+                """
+            );
+    }
 }


### PR DESCRIPTION
# Constructor mapping with `MapProperty` and `nameof`

## Description

Support for
```cs
public class Mapping
{
    [MapProperty(nameof(A.BId), nameof(B.Id))] // notice target ctor parameter is "id", but `MapProperty` target is "Id"
    private partial B Map(A source);
}

class A
{
    public long BId { get; }
}

class B
{
    public long Id { get; }

    public B(long id) { Id = id; }
}
```

Fixes #952

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
