### PR TITLE
feat: generate generic mapping only with LSP compatible methods

### DIFF
--- a/docs/docs/configuration/generic-mapping.md
+++ b/docs/docs/configuration/generic-mapping.md
@@ -17,10 +17,6 @@ using all mappings the user defined in the mapper that:
 public static partial class ModelMapper
 {
     // highlight-start
-    public static partial TTarget Map<TTarget>(object source);
-    // highlight-end
-
-    // highlight-start
     public static partial TTarget MapFruit<TTarget>(Fruit source);
     // highlight-end
 

--- a/docs/docs/configuration/generic-mapping.md
+++ b/docs/docs/configuration/generic-mapping.md
@@ -7,10 +7,7 @@ description: Create a generic mapping method
 
 Mapperly supports generic user defined mapping methods.
 Mapperly implements this mapping method
-using all mappings the user defined in the mapper that:
-
-- satisfy generic constraints,
-- and can be substituted instead of generic mapper
+using all mappings the user defined in the mapper that satisfy the source and target type constraints.
 
 ```csharp
 [Mapper]

--- a/docs/docs/configuration/generic-mapping.md
+++ b/docs/docs/configuration/generic-mapping.md
@@ -7,7 +7,10 @@ description: Create a generic mapping method
 
 Mapperly supports generic user defined mapping methods.
 Mapperly implements this mapping method
-using all mappings the user defined in the mapper.
+using all mappings the user defined in the mapper that:
+
+- satisfy generic constraints,
+- and can be substituted instead of generic mapper
 
 ```csharp
 [Mapper]
@@ -17,12 +20,17 @@ public static partial class ModelMapper
     public static partial TTarget Map<TTarget>(object source);
     // highlight-end
 
+    // highlight-start
+    public static partial TTarget MapFruit<TTarget>(Fruit source);
+    // highlight-end
+
     private static partial BananaDto MapBanana(Banana source);
     private static partial AppleDto MapApple(Apple source);
 }
 
-class Banana {}
-class Apple {}
+class Fruit {}
+class Banana : Fruit {}
+class Apple : Fruit {}
 
 class BananaDto {}
 class AppleDto {}

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/RuntimeTargetTypeMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/RuntimeTargetTypeMappingBodyBuilder.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Riok.Mapperly.Descriptors.MappingBuilders;
 using Riok.Mapperly.Descriptors.Mappings;
 using Riok.Mapperly.Descriptors.Mappings.UserMappings;
@@ -16,7 +17,7 @@ public static class RuntimeTargetTypeMappingBodyBuilder
         var mappings = GetUserMappingCandidates(ctx)
             .Where(
                 x =>
-                    mapping.DoesTypesSatisfySubstitutionPrinciples(ctx.SymbolAccessor, x.SourceType.NonNullable(), x.TargetType)
+                    DoesTypesSatisfySubstitutionPrinciples(mapping, ctx.SymbolAccessor, x.SourceType.NonNullable(), x.TargetType)
                     && mapping
                         .TypeParameters
                         .DoesTypesSatisfyTypeParameterConstraints(ctx.SymbolAccessor, x.SourceType.NonNullable(), x.TargetType)
@@ -24,6 +25,15 @@ public static class RuntimeTargetTypeMappingBodyBuilder
 
         BuildMappingBody(ctx, mapping, mappings);
     }
+
+    private static bool DoesTypesSatisfySubstitutionPrinciples(
+        IMapping mapping,
+        SymbolAccessor symbolAccessor,
+        ITypeSymbol sourceType,
+        ITypeSymbol targetType
+    ) =>
+        (mapping.SourceType.TypeKind == TypeKind.TypeParameter || symbolAccessor.HasImplicitConversion(sourceType, mapping.SourceType))
+        && (mapping.TargetType.TypeKind == TypeKind.TypeParameter || symbolAccessor.HasImplicitConversion(targetType, mapping.TargetType));
 
     public static void BuildMappingBody(MappingBuilderContext ctx, UserDefinedNewInstanceRuntimeTargetTypeMapping mapping)
     {

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/RuntimeTargetTypeMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/RuntimeTargetTypeMappingBodyBuilder.cs
@@ -16,7 +16,8 @@ public static class RuntimeTargetTypeMappingBodyBuilder
         var mappings = GetUserMappingCandidates(ctx)
             .Where(
                 x =>
-                    mapping
+                    mapping.DoesTypesSatisfySubstitutionPrinciples(ctx.SymbolAccessor, x.SourceType.NonNullable(), x.TargetType)
+                    && mapping
                         .TypeParameters
                         .DoesTypesSatisfyTypeParameterConstraints(ctx.SymbolAccessor, x.SourceType.NonNullable(), x.TargetType)
             );

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceGenericTypeMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceGenericTypeMapping.cs
@@ -32,10 +32,6 @@ public class UserDefinedNewInstanceGenericTypeMapping(
 {
     public GenericMappingTypeParameters TypeParameters { get; } = typeParameters;
 
-    public bool DoesTypesSatisfySubstitutionPrinciples(SymbolAccessor symbolAccessor, ITypeSymbol sourceType, ITypeSymbol targetType) =>
-        (SourceType.TypeKind == TypeKind.TypeParameter || symbolAccessor.HasImplicitConversion(sourceType, SourceType))
-        && (TargetType.TypeKind == TypeKind.TypeParameter || symbolAccessor.HasImplicitConversion(targetType, TargetType));
-
     public override MethodDeclarationSyntax BuildMethod(SourceEmitterContext ctx) =>
         base.BuildMethod(ctx).WithTypeParameterList(TypeParameterList(TypeParameters.SourceType, TypeParameters.TargetType));
 

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceGenericTypeMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceGenericTypeMapping.cs
@@ -32,6 +32,10 @@ public class UserDefinedNewInstanceGenericTypeMapping(
 {
     public GenericMappingTypeParameters TypeParameters { get; } = typeParameters;
 
+    public bool DoesTypesSatisfySubstitutionPrinciples(SymbolAccessor symbolAccessor, ITypeSymbol sourceType, ITypeSymbol targetType) =>
+        (SourceType.TypeKind == TypeKind.TypeParameter || symbolAccessor.HasImplicitConversion(sourceType, SourceType))
+        && (TargetType.TypeKind == TypeKind.TypeParameter || symbolAccessor.HasImplicitConversion(targetType, TargetType));
+
     public override MethodDeclarationSyntax BuildMethod(SourceEmitterContext ctx) =>
         base.BuildMethod(ctx).WithTypeParameterList(TypeParameterList(TypeParameters.SourceType, TypeParameters.TargetType));
 

--- a/test/Riok.Mapperly.Tests/Mapping/GenericTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/GenericTest.cs
@@ -304,6 +304,41 @@ public class GenericTest
     }
 
     [Fact]
+    public void WithGenericSourceSpecificTarget()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            partial BaseDto Map<TSource>(TSource source);
+
+            partial C MapToC(A source);
+            partial D MapToD(B source);
+            partial MyEnum MapToMyEnum(DtoEnum source);
+            """,
+            "record A(string BaseValue);",
+            "record B(string BaseValue);",
+            "abstract record BaseDto(string BaseValue);",
+            "record C(string BaseValue) : BaseDto(BaseValue);",
+            "record D(string BaseValue) : BaseDto(BaseValue);",
+            "enum DtoEnum;",
+            "enum MyEnum;"
+        );
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                return source switch
+                {
+                    global::A x => MapToC(x),
+                    global::B x => MapToD(x),
+                    null => throw new System.ArgumentNullException(nameof(source)),
+                    _ => throw new System.ArgumentException($"Cannot map {source.GetType()} to {typeof(global::BaseDto)} as there is no known type mapping", nameof(source)),
+                };
+                """
+            );
+    }
+
+    [Fact]
     public void WithGenericTarget()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(


### PR DESCRIPTION
# Generate generic mapping only with LSP compatible methods

## Description

Generic mapping is selecting target methods only by type argument constraint. This PR filters them also by LSP type compatibility.

Right now, the mapping does not produce valid code when e.g. source is a specific abstract type (not the `object`). And your mapper has e.g. enum mapping. The compiler then complains: `Error CS8121 : An expression of type 'TheClass' cannot be handled by a pattern of type 'TheEnum'.` on generated code that looks like this:
```cs
partial T Map<T>(TheClass source)
{
    return source switch
            {
                global::TheEnum x when typeof(T).IsAssignableFrom(typeof(global::TheEnum)) => (T)(object)MapToTheEnum(x),
            };
}
```

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
