### PR TITLE
fix: move generated reference handler implementation to a constant named mapperly namespace

### DIFF
--- a/src/Riok.Mapperly.Templates/PreserveReferenceHandler.cs
+++ b/src/Riok.Mapperly.Templates/PreserveReferenceHandler.cs
@@ -5,7 +5,7 @@ using Riok.Mapperly.Abstractions.ReferenceHandling;
 
 #nullable enable
 
-namespace Riok.Mapperly.Internal.AssemblyName
+namespace Riok.Mapperly.Internal
 {
     /// <summary>
     /// A <see cref="IReferenceHandler"/> implementation

--- a/src/Riok.Mapperly.Templates/Riok.Mapperly.Templates.csproj
+++ b/src/Riok.Mapperly.Templates/Riok.Mapperly.Templates.csproj
@@ -2,15 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-
-    <!--
-    AssemblyName is replaced by the source generator
-    with the name of the assembly of the target project.
-    This is done to reduce type name collisions when
-    InternalsVisibleTo is used in another project,
-    which needs the same generated templated type.
-    -->
-    <RootNamespace>Riok.Mapperly.Internal.AssemblyName</RootNamespace>
+    <RootNamespace>Riok.Mapperly.Internal</RootNamespace>
 
     <!--
     disable nullable and enable it for each file individually,
@@ -35,12 +27,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>Riok.Mapperly.Templates.Tests</_Parameter1>
-    </AssemblyAttribute>
+    <ProjectReference Include="..\Riok.Mapperly.Abstractions\Riok.Mapperly.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Riok.Mapperly.Abstractions\Riok.Mapperly.Abstractions.csproj"/>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Riok.Mapperly.Templates.Tests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
@@ -73,7 +73,7 @@ public class DescriptorBuilder
         ExtractExternalMappings();
         _mappingBodyBuilder.BuildMappingBodies(cancellationToken);
         BuildMappingMethodNames();
-        TemplateResolver.AddRequiredTemplates(_builderContext.MapperConfiguration, _mappings, _mapperDescriptor);
+        TemplateResolver.AddRequiredTemplates(_builderContext, _mappings, _mapperDescriptor);
         BuildReferenceHandlingParameters();
         AddMappingsToDescriptor();
         AddAccessorsToDescriptor();

--- a/src/Riok.Mapperly/Emit/SourceEmitter.cs
+++ b/src/Riok.Mapperly/Emit/SourceEmitter.cs
@@ -13,11 +13,7 @@ public static class SourceEmitter
 
     public static CompilationUnitSyntax Build(MapperDescriptor descriptor, CancellationToken cancellationToken)
     {
-        var ctx = new SourceEmitterContext(
-            descriptor.Static,
-            descriptor.NameBuilder,
-            new SyntaxFactoryHelper(descriptor.Symbol.ContainingAssembly.Name)
-        );
+        var ctx = new SourceEmitterContext(descriptor.Static, descriptor.NameBuilder, new SyntaxFactoryHelper());
         ctx = IndentForMapper(ctx, descriptor.Symbol);
 
         var memberCtx = ctx.AddIndentation();

--- a/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.New.cs
+++ b/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.New.cs
@@ -10,7 +10,7 @@ public partial struct SyntaxFactoryHelper
 {
     public ObjectCreationExpressionSyntax CreateInstance(TemplateReference template)
     {
-        var typeName = TemplateReader.GetTypeName(template, _assemblyName);
+        var typeName = TemplateReader.GetTypeName(template);
         var type = IdentifierName(typeName);
         return CreateObject(type, SyntaxFactory.ArgumentList());
     }

--- a/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.cs
+++ b/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.cs
@@ -10,24 +10,16 @@ public readonly partial struct SyntaxFactoryHelper
 {
     public static readonly IdentifierNameSyntax VarIdentifier = IdentifierName("var").AddTrailingSpace();
 
-    private readonly string _assemblyName;
-
-    public SyntaxFactoryHelper(string assemblyName)
-    {
-        _assemblyName = assemblyName;
-    }
-
-    private SyntaxFactoryHelper(int indentation, string assemblyName)
+    private SyntaxFactoryHelper(int indentation)
     {
         Indentation = indentation;
-        _assemblyName = assemblyName;
     }
 
     public int Indentation { get; }
 
-    public SyntaxFactoryHelper AddIndentation() => new(Indentation + 1, _assemblyName);
+    public SyntaxFactoryHelper AddIndentation() => new(Indentation + 1);
 
-    public SyntaxFactoryHelper RemoveIndentation() => new(Indentation - 1, _assemblyName);
+    public SyntaxFactoryHelper RemoveIndentation() => new(Indentation - 1);
 
     public static AssignmentExpressionSyntax Assignment(ExpressionSyntax target, ExpressionSyntax source)
     {

--- a/src/Riok.Mapperly/MapperGenerator.cs
+++ b/src/Riok.Mapperly/MapperGenerator.cs
@@ -23,8 +23,6 @@ public class MapperGenerator : IIncrementalGenerator
 #if DEBUG_SOURCE_GENERATOR
         DebuggerUtil.AttachDebugger();
 #endif
-        var assemblyName = context.CompilationProvider.Select((x, _) => x.Assembly.Name);
-
         // report compilation diagnostics
         var compilationDiagnostics = context.CompilationProvider.SelectMany(
             static (compilation, _) => BuildCompilationDiagnostics(compilation)
@@ -66,9 +64,8 @@ public class MapperGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Templates)
             .Collect()
             .SelectMany(static (x, _) => x.DistinctBy(tm => tm))
-            .Combine(assemblyName)
             .WithTrackingName(MapperGeneratorStepNames.BuildTemplates)
-            .Select(static (x, _) => TemplateReader.ReadContent(x.Left, x.Right))
+            .Select(static (x, _) => TemplateReader.ReadContent(x))
             .WithTrackingName(MapperGeneratorStepNames.BuildTemplatesContent);
         context.EmitTemplates(templates);
     }

--- a/src/Riok.Mapperly/Templates/TemplateReader.cs
+++ b/src/Riok.Mapperly/Templates/TemplateReader.cs
@@ -5,13 +5,12 @@ namespace Riok.Mapperly.Templates;
 internal static class TemplateReader
 {
     private const string ResourceNamePrefix = "Templates/";
-    private const string AssemblyNamePlaceholder = "AssemblyName";
     private const string TypeNamePrefix = "global::Riok.Mapperly.Internal.";
 
-    public static TemplateContent ReadContent(TemplateReference reference, string assemblyName)
+    public static TemplateContent ReadContent(TemplateReference reference)
     {
         var fileName = FileNameBuilder.BuildForTemplate(reference);
-        var content = Read(reference).Replace(AssemblyNamePlaceholder, assemblyName, StringComparison.Ordinal);
+        var content = Read(reference);
         return new TemplateContent(fileName, content);
     }
 
@@ -22,9 +21,8 @@ internal static class TemplateReader
     /// which also uses Mapperly.
     /// </summary>
     /// <param name="reference">The name of the template.</param>
-    /// <param name="assemblyName">The name of the assembly.</param>
     /// <returns>The resulting type name of the template.</returns>
-    public static string GetTypeName(TemplateReference reference, string assemblyName) => $"{TypeNamePrefix}{assemblyName}.{reference}";
+    public static string GetTypeName(TemplateReference reference) => TypeNamePrefix + reference;
 
     private static string Read(TemplateReference reference)
     {

--- a/test/Riok.Mapperly.Templates.Tests/PreserveReferenceHandlerTest.cs
+++ b/test/Riok.Mapperly.Templates.Tests/PreserveReferenceHandlerTest.cs
@@ -1,5 +1,5 @@
 using Riok.Mapperly.Abstractions.ReferenceHandling;
-using Riok.Mapperly.Internal.AssemblyName;
+using Riok.Mapperly.Internal;
 
 namespace Riok.Mapperly.Templates.Tests;
 

--- a/test/Riok.Mapperly.Tests/_snapshots/GenericTest.WithGenericSourceAndTargetAndEnabledReferenceHandling#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/GenericTest.WithGenericSourceAndTargetAndEnabledReferenceHandling#Mapper.g.verified.cs
@@ -5,7 +5,7 @@ public partial class Mapper
 {
     private partial TTarget Map<TSource, TTarget>(TSource source)
     {
-        var refHandler = new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler();
+        var refHandler = new global::Riok.Mapperly.Internal.PreserveReferenceHandler();
         return source switch
         {
             global::A x when typeof(TTarget).IsAssignableFrom(typeof(global::B)) => (TTarget)(object)MapToB1(x, refHandler),
@@ -17,12 +17,12 @@ public partial class Mapper
 
     private partial global::B MapToB(global::A source)
     {
-        return MapToB1(source, new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler());
+        return MapToB1(source, new global::Riok.Mapperly.Internal.PreserveReferenceHandler());
     }
 
     private partial global::D MapToD(global::C source)
     {
-        return MapToD1(source, new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler());
+        return MapToD1(source, new global::Riok.Mapperly.Internal.PreserveReferenceHandler());
     }
 
     private global::B MapToB1(global::A source, global::Riok.Mapperly.Abstractions.ReferenceHandling.IReferenceHandler refHandler)

--- a/test/Riok.Mapperly.Tests/_snapshots/GenericTest.WithGenericSourceAndTargetAndEnabledReferenceHandling#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/GenericTest.WithGenericSourceAndTargetAndEnabledReferenceHandling#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
@@ -6,7 +6,7 @@ using Riok.Mapperly.Abstractions.ReferenceHandling;
 
 #nullable enable
 
-namespace Riok.Mapperly.Internal.Tests
+namespace Riok.Mapperly.Internal
 {
     /// <summary>
     /// A <see cref="IReferenceHandler"/> implementation

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ArrayShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ArrayShouldWork#Mapper.g.verified.cs
@@ -5,7 +5,7 @@ public partial class Mapper
 {
     private partial global::B Map(global::A source)
     {
-        return MapToB(source, new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler());
+        return MapToB(source, new global::Riok.Mapperly.Internal.PreserveReferenceHandler());
     }
 
     private global::B MapToB(global::A source, global::Riok.Mapperly.Abstractions.ReferenceHandling.IReferenceHandler refHandler)

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ArrayShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ArrayShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
@@ -6,7 +6,7 @@ using Riok.Mapperly.Abstractions.ReferenceHandling;
 
 #nullable enable
 
-namespace Riok.Mapperly.Internal.Tests
+namespace Riok.Mapperly.Internal
 {
     /// <summary>
     /// A <see cref="IReferenceHandler"/> implementation

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.EnumerableShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.EnumerableShouldWork#Mapper.g.verified.cs
@@ -5,7 +5,7 @@ public partial class Mapper
 {
     private partial global::B Map(global::A source)
     {
-        return MapToB(source, new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler());
+        return MapToB(source, new global::Riok.Mapperly.Internal.PreserveReferenceHandler());
     }
 
     private global::B MapToB(global::A source, global::Riok.Mapperly.Abstractions.ReferenceHandling.IReferenceHandler refHandler)

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.EnumerableShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.EnumerableShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
@@ -6,7 +6,7 @@ using Riok.Mapperly.Abstractions.ReferenceHandling;
 
 #nullable enable
 
-namespace Riok.Mapperly.Internal.Tests
+namespace Riok.Mapperly.Internal
 {
     /// <summary>
     /// A <see cref="IReferenceHandler"/> implementation

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ExistingInstanceShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ExistingInstanceShouldWork#Mapper.g.verified.cs
@@ -5,7 +5,7 @@ public partial class Mapper
 {
     private partial void Map(global::A source, global::B target)
     {
-        var refHandler = new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler();
+        var refHandler = new global::Riok.Mapperly.Internal.PreserveReferenceHandler();
         target.Parent = MapToB(source.Parent, refHandler);
         target.Value = MapToD(source.Value, refHandler);
     }

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ExistingInstanceShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ExistingInstanceShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
@@ -6,7 +6,7 @@ using Riok.Mapperly.Abstractions.ReferenceHandling;
 
 #nullable enable
 
-namespace Riok.Mapperly.Internal.Tests
+namespace Riok.Mapperly.Internal
 {
     /// <summary>
     /// A <see cref="IReferenceHandler"/> implementation

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ManuallyMappedPropertiesShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ManuallyMappedPropertiesShouldWork#Mapper.g.verified.cs
@@ -5,12 +5,12 @@ public partial class Mapper
 {
     private partial global::B MapToB(global::A source)
     {
-        return MapToB2(source, new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler());
+        return MapToB2(source, new global::Riok.Mapperly.Internal.PreserveReferenceHandler());
     }
 
     private partial global::B MapToB1(global::A source)
     {
-        return MapToB3(source, new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler());
+        return MapToB3(source, new global::Riok.Mapperly.Internal.PreserveReferenceHandler());
     }
 
     private global::B MapToB2(global::A source, global::Riok.Mapperly.Abstractions.ReferenceHandling.IReferenceHandler refHandler)

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ManuallyMappedPropertiesShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ManuallyMappedPropertiesShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
@@ -6,7 +6,7 @@ using Riok.Mapperly.Abstractions.ReferenceHandling;
 
 #nullable enable
 
-namespace Riok.Mapperly.Internal.Tests
+namespace Riok.Mapperly.Internal
 {
     /// <summary>
     /// A <see cref="IReferenceHandler"/> implementation

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ObjectFactoryShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ObjectFactoryShouldWork#Mapper.g.verified.cs
@@ -5,7 +5,7 @@ public partial class Mapper
 {
     private partial global::B Map(global::A a)
     {
-        return MapToB(a, new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler());
+        return MapToB(a, new global::Riok.Mapperly.Internal.PreserveReferenceHandler());
     }
 
     private global::B MapToB(global::A source, global::Riok.Mapperly.Abstractions.ReferenceHandling.IReferenceHandler refHandler)

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ObjectFactoryShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ObjectFactoryShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
@@ -6,7 +6,7 @@ using Riok.Mapperly.Abstractions.ReferenceHandling;
 
 #nullable enable
 
-namespace Riok.Mapperly.Internal.Tests
+namespace Riok.Mapperly.Internal
 {
     /// <summary>
     /// A <see cref="IReferenceHandler"/> implementation

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.RuntimeTargetTypeShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.RuntimeTargetTypeShouldWork#Mapper.g.verified.cs
@@ -5,7 +5,7 @@ public partial class Mapper
 {
     public partial object Map(object source, global::System.Type destinationType)
     {
-        var refHandler = new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler();
+        var refHandler = new global::Riok.Mapperly.Internal.PreserveReferenceHandler();
         return source switch
         {
             global::A x when destinationType.IsAssignableFrom(typeof(global::B)) => MapToB(x, refHandler),

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.RuntimeTargetTypeShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.RuntimeTargetTypeShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
@@ -6,7 +6,7 @@ using Riok.Mapperly.Abstractions.ReferenceHandling;
 
 #nullable enable
 
-namespace Riok.Mapperly.Internal.Tests
+namespace Riok.Mapperly.Internal
 {
     /// <summary>
     /// A <see cref="IReferenceHandler"/> implementation

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ShouldWork#Mapper.g.verified.cs
@@ -5,7 +5,7 @@ public partial class Mapper
 {
     private partial global::B Map(global::A source)
     {
-        return MapToB(source, new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler());
+        return MapToB(source, new global::Riok.Mapperly.Internal.PreserveReferenceHandler());
     }
 
     private global::B MapToB(global::A source, global::Riok.Mapperly.Abstractions.ReferenceHandling.IReferenceHandler refHandler)

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
@@ -6,7 +6,7 @@ using Riok.Mapperly.Abstractions.ReferenceHandling;
 
 #nullable enable
 
-namespace Riok.Mapperly.Internal.Tests
+namespace Riok.Mapperly.Internal
 {
     /// <summary>
     /// A <see cref="IReferenceHandler"/> implementation

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.UserImplementedWithReferenceHandlerShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.UserImplementedWithReferenceHandlerShouldWork#Mapper.g.verified.cs
@@ -5,7 +5,7 @@ public partial class Mapper
 {
     private partial global::B Map(global::A a)
     {
-        return MapToB(a, new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler());
+        return MapToB(a, new global::Riok.Mapperly.Internal.PreserveReferenceHandler());
     }
 
     private global::B MapToB(global::A source, global::Riok.Mapperly.Abstractions.ReferenceHandling.IReferenceHandler refHandler)

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.UserImplementedWithReferenceHandlerShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.UserImplementedWithReferenceHandlerShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
@@ -6,7 +6,7 @@ using Riok.Mapperly.Abstractions.ReferenceHandling;
 
 #nullable enable
 
-namespace Riok.Mapperly.Internal.Tests
+namespace Riok.Mapperly.Internal
 {
     /// <summary>
     /// A <see cref="IReferenceHandler"/> implementation

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.UserImplementedWithoutReferenceHandlerShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.UserImplementedWithoutReferenceHandlerShouldWork#Mapper.g.verified.cs
@@ -5,7 +5,7 @@ public partial class Mapper
 {
     private partial global::B Map(global::A a)
     {
-        return MapToB(a, new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler());
+        return MapToB(a, new global::Riok.Mapperly.Internal.PreserveReferenceHandler());
     }
 
     private global::B MapToB(global::A source, global::Riok.Mapperly.Abstractions.ReferenceHandling.IReferenceHandler refHandler)

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.UserImplementedWithoutReferenceHandlerShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.UserImplementedWithoutReferenceHandlerShouldWork#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
@@ -6,7 +6,7 @@ using Riok.Mapperly.Abstractions.ReferenceHandling;
 
 #nullable enable
 
-namespace Riok.Mapperly.Internal.Tests
+namespace Riok.Mapperly.Internal
 {
     /// <summary>
     /// A <see cref="IReferenceHandler"/> implementation

--- a/test/Riok.Mapperly.Tests/_snapshots/RuntimeTargetTypeMappingTest.WithReferenceHandlingEnabled#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/RuntimeTargetTypeMappingTest.WithReferenceHandlingEnabled#Mapper.g.verified.cs
@@ -5,7 +5,7 @@ public partial class Mapper
 {
     private partial object Map(object source, global::System.Type targetType)
     {
-        var refHandler = new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler();
+        var refHandler = new global::Riok.Mapperly.Internal.PreserveReferenceHandler();
         return source switch
         {
             global::A x when targetType.IsAssignableFrom(typeof(global::B)) => MapToB1(x, refHandler),
@@ -17,12 +17,12 @@ public partial class Mapper
 
     private partial global::B MapToB(global::A source)
     {
-        return MapToB1(source, new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler());
+        return MapToB1(source, new global::Riok.Mapperly.Internal.PreserveReferenceHandler());
     }
 
     private partial global::D MapToD(global::C source)
     {
-        return MapToD1(source, new global::Riok.Mapperly.Internal.Tests.PreserveReferenceHandler());
+        return MapToD1(source, new global::Riok.Mapperly.Internal.PreserveReferenceHandler());
     }
 
     private global::B MapToB1(global::A source, global::Riok.Mapperly.Abstractions.ReferenceHandling.IReferenceHandler refHandler)

--- a/test/Riok.Mapperly.Tests/_snapshots/RuntimeTargetTypeMappingTest.WithReferenceHandlingEnabled#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/RuntimeTargetTypeMappingTest.WithReferenceHandlingEnabled#MapperlyInternal.PreserveReferenceHandler.g.verified.cs
@@ -6,7 +6,7 @@ using Riok.Mapperly.Abstractions.ReferenceHandling;
 
 #nullable enable
 
-namespace Riok.Mapperly.Internal.Tests
+namespace Riok.Mapperly.Internal
 {
     /// <summary>
     /// A <see cref="IReferenceHandler"/> implementation


### PR DESCRIPTION
Use a constant named namespace for the reference handler implementation, but check if it is included in the compilation already to prevent InternalVisibleTo duplicates.

Closes #1015