### PR TITLE
fix: remove Runtime suffix of MapperlyAbstractionsScope msbuild option

### DIFF
--- a/docs/docs/getting-started/installation.mdx
+++ b/docs/docs/getting-started/installation.mdx
@@ -62,11 +62,11 @@ Checkout the latest stable version [here](https://mapperly.riok.app).
 Mapperly removes the attribute references at compile time by default (they have the `ConditionalAttribute`).
 If you want
 to preserve the attribute references at runtime
-you can set the MSBuild variable `MapperlyAbstractionsScopeRuntime` to `runtime`.
+you can set the MSBuild variable `MapperlyAbstractionsScope` to `runtime`.
 
 ```xml
 <PropertyGroup>
-  <MapperlyAbstractionsScopeRuntime>runtime</MapperlyAbstractionsScopeRuntime>
+  <MapperlyAbstractionsScope>runtime</MapperlyAbstractionsScope>
 </PropertyGroup>
 ```
 

--- a/src/Riok.Mapperly/Riok.Mapperly.targets
+++ b/src/Riok.Mapperly/Riok.Mapperly.targets
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <DefineConstants Condition="'$(MapperlyAbstractionsScopeRuntime)' == 'runtime'">$(DefineConstants);MAPPERLY_ABSTRACTIONS_SCOPE_RUNTIME</DefineConstants>
+    <DefineConstants Condition="'$(MapperlyAbstractionsScope)' == 'runtime'">$(DefineConstants);MAPPERLY_ABSTRACTIONS_SCOPE_RUNTIME</DefineConstants>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This ensures naming consistency. Otherwise the runtime term is duplicated.