### PR TITLE
feat: support required mapping strategies on enums

### DIFF
--- a/docs/docs/configuration/enum.mdx
+++ b/docs/docs/configuration/enum.mdx
@@ -120,3 +120,44 @@ set the following two EditorConfig settings (see also [analyzer diagnostics](./a
 dotnet_diagnostic.RMG037.severity = error # Unmapped target enum value
 dotnet_diagnostic.RMG038.severity = error # Unmapped source enum value
 ```
+
+### One side strict enum member mappings
+
+To enforce strict enum member mappings on only either the source or the target,
+the `RequiredMappingStrategy` can be used.
+
+<Tabs>
+    <TabItem value="global" label="Global (mapper level)" default>
+    
+        Sets the `RequiredMappingStrategy` for all methods within the mapper,
+        by default it is `Both` requiring all members to be mapped.
+        This can be overriden by individual mapping methods using `MapperRequiredMappingAttribute`.
+    
+        ```csharp
+        // highlight-start
+        [Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Source)]
+        // highlight-end
+        public partial class CarMapper
+        {
+            ...
+        }
+        ```
+    
+    </TabItem>
+    <TabItem value="local" label="Local (mapping method level)">
+    
+        Applied to the specific mapping method.
+    
+        ```csharp
+        [Mapper]
+        public partial class CarMapper
+        {
+            // highlight-start
+            [MapperRequiredMapping(RequiredMappingStrategy.Source)]
+            // highlight-end
+            public partial CarFeatureDto MapCar(CarFeature feature);
+        }
+        ```
+    
+    </TabItem>
+</Tabs>

--- a/docs/docs/configuration/mapper.mdx
+++ b/docs/docs/configuration/mapper.mdx
@@ -234,6 +234,7 @@ the `RequiredMappingStrategy` can be used.
 ### Strict enum mappings
 
 To enforce strict enum mappings set `RMG037` and `RMG038` to error, see [strict enum mappings](./enum.mdx#strict-enum-mappings).
+One side strict enum member mappings work the same way as one side property mappings.
 
 ### String format
 

--- a/src/Riok.Mapperly/Configuration/EnumMappingConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/EnumMappingConfiguration.cs
@@ -9,7 +9,8 @@ public record EnumMappingConfiguration(
     IFieldSymbol? FallbackValue,
     IReadOnlyCollection<IFieldSymbol> IgnoredSourceMembers,
     IReadOnlyCollection<IFieldSymbol> IgnoredTargetMembers,
-    IReadOnlyCollection<EnumValueMappingConfiguration> ExplicitMappings
+    IReadOnlyCollection<EnumValueMappingConfiguration> ExplicitMappings,
+    RequiredMappingStrategy RequiredMappingStrategy
 )
 {
     public bool HasExplicitConfigurations => ExplicitMappings.Count > 0 || IgnoredSourceMembers.Count > 0 || IgnoredTargetMembers.Count > 0;

--- a/src/Riok.Mapperly/Configuration/MapperConfigurationReader.cs
+++ b/src/Riok.Mapperly/Configuration/MapperConfigurationReader.cs
@@ -26,7 +26,8 @@ public class MapperConfigurationReader
                 null,
                 Array.Empty<IFieldSymbol>(),
                 Array.Empty<IFieldSymbol>(),
-                Array.Empty<EnumValueMappingConfiguration>()
+                Array.Empty<EnumValueMappingConfiguration>(),
+                Mapper.RequiredMappingStrategy
             ),
             new PropertiesMappingConfiguration(
                 Array.Empty<string>(),
@@ -104,13 +105,18 @@ public class MapperConfigurationReader
             .Access<MapperIgnoreTargetValueAttribute, MapperIgnoreEnumValueConfiguration>(configRef.Method)
             .Select(x => x.Value)
             .ToList();
+        var requiredMapping = _dataAccessor.Access<MapperRequiredMappingAttribute>(configRef.Method).FirstOrDefault()
+            is not { } methodWarnUnmapped
+            ? _defaultConfiguration.Enum.RequiredMappingStrategy
+            : methodWarnUnmapped.RequiredMappingStrategy;
         return new EnumMappingConfiguration(
             configData?.Strategy ?? _defaultConfiguration.Enum.Strategy,
             configData?.IgnoreCase ?? _defaultConfiguration.Enum.IgnoreCase,
             configData?.FallbackValue,
             ignoredSources,
             ignoredTargets,
-            explicitMappings
+            explicitMappings,
+            requiredMapping
         );
     }
 }

--- a/test/Riok.Mapperly.Tests/Mapping/EnumRequiredMappingTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumRequiredMappingTest.cs
@@ -1,0 +1,136 @@
+using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Diagnostics;
+
+namespace Riok.Mapperly.Tests.Mapping;
+
+public class EnumRequiredMappingTest
+{
+    [Fact]
+    public void MapperAttributeRequiredMappingSourceWithUnmappedMember()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "E1",
+            "E2",
+            TestSourceBuilderOptions.WithRequiredMappingStrategy(RequiredMappingStrategy.Source),
+            "enum E1 { V1, V2, V3 }",
+            "enum E2 { V1, V2 }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.SourceEnumValueNotMapped, "Enum member V3 (2) on E1 not found on target enum E2")
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody("return (global::E2)source;");
+    }
+
+    [Fact]
+    public void MapperAttributeRequiredMappingSourceByNameWithUnmappedMember()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "E1",
+            "E2",
+            TestSourceBuilderOptions.Default with
+            {
+                RequiredMappingStrategy = RequiredMappingStrategy.Source,
+                EnumMappingStrategy = EnumMappingStrategy.ByName,
+            },
+            "enum E1 { V1, V2, V3 }",
+            "enum E2 { V1, V2 }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.SourceEnumValueNotMapped, "Enum member V3 (2) on E1 not found on target enum E2")
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                return source switch
+                {
+                    global::E1.V1 => global::E2.V1,
+                    global::E1.V2 => global::E2.V2,
+                    _ => throw new System.ArgumentOutOfRangeException(nameof(source), source, "The value of enum E1 is not supported"),
+                };
+                """
+            );
+    }
+
+    [Fact]
+    public void MapperAttributeRequiredMappingTargetWithUnmappedMember()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "E1",
+            "E2",
+            TestSourceBuilderOptions.WithRequiredMappingStrategy(RequiredMappingStrategy.Target),
+            "enum E1 { V1, V2 }",
+            "enum E2 { V1, V2, V3 }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.TargetEnumValueNotMapped, "Enum member V3 (2) on E2 not found on source enum E1")
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody("return (global::E2)source;");
+    }
+
+    [Fact]
+    public void MapperAttributeRequiredMappingTargetByNameWithUnmappedMember()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "E1",
+            "E2",
+            TestSourceBuilderOptions.Default with
+            {
+                RequiredMappingStrategy = RequiredMappingStrategy.Target,
+                EnumMappingStrategy = EnumMappingStrategy.ByName,
+            },
+            "enum E1 { V1, V2 }",
+            "enum E2 { V1, V2, V3 }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.TargetEnumValueNotMapped, "Enum member V3 (2) on E2 not found on source enum E1")
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                return source switch
+                {
+                    global::E1.V1 => global::E2.V1,
+                    global::E1.V2 => global::E2.V2,
+                    _ => throw new System.ArgumentOutOfRangeException(nameof(source), source, "The value of enum E1 is not supported"),
+                };
+                """
+            );
+    }
+
+    [Fact]
+    public void MapperAttributeRequiredMappingNoneWithUnmappedMember()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "E1",
+            "E2",
+            TestSourceBuilderOptions.WithRequiredMappingStrategy(RequiredMappingStrategy.None),
+            "enum E1 { V1, V2, V3 }",
+            "enum E2 { V1, V2, V4 }"
+        );
+
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::E2)source;");
+    }
+
+    [Fact]
+    public void MethodAttributeRequiredMappingNoneShouldOverrideMapperAttributeWithUnmappedMember()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapperRequiredMapping(RequiredMappingStrategy.None)] public partial E2 Map(E1 source);",
+            TestSourceBuilderOptions.WithRequiredMappingStrategy(RequiredMappingStrategy.Source),
+            "enum E1 { V1, V2, V3 }",
+            "enum E2 { V1, V2, V4 }"
+        );
+
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::E2)source;");
+    }
+}

--- a/test/Riok.Mapperly.Tests/Mapping/EnumTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumTest.cs
@@ -162,22 +162,16 @@ public class EnumTest
     [Fact]
     public void EnumToOtherEnumByNameViaGlobalConfigShouldSwitch()
     {
-        var source =
-            @"
-using System;
-using System.Collections.Generic;
-using Riok.Mapperly.Abstractions;
-
-[Mapper(EnumMappingStrategy = EnumMappingStrategy.ByName)]
-public partial class Mapper
-{
-    partial global::E2 ToE1(global::E1 source);
-}
-
-enum E1 {A, B, C}
-
-enum E2 {A = 100, B, C}
-";
+        var source = TestSourceBuilder.Mapping(
+            "E1",
+            "E2",
+            TestSourceBuilderOptions.Default with
+            {
+                EnumMappingStrategy = EnumMappingStrategy.ByName
+            },
+            "enum E1 {A, B, C}",
+            "enum E2 {A = 100, B, C}"
+        );
 
         TestHelper
             .GenerateMapper(source)


### PR DESCRIPTION
Fixes https://github.com/riok/mapperly/issues/811

Adds support for `RequiredMappingStrategy` for enum members.