### PR TITLE
feat: validate usage of MapProperty attributes on enum and queryable mapping methods

### DIFF
--- a/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
@@ -147,3 +147,6 @@ RMG059  | Mapper   | Error    | Multiple default user mappings found, only one i
 RMG060  | Mapper   | Info     | Multiple user mappings discovered without specifying an explicit default
 RMG061  | Mapper   | Error    | The referenced mapping was not found
 RMG062  | Mapper   | Error    | The referenced mapping name is ambiguous
+RMG063  | Mapper   | Error    | Cannot configure an enum mapping on a non-enum mapping
+RMG064  | Mapper   | Error    | Cannot configure an object mapping on a non-object mapping
+RMG065  | Mapper   | Warning  | Cannot configure an object mapping on a queryable projection mapping, apply the configurations to an object mapping method instead

--- a/src/Riok.Mapperly/Configuration/AttributeDataAccessor.cs
+++ b/src/Riok.Mapperly/Configuration/AttributeDataAccessor.cs
@@ -20,6 +20,9 @@ public class AttributeDataAccessor(SymbolAccessor symbolAccessor)
         where TAttribute : Attribute
         where TData : notnull => Access<TAttribute, TData>(symbol).Single();
 
+    public TAttribute? AccessFirstOrDefault<TAttribute>(ISymbol symbol)
+        where TAttribute : Attribute => Access<TAttribute, TAttribute>(symbol).FirstOrDefault();
+
     public TData? AccessFirstOrDefault<TAttribute, TData>(ISymbol symbol)
         where TAttribute : Attribute
         where TData : notnull => Access<TAttribute, TData>(symbol).FirstOrDefault();
@@ -158,7 +161,7 @@ public class AttributeDataAccessor(SymbolAccessor symbolAccessor)
             {
                 var argMemberPath = argMemberPathStr
                     .TrimStart(FullNameOfPrefix)
-                    .Split(StringMemberPath.PropertyAccessSeparator)
+                    .Split(StringMemberPath.MemberAccessSeparator)
                     .Skip(1)
                     .ToArray();
                 return new StringMemberPath(argMemberPath);
@@ -167,7 +170,7 @@ public class AttributeDataAccessor(SymbolAccessor symbolAccessor)
 
         if (arg is { Kind: TypedConstantKind.Primitive, Value: string v })
         {
-            return new StringMemberPath(v.Split(StringMemberPath.PropertyAccessSeparator));
+            return new StringMemberPath(v.Split(StringMemberPath.MemberAccessSeparator));
         }
 
         throw new InvalidOperationException($"Cannot create {nameof(StringMemberPath)} from {arg.Kind}");

--- a/src/Riok.Mapperly/Configuration/MapperConfigurationReader.cs
+++ b/src/Riok.Mapperly/Configuration/MapperConfigurationReader.cs
@@ -1,56 +1,61 @@
 using Microsoft.CodeAnalysis;
 using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Descriptors;
+using Riok.Mapperly.Diagnostics;
 using Riok.Mapperly.Helpers;
 
 namespace Riok.Mapperly.Configuration;
 
 public class MapperConfigurationReader
 {
-    private readonly MappingConfiguration _defaultConfiguration;
     private readonly AttributeDataAccessor _dataAccessor;
+    private readonly WellKnownTypes _types;
 
     public MapperConfigurationReader(
         AttributeDataAccessor dataAccessor,
+        WellKnownTypes types,
         ISymbol mapperSymbol,
         MapperConfiguration defaultMapperConfiguration
     )
     {
         _dataAccessor = dataAccessor;
+        _types = types;
         var mapperConfiguration = _dataAccessor.AccessSingle<MapperAttribute, MapperConfiguration>(mapperSymbol);
-        Mapper = MapperConfigurationMerger.Merge(mapperConfiguration, defaultMapperConfiguration);
+        var mapper = MapperConfigurationMerger.Merge(mapperConfiguration, defaultMapperConfiguration);
 
-        _defaultConfiguration = new MappingConfiguration(
+        MapperConfiguration = new MappingConfiguration(
+            mapper,
             new EnumMappingConfiguration(
-                Mapper.EnumMappingStrategy,
-                Mapper.EnumMappingIgnoreCase,
+                mapper.EnumMappingStrategy,
+                mapper.EnumMappingIgnoreCase,
                 null,
                 Array.Empty<IFieldSymbol>(),
                 Array.Empty<IFieldSymbol>(),
                 Array.Empty<EnumValueMappingConfiguration>(),
-                Mapper.RequiredMappingStrategy
+                mapper.RequiredMappingStrategy
             ),
-            new PropertiesMappingConfiguration(
+            new MembersMappingConfiguration(
                 Array.Empty<string>(),
                 Array.Empty<string>(),
-                Array.Empty<PropertyMappingConfiguration>(),
-                Mapper.IgnoreObsoleteMembersStrategy,
-                Mapper.RequiredMappingStrategy
+                Array.Empty<MemberMappingConfiguration>(),
+                mapper.IgnoreObsoleteMembersStrategy,
+                mapper.RequiredMappingStrategy
             ),
             Array.Empty<DerivedTypeMappingConfiguration>()
         );
     }
 
-    public MapperAttribute Mapper { get; }
+    public MappingConfiguration MapperConfiguration { get; }
 
-    public MappingConfiguration BuildFor(MappingConfigurationReference reference)
+    public MappingConfiguration BuildFor(MappingConfigurationReference reference, DiagnosticCollection diagnostics)
     {
         if (reference.Method == null)
-            return _defaultConfiguration;
+            return MapperConfiguration;
 
-        var enumConfig = BuildEnumConfig(reference);
-        var propertiesConfig = BuildPropertiesConfig(reference.Method);
+        var enumConfig = BuildEnumConfig(reference, diagnostics);
+        var membersConfig = BuildMembersConfig(reference, diagnostics);
         var derivedTypesConfig = BuildDerivedTypeConfigs(reference.Method);
-        return new MappingConfiguration(enumConfig, propertiesConfig, derivedTypesConfig);
+        return new MappingConfiguration(MapperConfiguration.Mapper, enumConfig, membersConfig, derivedTypesConfig);
     }
 
     private IReadOnlyCollection<DerivedTypeMappingConfiguration> BuildDerivedTypeConfigs(IMethodSymbol method)
@@ -61,39 +66,59 @@ public class MapperConfigurationReader
             .ToList();
     }
 
-    private PropertiesMappingConfiguration BuildPropertiesConfig(IMethodSymbol method)
+    private MembersMappingConfiguration BuildMembersConfig(MappingConfigurationReference configRef, DiagnosticCollection diagnostics)
     {
-        var ignoredSourceProperties = _dataAccessor
-            .Access<MapperIgnoreSourceAttribute>(method)
+        if (configRef.Method == null)
+            return MapperConfiguration.Members;
+
+        var ignoredSourceMembers = _dataAccessor
+            .Access<MapperIgnoreSourceAttribute>(configRef.Method)
             .Select(x => x.Source)
             .WhereNotNull()
             .ToList();
-        var ignoredTargetProperties = _dataAccessor
-            .Access<MapperIgnoreTargetAttribute>(method)
+        var ignoredTargetMembers = _dataAccessor
+            .Access<MapperIgnoreTargetAttribute>(configRef.Method)
             .Select(x => x.Target)
             .WhereNotNull()
             .ToList();
-        var propertyConfigurations = _dataAccessor.Access<MapPropertyAttribute, PropertyMappingConfiguration>(method).ToList();
-        var ignoreObsolete = _dataAccessor.Access<MapperIgnoreObsoleteMembersAttribute>(method).FirstOrDefault() is not { } methodIgnore
-            ? _defaultConfiguration.Properties.IgnoreObsoleteMembersStrategy
-            : methodIgnore.IgnoreObsoleteStrategy;
-        var requiredMapping = _dataAccessor.Access<MapperRequiredMappingAttribute>(method).FirstOrDefault() is not { } methodWarnUnmapped
-            ? _defaultConfiguration.Properties.RequiredMappingStrategy
-            : methodWarnUnmapped.RequiredMappingStrategy;
+        var memberConfigurations = _dataAccessor.Access<MapPropertyAttribute, MemberMappingConfiguration>(configRef.Method).ToList();
+        var ignoreObsolete = _dataAccessor
+            .AccessFirstOrDefault<MapperIgnoreObsoleteMembersAttribute>(configRef.Method)
+            ?.IgnoreObsoleteStrategy;
+        var requiredMapping = _dataAccessor.AccessFirstOrDefault<MapperRequiredMappingAttribute>(configRef.Method)?.RequiredMappingStrategy;
 
-        return new PropertiesMappingConfiguration(
-            ignoredSourceProperties,
-            ignoredTargetProperties,
-            propertyConfigurations,
-            ignoreObsolete,
-            requiredMapping
+        // ignore the required mapping / ignore obsolete as the same attribute is used for other mapping types
+        // e.g. enum to enum
+        var hasMemberConfigs = ignoredSourceMembers.Count > 0 || ignoredTargetMembers.Count > 0 || memberConfigurations.Count > 0;
+        if (hasMemberConfigs && (configRef.Source.IsEnum() || configRef.Target.IsEnum()))
+        {
+            diagnostics.ReportDiagnostic(DiagnosticDescriptors.MemberConfigurationOnNonMemberMapping, configRef.Method);
+            return MapperConfiguration.Members;
+        }
+
+        if (
+            hasMemberConfigs
+            && configRef.Source.ImplementsGeneric(_types.Get(typeof(IQueryable<>)), out _)
+            && configRef.Target.ImplementsGeneric(_types.Get(typeof(IQueryable<>)), out _)
+        )
+        {
+            diagnostics.ReportDiagnostic(DiagnosticDescriptors.MemberConfigurationOnQueryableProjectionMapping, configRef.Method);
+            return MapperConfiguration.Members;
+        }
+
+        return new MembersMappingConfiguration(
+            ignoredSourceMembers,
+            ignoredTargetMembers,
+            memberConfigurations,
+            ignoreObsolete ?? MapperConfiguration.Members.IgnoreObsoleteMembersStrategy,
+            requiredMapping ?? MapperConfiguration.Members.RequiredMappingStrategy
         );
     }
 
-    private EnumMappingConfiguration BuildEnumConfig(MappingConfigurationReference configRef)
+    private EnumMappingConfiguration BuildEnumConfig(MappingConfigurationReference configRef, DiagnosticCollection diagnostics)
     {
-        if (configRef.Method == null || !configRef.Source.IsEnum() && !configRef.Target.IsEnum())
-            return _defaultConfiguration.Enum;
+        if (configRef.Method == null)
+            return MapperConfiguration.Enum;
 
         var configData = _dataAccessor.AccessFirstOrDefault<MapEnumAttribute, EnumConfiguration>(configRef.Method);
         var explicitMappings = _dataAccessor.Access<MapEnumValueAttribute, EnumValueMappingConfiguration>(configRef.Method).ToList();
@@ -105,18 +130,25 @@ public class MapperConfigurationReader
             .Access<MapperIgnoreTargetValueAttribute, MapperIgnoreEnumValueConfiguration>(configRef.Method)
             .Select(x => x.Value)
             .ToList();
-        var requiredMapping = _dataAccessor.Access<MapperRequiredMappingAttribute>(configRef.Method).FirstOrDefault()
-            is not { } methodWarnUnmapped
-            ? _defaultConfiguration.Enum.RequiredMappingStrategy
-            : methodWarnUnmapped.RequiredMappingStrategy;
+        var requiredMapping = _dataAccessor.AccessFirstOrDefault<MapperRequiredMappingAttribute>(configRef.Method)?.RequiredMappingStrategy;
+
+        // ignore the required mapping as the same attribute is used for other mapping types
+        // e.g. object to object
+        var hasEnumConfigs = configData != null || explicitMappings.Count > 0 || ignoredSources.Count > 0 || ignoredTargets.Count > 0;
+        if (hasEnumConfigs && !configRef.Source.IsEnum() && !configRef.Target.IsEnum())
+        {
+            diagnostics.ReportDiagnostic(DiagnosticDescriptors.EnumConfigurationOnNonEnumMapping, configRef.Method);
+            return MapperConfiguration.Enum;
+        }
+
         return new EnumMappingConfiguration(
-            configData?.Strategy ?? _defaultConfiguration.Enum.Strategy,
-            configData?.IgnoreCase ?? _defaultConfiguration.Enum.IgnoreCase,
+            configData?.Strategy ?? MapperConfiguration.Enum.Strategy,
+            configData?.IgnoreCase ?? MapperConfiguration.Enum.IgnoreCase,
             configData?.FallbackValue,
             ignoredSources,
             ignoredTargets,
             explicitMappings,
-            requiredMapping
+            requiredMapping ?? MapperConfiguration.Enum.RequiredMappingStrategy
         );
     }
 }

--- a/src/Riok.Mapperly/Configuration/MappingConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/MappingConfiguration.cs
@@ -1,7 +1,10 @@
+using Riok.Mapperly.Abstractions;
+
 namespace Riok.Mapperly.Configuration;
 
 public record MappingConfiguration(
+    MapperAttribute Mapper,
     EnumMappingConfiguration Enum,
-    PropertiesMappingConfiguration Properties,
+    MembersMappingConfiguration Members,
     IReadOnlyCollection<DerivedTypeMappingConfiguration> DerivedTypes
 );

--- a/src/Riok.Mapperly/Configuration/MemberMappingConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/MemberMappingConfiguration.cs
@@ -2,7 +2,7 @@ using Riok.Mapperly.Descriptors;
 
 namespace Riok.Mapperly.Configuration;
 
-public record PropertyMappingConfiguration(StringMemberPath Source, StringMemberPath Target) : HasSyntaxReference
+public record MemberMappingConfiguration(StringMemberPath Source, StringMemberPath Target) : HasSyntaxReference
 {
     public string? StringFormat { get; set; }
 

--- a/src/Riok.Mapperly/Configuration/MembersMappingConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/MembersMappingConfiguration.cs
@@ -2,10 +2,10 @@ using Riok.Mapperly.Abstractions;
 
 namespace Riok.Mapperly.Configuration;
 
-public record PropertiesMappingConfiguration(
+public record MembersMappingConfiguration(
     IReadOnlyCollection<string> IgnoredSources,
     IReadOnlyCollection<string> IgnoredTargets,
-    IReadOnlyCollection<PropertyMappingConfiguration> ExplicitMappings,
+    IReadOnlyCollection<MemberMappingConfiguration> ExplicitMappings,
     IgnoreObsoleteMembersStrategy IgnoreObsoleteMembersStrategy,
     RequiredMappingStrategy RequiredMappingStrategy
 );

--- a/src/Riok.Mapperly/Configuration/StringMemberPath.cs
+++ b/src/Riok.Mapperly/Configuration/StringMemberPath.cs
@@ -2,10 +2,10 @@ namespace Riok.Mapperly.Configuration;
 
 public record StringMemberPath(IReadOnlyCollection<string> Path)
 {
-    public const char PropertyAccessSeparator = '.';
-    private const string PropertyAccessSeparatorString = ".";
+    public const char MemberAccessSeparator = '.';
+    private const string MemberAccessSeparatorString = ".";
 
-    public string FullName => string.Join(PropertyAccessSeparatorString, Path);
+    public string FullName => string.Join(MemberAccessSeparatorString, Path);
 
     public override string ToString() => FullName;
 }

--- a/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
@@ -28,7 +28,6 @@ public class DescriptorBuilder
     private readonly SimpleMappingBuilderContext _builderContext;
     private readonly DiagnosticCollection _diagnostics;
     private readonly UnsafeAccessorContext _unsafeAccessorContext;
-    private readonly MapperConfigurationReader _configurationReader;
 
     public DescriptorBuilder(
         CompilationContext compilationContext,
@@ -44,12 +43,17 @@ public class DescriptorBuilder
         _unsafeAccessorContext = new UnsafeAccessorContext(_methodNameBuilder, symbolAccessor);
 
         var attributeAccessor = new AttributeDataAccessor(symbolAccessor);
-        _configurationReader = new MapperConfigurationReader(attributeAccessor, mapperDeclaration.Symbol, defaultMapperConfiguration);
+        var configurationReader = new MapperConfigurationReader(
+            attributeAccessor,
+            _types,
+            mapperDeclaration.Symbol,
+            defaultMapperConfiguration
+        );
         _diagnostics = new DiagnosticCollection(mapperDeclaration.Syntax.GetLocation());
 
         _builderContext = new SimpleMappingBuilderContext(
             compilationContext,
-            _configurationReader,
+            configurationReader,
             _symbolAccessor,
             attributeAccessor,
             _unsafeAccessorContext,
@@ -86,7 +90,7 @@ public class DescriptorBuilder
     /// </summary>
     private void ConfigureMemberVisibility()
     {
-        var includedMembers = _configurationReader.Mapper.IncludedMembers;
+        var includedMembers = _builderContext.Configuration.Mapper.IncludedMembers;
 
         if (_types.TryGet(UnsafeAccessorName) != null)
         {
@@ -185,7 +189,7 @@ public class DescriptorBuilder
 
     private void BuildReferenceHandlingParameters()
     {
-        if (!_builderContext.MapperConfiguration.UseReferenceHandling)
+        if (!_builderContext.Configuration.Mapper.UseReferenceHandling)
             return;
 
         foreach (var methodMapping in _mappings.MethodMappings)

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/IMembersBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/IMembersBuilderContext.cs
@@ -21,7 +21,7 @@ public interface IMembersBuilderContext<out T>
 
     Dictionary<string, IMappableMember> TargetMembers { get; }
 
-    Dictionary<string, List<PropertyMappingConfiguration>> MemberConfigsByRootTargetName { get; }
+    Dictionary<string, List<MemberMappingConfiguration>> MemberConfigsByRootTargetName { get; }
 
     void AddDiagnostics();
 

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
@@ -26,7 +26,7 @@ public class MembersContainerBuilderContext<T>(MappingBuilderContext builderCont
 
         // set target member to null if null assignments are allowed
         // and the source is null
-        if (BuilderContext.MapperConfiguration.AllowNullPropertyAssignment && memberMapping.TargetPath.Member.Type.IsNullable())
+        if (BuilderContext.Configuration.Mapper.AllowNullPropertyAssignment && memberMapping.TargetPath.Member.Type.IsNullable())
         {
             container.AddNullMemberAssignment(SetterMemberPath.Build(BuilderContext, memberMapping.TargetPath));
         }
@@ -95,7 +95,7 @@ public class MembersContainerBuilderContext<T>(MappingBuilderContext builderCont
         mapping = new MemberNullDelegateAssignmentMapping(
             GetterMemberPath.Build(BuilderContext, nullConditionSourcePath),
             parentMapping,
-            BuilderContext.MapperConfiguration.ThrowOnPropertyMappingNullMismatch,
+            BuilderContext.Configuration.Mapper.ThrowOnPropertyMappingNullMismatch,
             needsNullSafeAccess
         );
         _nullDelegateMappings[nullConditionSourcePath] = mapping;

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
@@ -32,15 +32,15 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
         TargetMembers = GetTargetMembers();
 
         IgnoredSourceMemberNames = builderContext
-            .Configuration.Properties.IgnoredSources.Concat(GetIgnoredObsoleteSourceMembers())
+            .Configuration.Members.IgnoredSources.Concat(GetIgnoredObsoleteSourceMembers())
             .ToHashSet();
         var ignoredTargetMemberNames = builderContext
-            .Configuration.Properties.IgnoredTargets.Concat(GetIgnoredObsoleteTargetMembers())
+            .Configuration.Members.IgnoredTargets.Concat(GetIgnoredObsoleteTargetMembers())
             .ToHashSet();
 
         _ignoredUnmatchedSourceMemberNames = InitIgnoredUnmatchedProperties(IgnoredSourceMemberNames, _unmappedSourceMemberNames);
         _ignoredUnmatchedTargetMemberNames = InitIgnoredUnmatchedProperties(
-            builderContext.Configuration.Properties.IgnoredTargets,
+            builderContext.Configuration.Members.IgnoredTargets,
             TargetMembers.Keys
         );
 
@@ -72,7 +72,7 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
 
     public Dictionary<string, IMappableMember> TargetMembers { get; }
 
-    public Dictionary<string, List<PropertyMappingConfiguration>> MemberConfigsByRootTargetName { get; }
+    public Dictionary<string, List<MemberMappingConfiguration>> MemberConfigsByRootTargetName { get; }
 
     public NullMemberMapping BuildNullMemberMapping(
         MemberPath sourcePath,
@@ -112,7 +112,7 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
 
     private IEnumerable<string> GetIgnoredObsoleteTargetMembers()
     {
-        var obsoleteStrategy = BuilderContext.Configuration.Properties.IgnoreObsoleteMembersStrategy;
+        var obsoleteStrategy = BuilderContext.Configuration.Members.IgnoreObsoleteMembersStrategy;
 
         if (!obsoleteStrategy.HasFlag(IgnoreObsoleteMembersStrategy.Target))
             return Enumerable.Empty<string>();
@@ -125,7 +125,7 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
 
     private IEnumerable<string> GetIgnoredObsoleteSourceMembers()
     {
-        var obsoleteStrategy = BuilderContext.Configuration.Properties.IgnoreObsoleteMembersStrategy;
+        var obsoleteStrategy = BuilderContext.Configuration.Members.IgnoreObsoleteMembersStrategy;
 
         if (!obsoleteStrategy.HasFlag(IgnoreObsoleteMembersStrategy.Source))
             return Enumerable.Empty<string>();
@@ -148,10 +148,10 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
             .ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
     }
 
-    private Dictionary<string, List<PropertyMappingConfiguration>> GetMemberConfigurations()
+    private Dictionary<string, List<MemberMappingConfiguration>> GetMemberConfigurations()
     {
         return BuilderContext
-            .Configuration.Properties.ExplicitMappings.GroupBy(x => x.Target.Path.First())
+            .Configuration.Members.ExplicitMappings.GroupBy(x => x.Target.Path.First())
             .ToDictionary(x => x.Key, x => x.ToList());
     }
 
@@ -159,7 +159,7 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
     {
         foreach (var notFoundIgnoredMember in _ignoredUnmatchedTargetMemberNames)
         {
-            if (notFoundIgnoredMember.Contains(StringMemberPath.PropertyAccessSeparator, StringComparison.Ordinal))
+            if (notFoundIgnoredMember.Contains(StringMemberPath.MemberAccessSeparator, StringComparison.Ordinal))
             {
                 BuilderContext.ReportDiagnostic(DiagnosticDescriptors.NestedIgnoredTargetMember, notFoundIgnoredMember, Mapping.TargetType);
                 continue;
@@ -172,7 +172,7 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
     {
         foreach (var notFoundIgnoredMember in _ignoredUnmatchedSourceMemberNames)
         {
-            if (notFoundIgnoredMember.Contains(StringMemberPath.PropertyAccessSeparator, StringComparison.Ordinal))
+            if (notFoundIgnoredMember.Contains(StringMemberPath.MemberAccessSeparator, StringComparison.Ordinal))
             {
                 BuilderContext.ReportDiagnostic(DiagnosticDescriptors.NestedIgnoredSourceMember, notFoundIgnoredMember, Mapping.TargetType);
                 continue;
@@ -195,7 +195,7 @@ public abstract class MembersMappingBuilderContext<T> : IMembersBuilderContext<T
 
     private void AddUnmatchedSourceMembersDiagnostics()
     {
-        if (!BuilderContext.Configuration.Properties.RequiredMappingStrategy.HasFlag(RequiredMappingStrategy.Source))
+        if (!BuilderContext.Configuration.Members.RequiredMappingStrategy.HasFlag(RequiredMappingStrategy.Source))
             return;
 
         foreach (var sourceMemberName in _unmappedSourceMemberNames)

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
@@ -34,7 +34,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
 
     private static void BuildInitOnlyMemberMappings(INewInstanceBuilderContext<IMapping> ctx, bool includeAllMembers = false)
     {
-        var ignoreCase = ctx.BuilderContext.MapperConfiguration.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseInsensitive;
+        var ignoreCase = ctx.BuilderContext.Configuration.Mapper.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseInsensitive;
 
         var initOnlyTargetMembers = includeAllMembers
             ? ctx.TargetMembers.Values.ToArray()
@@ -68,7 +68,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
                         ctx.Mapping.SourceType
                     );
                 }
-                else if (ctx.BuilderContext.Configuration.Properties.RequiredMappingStrategy.HasFlag(RequiredMappingStrategy.Target))
+                else if (ctx.BuilderContext.Configuration.Members.RequiredMappingStrategy.HasFlag(RequiredMappingStrategy.Target))
                 {
                     ctx.BuilderContext.ReportDiagnostic(
                         DiagnosticDescriptors.SourceMemberNotFound,
@@ -88,7 +88,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
     private static void BuildInitMemberMapping(
         INewInstanceBuilderContext<IMapping> ctx,
         IMappableMember targetMember,
-        IReadOnlyCollection<PropertyMappingConfiguration> memberConfigs
+        IReadOnlyCollection<MemberMappingConfiguration> memberConfigs
     )
     {
         // add configured mapping
@@ -117,7 +117,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
             !ctx.BuilderContext.SymbolAccessor.TryFindMemberPath(ctx.Mapping.SourceType, memberConfig.Source.Path, out var sourceMemberPath)
         )
         {
-            if (ctx.BuilderContext.Configuration.Properties.RequiredMappingStrategy.HasFlag(RequiredMappingStrategy.Target))
+            if (ctx.BuilderContext.Configuration.Members.RequiredMappingStrategy.HasFlag(RequiredMappingStrategy.Target))
             {
                 ctx.BuilderContext.ReportDiagnostic(
                     DiagnosticDescriptors.SourceMemberNotFound,
@@ -137,7 +137,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
         INewInstanceBuilderContext<IMapping> ctx,
         IMappableMember targetMember,
         MemberPath sourcePath,
-        PropertyMappingConfiguration? memberConfig = null
+        MemberMappingConfiguration? memberConfig = null
     )
     {
         var targetPath = new MemberPath(new[] { targetMember });
@@ -196,7 +196,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
             .OrderByDescending(x => ctx.BuilderContext.SymbolAccessor.HasAttribute<MapperConstructorAttribute>(x))
             .ThenBy(x => ctx.BuilderContext.SymbolAccessor.HasAttribute<ObsoleteAttribute>(x));
 
-        if (ctx.BuilderContext.MapperConfiguration.PreferParameterlessConstructors)
+        if (ctx.BuilderContext.Configuration.Mapper.PreferParameterlessConstructors)
         {
             ctorCandidates = ctorCandidates.ThenByDescending(x => x.Parameters.Length == 0).ThenByDescending(x => x.Parameters.Length);
         }
@@ -297,7 +297,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
         INewInstanceBuilderContext<IMapping> ctx,
         IParameterSymbol parameter,
         [NotNullWhen(true)] out MemberPath? sourcePath,
-        out PropertyMappingConfiguration? memberConfig
+        out MemberMappingConfiguration? memberConfig
     )
     {
         sourcePath = null;

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewValueTupleMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewValueTupleMappingBodyBuilder.cs
@@ -126,7 +126,7 @@ public static class NewValueTupleMappingBodyBuilder
         INewValueTupleBuilderContext<INewValueTupleMapping> ctx,
         IFieldSymbol field,
         [NotNullWhen(true)] out MemberPath? sourcePath,
-        out PropertyMappingConfiguration? memberConfig
+        out MemberMappingConfiguration? memberConfig
     )
     {
         sourcePath = null;
@@ -170,7 +170,7 @@ public static class NewValueTupleMappingBodyBuilder
         out MemberPath? sourcePath
     )
     {
-        var ignoreCase = ctx.BuilderContext.MapperConfiguration.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseInsensitive;
+        var ignoreCase = ctx.BuilderContext.Configuration.Mapper.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseInsensitive;
 
         if (
             ctx.BuilderContext.SymbolAccessor.TryFindMemberPath(

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
@@ -23,7 +23,7 @@ public static class ObjectMemberMappingBodyBuilder
 
     public static void BuildMappingBody(IMembersContainerBuilderContext<IMemberAssignmentTypeMapping> ctx)
     {
-        var ignoreCase = ctx.BuilderContext.MapperConfiguration.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseInsensitive;
+        var ignoreCase = ctx.BuilderContext.Configuration.Mapper.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseInsensitive;
 
         foreach (var targetMember in ctx.TargetMembers.Values)
         {
@@ -56,7 +56,7 @@ public static class ObjectMemberMappingBodyBuilder
 
             if (
                 targetMember.CanSet
-                && ctx.BuilderContext.Configuration.Properties.RequiredMappingStrategy.HasFlag(RequiredMappingStrategy.Target)
+                && ctx.BuilderContext.Configuration.Members.RequiredMappingStrategy.HasFlag(RequiredMappingStrategy.Target)
             )
             {
                 ctx.BuilderContext.ReportDiagnostic(
@@ -73,7 +73,7 @@ public static class ObjectMemberMappingBodyBuilder
 
     private static void BuildMemberAssignmentMapping(
         IMembersContainerBuilderContext<IMemberAssignmentTypeMapping> ctx,
-        PropertyMappingConfiguration config
+        MemberMappingConfiguration config
     )
     {
         if (!ctx.BuilderContext.SymbolAccessor.TryFindMemberPath(ctx.Mapping.TargetType, config.Target.Path, out var targetMemberPath))
@@ -265,7 +265,7 @@ public static class ObjectMemberMappingBodyBuilder
         IMembersContainerBuilderContext<IMemberAssignmentTypeMapping> ctx,
         MemberPath sourceMemberPath,
         MemberPath targetMemberPath,
-        PropertyMappingConfiguration? memberConfig = null
+        MemberMappingConfiguration? memberConfig = null
     )
     {
         if (TryAddExistingTargetMapping(ctx, sourceMemberPath, targetMemberPath))
@@ -294,7 +294,7 @@ public static class ObjectMemberMappingBodyBuilder
         // or the mapping is synthetic and the target accepts nulls
         // access the source in a null save matter (via ?.) but no other special handling required.
         if (
-            ctx.BuilderContext.MapperConfiguration.AllowNullPropertyAssignment
+            ctx.BuilderContext.Configuration.Mapper.AllowNullPropertyAssignment
             && (delegateMapping.SourceType.IsNullable() || delegateMapping.IsSynthetic && targetMemberPath.Member.IsNullable)
         )
         {
@@ -314,7 +314,7 @@ public static class ObjectMemberMappingBodyBuilder
         IMembersContainerBuilderContext<IMemberAssignmentTypeMapping> ctx,
         MemberPath sourceMemberPath,
         MemberPath targetMemberPath,
-        PropertyMappingConfiguration? memberConfig
+        MemberMappingConfiguration? memberConfig
     )
     {
         // nullability is handled inside the member mapping

--- a/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
@@ -50,8 +50,6 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
         }
     }
 
-    public MappingConfiguration Configuration { get; }
-
     public TypeMappingKey MappingKey { get; }
 
     public ITypeSymbol Source => MappingKey.Source;
@@ -287,7 +285,7 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
         base.ReportDiagnostic(descriptor, null, messageArgs);
 
     public NullFallbackValue GetNullFallbackValue(ITypeSymbol? targetType = null) =>
-        GetNullFallbackValue(targetType ?? Target, MapperConfiguration.ThrowOnMappingNullMismatch);
+        GetNullFallbackValue(targetType ?? Target, Configuration.Mapper.ThrowOnMappingNullMismatch);
 
     public (FormatProvider? formatProvider, bool isDefault) GetFormatProvider(string? formatProviderName)
     {

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/DirectAssignmentMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/DirectAssignmentMappingBuilder.cs
@@ -10,7 +10,7 @@ public static class DirectAssignmentMappingBuilder
     {
         return
             SymbolEqualityComparer.IncludeNullability.Equals(ctx.Source, ctx.Target)
-            && (!ctx.MapperConfiguration.UseDeepCloning || ctx.Source.IsImmutable())
+            && (!ctx.Configuration.Mapper.UseDeepCloning || ctx.Source.IsImmutable())
             ? new DirectAssignmentMapping(ctx.Source)
             : null;
     }

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
@@ -117,7 +117,7 @@ public static class EnumerableMappingBuilder
         // cannot cast if the method mapping is synthetic, deep clone is enabled or target is an unknown collection
         if (
             !elementMapping.IsSynthetic
-            || ctx.MapperConfiguration.UseDeepCloning
+            || ctx.Configuration.Mapper.UseDeepCloning
             || ctx.CollectionInfos!.Target.CollectionType == CollectionType.None
         )
         {
@@ -219,7 +219,7 @@ public static class EnumerableMappingBuilder
         // use a for loop mapping otherwise.
         if (elementMapping.IsSynthetic)
         {
-            return ctx.MapperConfiguration.UseDeepCloning
+            return ctx.Configuration.Mapper.UseDeepCloning
                 ? new ArrayCloneMapping(ctx.Source, ctx.Target)
                 : new CastMapping(ctx.Source, ctx.Target);
         }
@@ -350,7 +350,7 @@ public static class EnumerableMappingBuilder
         // if the target is an IEnumerable<T> don't collect at all
         // except deep cloning is enabled.
         var targetIsIEnumerable = ctx.CollectionInfos!.Target.CollectionType == CollectionType.IEnumerable;
-        if (targetIsIEnumerable && !ctx.MapperConfiguration.UseDeepCloning)
+        if (targetIsIEnumerable && !ctx.Configuration.Mapper.UseDeepCloning)
             return (true, null);
 
         // if the target is IReadOnlyCollection<T> or IEnumerable<T>

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/ExplicitCastMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/ExplicitCastMappingBuilder.cs
@@ -13,7 +13,7 @@ public static class ExplicitCastMappingBuilder
         if (!ctx.IsConversionEnabled(MappingConversionType.ExplicitCast))
             return null;
 
-        if (ctx.MapperConfiguration.UseDeepCloning && !ctx.Source.IsImmutable() && !ctx.Target.IsImmutable())
+        if (ctx.Configuration.Mapper.UseDeepCloning && !ctx.Source.IsImmutable() && !ctx.Target.IsImmutable())
             return null;
 
         // ClassifyConversion does not check if tuple field member names are the same

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/ImplicitCastMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/ImplicitCastMappingBuilder.cs
@@ -11,7 +11,7 @@ public static class ImplicitCastMappingBuilder
         if (!ctx.IsConversionEnabled(MappingConversionType.ImplicitCast))
             return null;
 
-        if (ctx.MapperConfiguration.UseDeepCloning && !ctx.Source.IsImmutable() && !ctx.Target.IsImmutable())
+        if (ctx.Configuration.Mapper.UseDeepCloning && !ctx.Source.IsImmutable() && !ctx.Target.IsImmutable())
             return null;
 
         // ClassifyConversion does not check if tuple field member names are the same

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/MemoryMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/MemoryMappingBuilder.cs
@@ -106,7 +106,7 @@ public static class MemoryMappingBuilder
 
     private static NewInstanceMapping? BuildSpanToMemoryMapping(MappingBuilderContext ctx, INewInstanceMapping elementMapping)
     {
-        if (elementMapping.IsSynthetic && !ctx.MapperConfiguration.UseDeepCloning)
+        if (elementMapping.IsSynthetic && !ctx.Configuration.Mapper.UseDeepCloning)
             return new SourceObjectMethodMapping(ctx.Source, ctx.Target, ToArrayMethodName);
 
         var targetArray = ctx.Types.GetArrayType(elementMapping.TargetType);
@@ -117,7 +117,7 @@ public static class MemoryMappingBuilder
 
     private static NewInstanceMapping? BuildMemoryToArrayMapping(MappingBuilderContext ctx, INewInstanceMapping elementMapping)
     {
-        if (!elementMapping.IsSynthetic || ctx.MapperConfiguration.UseDeepCloning)
+        if (!elementMapping.IsSynthetic || ctx.Configuration.Mapper.UseDeepCloning)
             return BuildSpanToArrayMethodMapping(ctx, elementMapping);
 
         return new SourceObjectMethodMapping(ctx.Source, ctx.Target, ToArrayMethodName);
@@ -125,7 +125,7 @@ public static class MemoryMappingBuilder
 
     private static NewInstanceMapping? BuildMemoryToSpanMapping(MappingBuilderContext ctx, INewInstanceMapping elementMapping)
     {
-        if (!elementMapping.IsSynthetic || ctx.MapperConfiguration.UseDeepCloning)
+        if (!elementMapping.IsSynthetic || ctx.Configuration.Mapper.UseDeepCloning)
             return BuildMemoryToSpanMethod(ctx, elementMapping);
 
         return new SourceObjectMemberMapping(ctx.Source, ctx.Target, SpanMemberName);
@@ -133,7 +133,7 @@ public static class MemoryMappingBuilder
 
     private static INewInstanceMapping BuildArrayToMemoryMapping(MappingBuilderContext ctx, INewInstanceMapping elementMapping)
     {
-        if (!elementMapping.IsSynthetic || ctx.MapperConfiguration.UseDeepCloning)
+        if (!elementMapping.IsSynthetic || ctx.Configuration.Mapper.UseDeepCloning)
             return new ArrayForMapping(
                 ctx.Source,
                 ctx.Types.GetArrayType(elementMapping.TargetType),
@@ -155,7 +155,7 @@ public static class MemoryMappingBuilder
 
     private static NewInstanceMapping? BuildMemoryToMemoryMapping(MappingBuilderContext ctx, INewInstanceMapping elementMapping)
     {
-        if (!elementMapping.IsSynthetic || ctx.MapperConfiguration.UseDeepCloning)
+        if (!elementMapping.IsSynthetic || ctx.Configuration.Mapper.UseDeepCloning)
             return BuildSpanToArrayMethodMapping(ctx, elementMapping);
 
         return new CastMapping(ctx.Source, ctx.Target);

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/NewInstanceObjectMemberMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/NewInstanceObjectMemberMappingBuilder.cs
@@ -21,7 +21,7 @@ public static class NewInstanceObjectMemberMappingBuilder
                 ctx.Source,
                 ctx.Target.NonNullable(),
                 objectFactory,
-                ctx.MapperConfiguration.UseReferenceHandling
+                ctx.Configuration.Mapper.UseReferenceHandling
             );
 
         if (
@@ -52,7 +52,7 @@ public static class NewInstanceObjectMemberMappingBuilder
         // and can only map to properties via object initializers.
         return ctx.IsExpression
             ? new NewInstanceObjectMemberMapping(ctx.Source, ctx.Target.NonNullable())
-            : new NewInstanceObjectMemberMethodMapping(ctx.Source, ctx.Target.NonNullable(), ctx.MapperConfiguration.UseReferenceHandling);
+            : new NewInstanceObjectMemberMethodMapping(ctx.Source, ctx.Target.NonNullable(), ctx.Configuration.Mapper.UseReferenceHandling);
     }
 
     public static IExistingTargetMapping? TryBuildExistingTargetMapping(MappingBuilderContext ctx)

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/QueryableMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/QueryableMappingBuilder.cs
@@ -27,7 +27,7 @@ public static class QueryableMappingBuilder
         if (mapping == null)
             return null;
 
-        if (ctx.MapperConfiguration.UseReferenceHandling)
+        if (ctx.Configuration.Mapper.UseReferenceHandling)
         {
             ctx.ReportDiagnostic(DiagnosticDescriptors.QueryableProjectionMappingsDoNotSupportReferenceHandling);
         }

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/SpanMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/SpanMappingBuilder.cs
@@ -47,7 +47,7 @@ public static class SpanMappingBuilder
             // if the source is Span/ReadOnlySpan or Array and target is Span/ReadOnlySpan
             // and element type is the same, then direct cast
             (CollectionType.Span or CollectionType.ReadOnlySpan or CollectionType.Array, CollectionType.Span or CollectionType.ReadOnlySpan)
-                when elementMapping.IsSynthetic && !ctx.MapperConfiguration.UseDeepCloning
+                when elementMapping.IsSynthetic && !ctx.Configuration.Mapper.UseDeepCloning
                 => new CastMapping(ctx.Source, ctx.Target),
 
             // otherwise map each value into an Array

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/ToObjectMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/ToObjectMappingBuilder.cs
@@ -15,7 +15,7 @@ public static class ToObjectMappingBuilder
         if (ctx.Target.SpecialType != SpecialType.System_Object)
             return null;
 
-        if (!ctx.MapperConfiguration.UseDeepCloning)
+        if (!ctx.Configuration.Mapper.UseDeepCloning)
             return new CastMapping(ctx.Source, ctx.Target);
 
         if (ctx.Source.SpecialType == SpecialType.System_Object)

--- a/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
@@ -43,7 +43,7 @@ public class SimpleMappingBuilderContext(
 
     public Compilation Compilation => _compilationContext.Compilation;
 
-    public MapperAttribute MapperConfiguration => _configurationReader.Mapper;
+    public MappingConfiguration Configuration { get; protected init; } = configurationReader.MapperConfiguration;
 
     public WellKnownTypes Types => _compilationContext.Types;
 
@@ -58,10 +58,11 @@ public class SimpleMappingBuilderContext(
     protected ExistingTargetMappingBuilder ExistingTargetMappingBuilder { get; } = existingTargetMappingBuilder;
 
     public virtual bool IsConversionEnabled(MappingConversionType conversionType) =>
-        MapperConfiguration.EnabledConversions.HasFlag(conversionType);
+        Configuration.Mapper.EnabledConversions.HasFlag(conversionType);
 
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, ISymbol? symbolLocation, params object[] messageArgs) =>
         _diagnostics.ReportDiagnostic(descriptor, symbolLocation?.GetSyntaxLocation() ?? _diagnosticLocation, messageArgs);
 
-    protected MappingConfiguration ReadConfiguration(MappingConfigurationReference configRef) => _configurationReader.BuildFor(configRef);
+    protected MappingConfiguration ReadConfiguration(MappingConfigurationReference configRef) =>
+        _configurationReader.BuildFor(configRef, _diagnostics);
 }

--- a/src/Riok.Mapperly/Descriptors/UserMethodMappingExtractor.cs
+++ b/src/Riok.Mapperly/Descriptors/UserMethodMappingExtractor.cs
@@ -148,7 +148,7 @@ public static class UserMethodMappingExtractor
             return new UserDefinedNewInstanceRuntimeTargetTypeParameterMapping(
                 methodSymbol,
                 runtimeTargetTypeParams,
-                ctx.MapperConfiguration.UseReferenceHandling,
+                ctx.Configuration.Mapper.UseReferenceHandling,
                 ctx.SymbolAccessor.UpgradeNullable(methodSymbol.ReturnType),
                 GetTypeSwitchNullArm(methodSymbol, runtimeTargetTypeParams, null),
                 ctx.Compilation.ObjectType.WithNullableAnnotation(NullableAnnotation.NotAnnotated)
@@ -168,7 +168,7 @@ public static class UserMethodMappingExtractor
                 typeParameters.Value,
                 parameters,
                 ctx.SymbolAccessor.UpgradeNullable(methodSymbol.ReturnType),
-                ctx.MapperConfiguration.UseReferenceHandling,
+                ctx.Configuration.Mapper.UseReferenceHandling,
                 GetTypeSwitchNullArm(methodSymbol, parameters, typeParameters),
                 ctx.Compilation.ObjectType.WithNullableAnnotation(NullableAnnotation.NotAnnotated)
             );
@@ -187,7 +187,7 @@ public static class UserMethodMappingExtractor
                 parameters.Source,
                 parameters.Target.Value,
                 parameters.ReferenceHandler,
-                ctx.MapperConfiguration.UseReferenceHandling
+                ctx.Configuration.Mapper.UseReferenceHandling
             );
         }
 
@@ -198,7 +198,7 @@ public static class UserMethodMappingExtractor
             parameters.Source,
             parameters.ReferenceHandler,
             ctx.SymbolAccessor.UpgradeNullable(methodSymbol.ReturnType),
-            ctx.MapperConfiguration.UseReferenceHandling
+            ctx.Configuration.Mapper.UseReferenceHandling
         );
     }
 
@@ -368,7 +368,7 @@ public static class UserMethodMappingExtractor
             );
         }
 
-        if (!ctx.MapperConfiguration.UseReferenceHandling)
+        if (!ctx.Configuration.Mapper.UseReferenceHandling)
         {
             ctx.ReportDiagnostic(
                 DiagnosticDescriptors.ReferenceHandlingNotEnabled,
@@ -399,6 +399,6 @@ public static class UserMethodMappingExtractor
     {
         var userMappingAttr = ctx.AttributeAccessor.AccessFirstOrDefault<UserMappingAttribute, UserMappingConfiguration>(method);
         hasAttribute = userMappingAttr != null;
-        return userMappingAttr ?? new UserMappingConfiguration { Ignore = !ctx.MapperConfiguration.AutoUserMappings, };
+        return userMappingAttr ?? new UserMappingConfiguration { Ignore = !ctx.Configuration.Mapper.AutoUserMappings, };
     }
 }

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -545,4 +545,31 @@ public static class DiagnosticDescriptors
         DiagnosticSeverity.Error,
         true
     );
+
+    public static readonly DiagnosticDescriptor EnumConfigurationOnNonEnumMapping = new DiagnosticDescriptor(
+        "RMG063",
+        "Cannot configure an enum mapping on a non-enum mapping",
+        "Cannot configure an enum mapping on a non-enum mapping",
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Error,
+        true
+    );
+
+    public static readonly DiagnosticDescriptor MemberConfigurationOnNonMemberMapping = new DiagnosticDescriptor(
+        "RMG064",
+        "Cannot configure an object mapping on a non-object mapping",
+        "Cannot configure an object mapping on a non-object mapping",
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Error,
+        true
+    );
+
+    public static readonly DiagnosticDescriptor MemberConfigurationOnQueryableProjectionMapping = new DiagnosticDescriptor(
+        "RMG065",
+        "Cannot configure an object mapping on a queryable projection mapping, apply the configurations to an object mapping method instead",
+        "Cannot configure an object mapping on a queryable projection mapping, apply the configurations to an object mapping method instead",
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Warning,
+        true
+    );
 }

--- a/test/Riok.Mapperly.Tests/Mapping/EnumTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumTest.cs
@@ -432,4 +432,19 @@ public class EnumTest
 
         return TestHelper.VerifyGenerator(source, null, testCase);
     }
+
+    [Fact]
+    public void EnumConfigurationOnNonEnumMethodShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapEnum(EnumMappingStrategy.ByValue)] partial B Map(A source);",
+            "record A(int V);",
+            "record B(int V);"
+        );
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.EnumConfigurationOnNonEnumMapping)
+            .HaveAssertedAllDiagnostics();
+    }
 }


### PR DESCRIPTION
Closes https://github.com/riok/mapperly/issues/868

* Refactors and simplifies the internal configuration mechanisms
* Emits diagnostics if property configurations are placed on queryable projection mappings
* Emits diagnostics if enum configurations are placed on object mappings
* Emits diagnostics if property configurations are placed on enum mappings