### PR TITLE
feat: report a diagnostic for invalid MapPropertyAttribute usages

### DIFF
--- a/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
@@ -151,3 +151,4 @@ RMG063  | Mapper   | Error    | Cannot configure an enum mapping on a non-enum m
 RMG064  | Mapper   | Error    | Cannot configure an object mapping on a non-object mapping
 RMG065  | Mapper   | Warning  | Cannot configure an object mapping on a queryable projection mapping, apply the configurations to an object mapping method instead
 RMG066  | Mapper   | Warning | No members are mapped in an object mapping
+RMG067  | Mapper   | Error    | Invalid usage of the MapPropertyAttribute

--- a/src/Riok.Mapperly/Configuration/MapperConfigurationReader.cs
+++ b/src/Riok.Mapperly/Configuration/MapperConfigurationReader.cs
@@ -106,6 +106,11 @@ public class MapperConfigurationReader
             return MapperConfiguration.Members;
         }
 
+        foreach (var invalidMemberConfigs in memberConfigurations.Where(x => !x.IsValid))
+        {
+            diagnostics.ReportDiagnostic(DiagnosticDescriptors.InvalidMapPropertyAttributeUsage, invalidMemberConfigs.Location);
+        }
+
         return new MembersMappingConfiguration(
             ignoredSourceMembers,
             ignoredTargetMembers,

--- a/src/Riok.Mapperly/Configuration/MemberMappingConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/MemberMappingConfiguration.cs
@@ -10,5 +10,7 @@ public record MemberMappingConfiguration(StringMemberPath Source, StringMemberPa
 
     public string? Use { get; set; }
 
+    public bool IsValid => Use == null || FormatProvider == null && StringFormat == null;
+
     public TypeMappingConfiguration ToTypeMappingConfiguration() => new(StringFormat, FormatProvider, Use);
 }

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -583,6 +583,15 @@ public static class DiagnosticDescriptors
         helpLinkUri: BuildHelpUri("RMG066")
     );
 
+    public static readonly DiagnosticDescriptor InvalidMapPropertyAttributeUsage = new DiagnosticDescriptor(
+        "RMG067",
+        "Invalid usage of the MapPropertyAttribute",
+        "Invalid usage of the MapPropertyAttribute",
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Error,
+        true
+    );
+
     private static string BuildHelpUri(string id)
     {
 #if ENV_NEXT

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
@@ -496,4 +496,25 @@ public class ObjectPropertyTest
                 """
             );
     }
+
+    [Fact]
+    public void InvalidMapPropertyAttributeUsageShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapProperty("IntValue", "StringValue", StringFormat = "D", Use = nameof(IntToString))]
+            partial B Map(A src);
+
+            string IntToString(int x) => x.ToString();
+            """,
+            "class A { public int IntValue { get; set; } }",
+            "class B { public string StringValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.InvalidMapPropertyAttributeUsage, "Invalid usage of the MapPropertyAttribute")
+            .HaveAssertedAllDiagnostics();
+    }
 }


### PR DESCRIPTION
Adds a new diagnostic for invalid map property attribute usages (eg. when using Use and StringFormat at the same time).