### PR TITLE
docs: Typo on the word 'member' in mapper.mdx

### DIFF
--- a/docs/docs/configuration/mapper.mdx
+++ b/docs/docs/configuration/mapper.mdx
@@ -68,7 +68,7 @@ public partial class CarMapper
 }
 ```
 
-#### Ignore a memeber at definition
+#### Ignore a member at definition
 
 To ignore a property or field at definition, the `MapperIgnoreAttribute` can be used.
 


### PR DESCRIPTION
Small fix in spelling.