### PR TITLE
feat: add a warning when a referenced mapping types do not match

### DIFF
--- a/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
@@ -155,4 +155,13 @@ RMG067  | Mapper   | Error    | Invalid usage of the MapPropertyAttribute
 RMG068  | Mapper   | Info     | Cannot inline user implemented queryable expression mapping
 RMG069  | Mapper   | Warning  | Runtime target type or generic type mapping does not match any mappings
 RMG070  | Mapper   | Error    | Mapping nested member not found
+
+## Release 3.6
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
 RMG071  | Mapper   | Warning  | Nested properties mapping is not used
+RMG072  | Mapper   | Warning  | The source type of the referenced mapping does not match
+RMG073  | Mapper   | Warning  | The target type of the referenced mapping does not match

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/UseNamedMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/UseNamedMappingBuilder.cs
@@ -39,8 +39,16 @@ public static class UseNamedMappingBuilder
 
     private static INewInstanceMapping? TryMapTarget(MappingBuilderContext ctx, INewInstanceMapping mapping)
     {
-        if (SymbolEqualityComparer.IncludeNullability.Equals(ctx.Target, mapping.TargetType))
-            return mapping;
+        // only report if there are other differences than nullability
+        if (!SymbolEqualityComparer.Default.Equals(ctx.Target, mapping.TargetType))
+        {
+            ctx.ReportDiagnostic(
+                DiagnosticDescriptors.ReferencedMappingTargetTypeMismatch,
+                ctx.MappingKey.Configuration.UseNamedMapping!,
+                mapping.TargetType.ToDisplayString(),
+                ctx.Target.ToDisplayString()
+            );
+        }
 
         var outputMapping = ctx.FindOrBuildMapping(mapping.TargetType, ctx.Target);
         if (outputMapping == null)
@@ -58,6 +66,17 @@ public static class UseNamedMappingBuilder
 
     private static INewInstanceMapping? TryMapSource(MappingBuilderContext ctx, INewInstanceMapping mapping)
     {
+        // only report if there are other differences than nullability
+        if (!SymbolEqualityComparer.Default.Equals(ctx.Source, mapping.SourceType))
+        {
+            ctx.ReportDiagnostic(
+                DiagnosticDescriptors.ReferencedMappingSourceTypeMismatch,
+                ctx.MappingKey.Configuration.UseNamedMapping!,
+                mapping.SourceType.ToDisplayString(),
+                ctx.Source.ToDisplayString()
+            );
+        }
+
         var inputMapping = ctx.FindOrBuildMapping(ctx.Source, mapping.SourceType);
         if (inputMapping == null)
         {

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -697,6 +697,26 @@ public static class DiagnosticDescriptors
             true
         );
 
+    public static readonly DiagnosticDescriptor ReferencedMappingSourceTypeMismatch =
+        new(
+            "RMG072",
+            "The source type of the referenced mapping does not match",
+            "The source type {1} of the referenced mapping {0} does not match the expected type {2}",
+            DiagnosticCategories.Mapper,
+            DiagnosticSeverity.Warning,
+            true
+        );
+
+    public static readonly DiagnosticDescriptor ReferencedMappingTargetTypeMismatch =
+        new(
+            "RMG073",
+            "The target type of the referenced mapping does not match",
+            "The target type {1} of the referenced mapping {0} does not match the expected type {2}",
+            DiagnosticCategories.Mapper,
+            DiagnosticSeverity.Warning,
+            true
+        );
+
     private static string BuildHelpUri(string id)
     {
 #if ENV_NEXT

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectNestedPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectNestedPropertyTest.cs
@@ -213,7 +213,7 @@ public class ObjectNestedPropertyTest
     }
 
     [Fact]
-    public void NestedPropertyWithMemberNameOfSource_CaseInsensitiveNameMappingStrategy()
+    public void NestedPropertyWithMemberNameOfSourceAndCaseInsensitiveNameMappingStrategy()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             "[MapNestedProperties(nameof(A.Value))] partial B Map(A source);",

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyUseNamedMappingTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyUseNamedMappingTest.cs
@@ -195,8 +195,10 @@ public class ObjectPropertyUseNamedMappingTest
             "record B(string V);"
         );
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.ReferencedMappingSourceTypeMismatch)
+            .HaveAssertedAllDiagnostics()
             .HaveMapMethodBody(
                 """
                 var target = new global::B(MyMapping(source.V.ToString()));
@@ -224,6 +226,10 @@ public class ObjectPropertyUseNamedMappingTest
                 DiagnosticDescriptors.CouldNotCreateMapping,
                 "Could not create mapping from object to byte. Consider implementing the mapping manually."
             )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.ReferencedMappingSourceTypeMismatch,
+                "The source type byte of the referenced mapping MyMapping does not match the expected type object"
+            )
             .HaveAssertedAllDiagnostics()
             .HaveMapMethodBody(
                 """
@@ -246,8 +252,10 @@ public class ObjectPropertyUseNamedMappingTest
             "record B(int V);"
         );
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.ReferencedMappingTargetTypeMismatch)
+            .HaveAssertedAllDiagnostics()
             .HaveMapMethodBody(
                 """
                 var target = new global::B(int.Parse(MyMapping(source.V)));
@@ -275,6 +283,10 @@ public class ObjectPropertyUseNamedMappingTest
                 DiagnosticDescriptors.CouldNotCreateMapping,
                 "Could not create mapping from object to byte. Consider implementing the mapping manually."
             )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.ReferencedMappingTargetTypeMismatch,
+                "The target type object of the referenced mapping MyMapping does not match the expected type byte"
+            )
             .HaveAssertedAllDiagnostics()
             .HaveMapMethodBody(
                 """
@@ -297,8 +309,11 @@ public class ObjectPropertyUseNamedMappingTest
             "record B(int V);"
         );
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.ReferencedMappingSourceTypeMismatch)
+            .HaveDiagnostic(DiagnosticDescriptors.ReferencedMappingTargetTypeMismatch)
+            .HaveAssertedAllDiagnostics()
             .HaveMapMethodBody(
                 """
                 var target = new global::B(int.Parse(MyMapping(source.V.ToString())));


### PR DESCRIPTION
Adds warnings `RMG072` and `RMG073` when the types of a referenced mapping do not exactly match (except for nullability)  the member types.

Closes #1254