### PR TITLE
docs: improve mapper ignore attribute description

### DIFF
--- a/docs/docs/configuration/mapper.mdx
+++ b/docs/docs/configuration/mapper.mdx
@@ -94,6 +94,11 @@ public class CarDto
 }
 ```
 
+If you want to use the `MapperIgnoreAttribute` in another .NET Project than the Mapper itself,
+that project needs to preserve the Mapperly attributes at runtime,
+see [preserving Mapperly attributes at runtime](../getting-started/installation.mdx#preserving-the-attributes-at-runtime).
+Without this, the `MapperIgnoreAttribute` is not visible to Mapperly.
+
 #### Ignore obsolete members
 
 By default, Mapperly will map source/target members marked with `ObsoleteAttribute`.


### PR DESCRIPTION
Note that the runtime attribute scope needs to be set if the mapper ignore attribute is in another dll
Relates #1252