### PR TITLE
fix: fixes using the wrong object factory when multiple factories with the same target type but different source types are used

### DIFF
--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/ObjectFactoryCollection.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/ObjectFactoryCollection.cs
@@ -5,18 +5,19 @@ namespace Riok.Mapperly.Descriptors.ObjectFactories;
 
 public class ObjectFactoryCollection(IReadOnlyCollection<ObjectFactory> objectFactories)
 {
-    private readonly Dictionary<ITypeSymbol, ObjectFactory> _concreteObjectFactories = new(SymbolEqualityComparer.IncludeNullability);
+    private readonly Dictionary<TypeMappingKey, ObjectFactory> _concreteObjectFactories = new();
 
     public bool TryFindObjectFactory(ITypeSymbol sourceType, ITypeSymbol targetType, [NotNullWhen(true)] out ObjectFactory? objectFactory)
     {
-        if (_concreteObjectFactories.TryGetValue(targetType, out objectFactory))
+        var key = new TypeMappingKey(sourceType, targetType);
+        if (_concreteObjectFactories.TryGetValue(key, out objectFactory))
             return true;
 
         objectFactory = objectFactories.FirstOrDefault(f => f.CanCreateType(sourceType, targetType));
         if (objectFactory == null)
             return false;
 
-        _concreteObjectFactories[targetType] = objectFactory;
+        _concreteObjectFactories[key] = objectFactory;
         return true;
     }
 }


### PR DESCRIPTION
Includes the source and target type when caching the resolved object factory for a given type pair instead of only the target type. This fixes a bug when using multiple object factories with the same return type but different parameter types and multiple mappings using these different object factories.

Fixes #1312 