### PR TITLE
fix: adjust diagnostic messages to be correct when applied with MapValue

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
@@ -157,8 +157,8 @@ public static class ObjectMemberMappingBodyBuilder
         {
             ctx.BuilderContext.ReportDiagnostic(
                 DiagnosticDescriptors.CannotMapToInitOnlyMemberPath,
-                sourceMemberPath.ToDisplayString(),
-                targetMemberPath.ToDisplayString()
+                sourceMemberPath.ToDisplayString(includeMemberType: false),
+                targetMemberPath.ToDisplayString(includeMemberType: false)
             );
             return false;
         }

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -89,7 +89,7 @@ public static class DiagnosticDescriptors
         new(
             "RMG009",
             "Cannot map to read only member",
-            "Cannot map member {0} to read only member {1}",
+            "Cannot map {0} to read only member {1}",
             DiagnosticCategories.Mapper,
             DiagnosticSeverity.Info,
             true
@@ -109,7 +109,7 @@ public static class DiagnosticDescriptors
         new(
             "RMG011",
             "Cannot map to write only member path",
-            "Cannot map from member {0} to write only member path {1}",
+            "Cannot map from {0} to write only member path {1}",
             DiagnosticCategories.Mapper,
             DiagnosticSeverity.Info,
             true
@@ -149,7 +149,7 @@ public static class DiagnosticDescriptors
         new(
             "RMG015",
             "Cannot map to init only member path",
-            "Cannot map from member {0} to init only member path {1}",
+            "Cannot map from {0} to init only member path {1}",
             DiagnosticCategories.Mapper,
             DiagnosticSeverity.Info,
             true
@@ -469,7 +469,7 @@ public static class DiagnosticDescriptors
         new(
             "RMG049",
             "Source member is ignored and also explicitly mapped",
-            "The source member {0} on {1} is ignored, but is also mapped by the " + nameof(MapPropertyAttribute),
+            "The source member {0} on {1} is ignored, but is also mapped explicitly",
             DiagnosticCategories.Mapper,
             DiagnosticSeverity.Warning,
             true
@@ -479,7 +479,7 @@ public static class DiagnosticDescriptors
         new(
             "RMG050",
             "Target member is ignored and also explicitly mapped",
-            "The target member {0} on {1} is ignored, but is also mapped by the " + nameof(MapPropertyAttribute),
+            "The target member {0} on {1} is ignored, but is also mapped explicitly",
             DiagnosticCategories.Mapper,
             DiagnosticSeverity.Warning,
             true
@@ -650,8 +650,8 @@ public static class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor InvalidMapPropertyAttributeUsage =
         new(
             "RMG067",
-            "Invalid usage of the MapPropertyAttribute",
-            "Invalid usage of the MapPropertyAttribute",
+            "Invalid usage of the " + nameof(MapPropertyAttribute),
+            "Invalid usage of the " + nameof(MapPropertyAttribute),
             DiagnosticCategories.Mapper,
             DiagnosticSeverity.Error,
             true

--- a/test/Riok.Mapperly.Tests/Mapping/IgnoreAttributeTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/IgnoreAttributeTest.cs
@@ -70,11 +70,11 @@ public class IgnoreAttributeTest
             )
             .HaveDiagnostic(
                 DiagnosticDescriptors.IgnoredSourceMemberExplicitlyMapped,
-                "The source member Ignored on A is ignored, but is also mapped by the MapPropertyAttribute"
+                "The source member Ignored on A is ignored, but is also mapped explicitly"
             )
             .HaveDiagnostic(
                 DiagnosticDescriptors.IgnoredTargetMemberExplicitlyMapped,
-                "The target member Ignored on B is ignored, but is also mapped by the MapPropertyAttribute"
+                "The target member Ignored on B is ignored, but is also mapped explicitly"
             )
             .HaveAssertedAllDiagnostics();
     }

--- a/test/Riok.Mapperly.Tests/Mapping/IgnoreObsoleteTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/IgnoreObsoleteTest.cs
@@ -256,11 +256,11 @@ public class IgnoreObsoleteTest
             )
             .HaveDiagnostic(
                 DiagnosticDescriptors.IgnoredSourceMemberExplicitlyMapped,
-                "The source member Ignored on A is ignored, but is also mapped by the MapPropertyAttribute"
+                "The source member Ignored on A is ignored, but is also mapped explicitly"
             )
             .HaveDiagnostic(
                 DiagnosticDescriptors.IgnoredTargetMemberExplicitlyMapped,
-                "The target member Ignored on B is ignored, but is also mapped by the MapPropertyAttribute"
+                "The target member Ignored on B is ignored, but is also mapped explicitly"
             )
             .HaveAssertedAllDiagnostics();
     }
@@ -291,7 +291,7 @@ public class IgnoreObsoleteTest
             )
             .HaveDiagnostic(
                 DiagnosticDescriptors.IgnoredSourceMemberExplicitlyMapped,
-                "The source member Ignored on A is ignored, but is also mapped by the MapPropertyAttribute"
+                "The source member Ignored on A is ignored, but is also mapped explicitly"
             )
             .HaveAssertedAllDiagnostics();
     }
@@ -322,7 +322,7 @@ public class IgnoreObsoleteTest
             )
             .HaveDiagnostic(
                 DiagnosticDescriptors.IgnoredTargetMemberExplicitlyMapped,
-                "The target member Ignored on B is ignored, but is also mapped by the MapPropertyAttribute"
+                "The target member Ignored on B is ignored, but is also mapped explicitly"
             )
             .HaveAssertedAllDiagnostics();
     }
@@ -363,7 +363,7 @@ public class IgnoreObsoleteTest
             )
             .HaveDiagnostic(
                 DiagnosticDescriptors.IgnoredTargetMemberExplicitlyMapped,
-                "The target member Ignored on B is ignored, but is also mapped by the MapPropertyAttribute"
+                "The target member Ignored on B is ignored, but is also mapped explicitly"
             )
             .HaveAssertedAllDiagnostics();
     }
@@ -404,7 +404,7 @@ public class IgnoreObsoleteTest
             )
             .HaveDiagnostic(
                 DiagnosticDescriptors.IgnoredTargetMemberExplicitlyMapped,
-                "The target member Ignored on B is ignored, but is also mapped by the MapPropertyAttribute"
+                "The target member Ignored on B is ignored, but is also mapped explicitly"
             )
             .HaveAssertedAllDiagnostics();
     }

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyInitPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyInitPropertyTest.cs
@@ -216,7 +216,7 @@ public class ObjectPropertyInitPropertyTest
             .Should()
             .HaveDiagnostic(
                 DiagnosticDescriptors.CannotMapToInitOnlyMemberPath,
-                "Cannot map from member A.StringValue of type string to init only member path B.StringValue of type string"
+                "Cannot map from A.StringValue to init only member path B.StringValue"
             )
             .HaveDiagnostic(
                 DiagnosticDescriptors.SourceMemberNotMapped,
@@ -253,7 +253,7 @@ public class ObjectPropertyInitPropertyTest
     public Task InitOnlyPropertyWithMultipleConfigurationsShouldDiagnostic()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
-            "[MapProperty($\"StringValue2\", \"StringValue\")] [MapProperty($\"StringValue3\", \"StringValue\")] private partial B Map(A source);",
+            "[MapProperty(\"StringValue2\", \"StringValue\")] [MapProperty(\"StringValue3\", \"StringValue\")] private partial B Map(A source);",
             "class A { public string StringValue2 { get; init; } public string StringValue3 { get; init; } }",
             "class B { public string StringValue { get; init; } }"
         );
@@ -265,7 +265,7 @@ public class ObjectPropertyInitPropertyTest
     public Task InitOnlyPropertyWithPathConfigurationsShouldDiagnostic()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
-            "[MapProperty($\"NestedValue\", \"Nested.Value\")] private partial B Map(A source);",
+            "[MapProperty(\"NestedValue\", \"Nested.Value\")] private partial B Map(A source);",
             "class A { public string NestedValue { get; init; } }",
             "class B { public C Nested { get; init; } }",
             "class C { public string Value { get; init; } }"
@@ -278,7 +278,7 @@ public class ObjectPropertyInitPropertyTest
     public Task InitOnlyPropertyWithConfigurationNotFoundSourcePropertyShouldDiagnostic()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
-            "[MapProperty($\"StringValue2\", \"StringValue\")] private partial B Map(A source);",
+            "[MapProperty(\"StringValue2\", \"StringValue\")] private partial B Map(A source);",
             "class A { public string StringValue { get; init; } }",
             "class B { public string StringValue { get; init; } }"
         );
@@ -366,7 +366,7 @@ public class ObjectPropertyInitPropertyTest
             )
             .HaveDiagnostic(
                 DiagnosticDescriptors.IgnoredTargetMemberExplicitlyMapped,
-                "The target member StringValue on B is ignored, but is also mapped by the MapPropertyAttribute"
+                "The target member StringValue on B is ignored, but is also mapped explicitly"
             )
             .HaveAssertedAllDiagnostics();
     }
@@ -401,7 +401,7 @@ public class ObjectPropertyInitPropertyTest
             )
             .HaveDiagnostic(
                 DiagnosticDescriptors.IgnoredTargetMemberExplicitlyMapped,
-                "The target member StringValue on B is ignored, but is also mapped by the MapPropertyAttribute"
+                "The target member StringValue on B is ignored, but is also mapped explicitly"
             )
             .HaveAssertedAllDiagnostics();
     }

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyFlatteningTest.ManualUnflattenedPropertyTargetPropertyPathWriteOnlyShouldDiagnostic.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyFlatteningTest.ManualUnflattenedPropertyTargetPropertyPathWriteOnlyShouldDiagnostic.verified.txt
@@ -6,8 +6,8 @@
       Severity: Info,
       WarningLevel: 1,
       Location: : (11,4)-(11,76),
-      MessageFormat: Cannot map from member {0} to write only member path {1},
-      Message: Cannot map from member A.MyValueId of type string to write only member path B.Value.Id of type string,
+      MessageFormat: Cannot map from {0} to write only member path {1},
+      Message: Cannot map from A.MyValueId of type string to write only member path B.Value.Id of type string,
       Category: Mapper
     },
     {

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyInitPropertyTest.InitOnlyPropertyWithConfigurationNotFoundSourcePropertyShouldDiagnostic.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyInitPropertyTest.InitOnlyPropertyWithConfigurationNotFoundSourcePropertyShouldDiagnostic.verified.txt
@@ -5,7 +5,7 @@
       Title: Source member was not found for target member,
       Severity: Info,
       WarningLevel: 1,
-      Location: : (11,4)-(11,82),
+      Location: : (11,4)-(11,81),
       MessageFormat: The member {0} on the mapping target type {1} was not found on the mapping source type {2},
       Message: The member StringValue on the mapping target type B was not found on the mapping source type A,
       Category: Mapper
@@ -15,7 +15,7 @@
       Title: Source member is not mapped to any target member,
       Severity: Info,
       WarningLevel: 1,
-      Location: : (11,4)-(11,82),
+      Location: : (11,4)-(11,81),
       MessageFormat: The member {0} on the mapping source type {1} is not mapped to any member on the mapping target type {2},
       Message: The member StringValue on the mapping source type A is not mapped to any member on the mapping target type B,
       Category: Mapper
@@ -25,7 +25,7 @@
       Title: No members are mapped in an object mapping,
       Severity: Warning,
       WarningLevel: 1,
-      Location: : (11,4)-(11,82),
+      Location: : (11,4)-(11,81),
       HelpLink: https://localhost:3000/docs/configuration/analyzer-diagnostics/RMG066,
       MessageFormat: No members are mapped in the object mapping from {0} to {1},
       Message: No members are mapped in the object mapping from A to B,

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyInitPropertyTest.InitOnlyPropertyWithMultipleConfigurationsShouldDiagnostic.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyInitPropertyTest.InitOnlyPropertyWithMultipleConfigurationsShouldDiagnostic.verified.txt
@@ -5,7 +5,7 @@
       Title: An init only member can have one configuration at max,
       Severity: Warning,
       WarningLevel: 1,
-      Location: : (11,4)-(11,128),
+      Location: : (11,4)-(11,126),
       MessageFormat: The init only member {0}.{1} can have one configuration at max,
       Message: The init only member string.StringValue can have one configuration at max,
       Category: Mapper
@@ -15,7 +15,7 @@
       Title: Source member is not mapped to any target member,
       Severity: Info,
       WarningLevel: 1,
-      Location: : (11,4)-(11,128),
+      Location: : (11,4)-(11,126),
       MessageFormat: The member {0} on the mapping source type {1} is not mapped to any member on the mapping target type {2},
       Message: The member StringValue3 on the mapping source type A is not mapped to any member on the mapping target type B,
       Category: Mapper

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyInitPropertyTest.InitOnlyPropertyWithPathConfigurationsShouldDiagnostic.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyInitPropertyTest.InitOnlyPropertyWithPathConfigurationsShouldDiagnostic.verified.txt
@@ -5,7 +5,7 @@
       Title: Init only member cannot handle target paths,
       Severity: Error,
       WarningLevel: 0,
-      Location: : (11,4)-(11,82),
+      Location: : (11,4)-(11,81),
       MessageFormat: Cannot map to init only member path {0}.{1},
       Message: Cannot map to init only member path C.Nested.Value,
       Category: Mapper
@@ -15,7 +15,7 @@
       Title: Source member is not mapped to any target member,
       Severity: Info,
       WarningLevel: 1,
-      Location: : (11,4)-(11,82),
+      Location: : (11,4)-(11,81),
       MessageFormat: The member {0} on the mapping source type {1} is not mapped to any member on the mapping target type {2},
       Message: The member NestedValue on the mapping source type A is not mapped to any member on the mapping target type B,
       Category: Mapper
@@ -25,7 +25,7 @@
       Title: No members are mapped in an object mapping,
       Severity: Warning,
       WarningLevel: 1,
-      Location: : (11,4)-(11,82),
+      Location: : (11,4)-(11,81),
       HelpLink: https://localhost:3000/docs/configuration/analyzer-diagnostics/RMG066,
       MessageFormat: No members are mapped in the object mapping from {0} to {1},
       Message: No members are mapped in the object mapping from A to B,

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.ShouldIgnoreReadOnlyPropertyOnTargetWithDiagnostic.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.ShouldIgnoreReadOnlyPropertyOnTargetWithDiagnostic.verified.txt
@@ -6,8 +6,8 @@
       Severity: Info,
       WarningLevel: 1,
       Location: : (11,4)-(11,36),
-      MessageFormat: Cannot map member {0} to read only member {1},
-      Message: Cannot map member A.StringValue2 of type string to read only member B.StringValue2 of type string,
+      MessageFormat: Cannot map {0} to read only member {1},
+      Message: Cannot map A.StringValue2 of type string to read only member B.StringValue2 of type string,
       Category: Mapper
     },
     {

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.WithPrivateTargetPathGetterShouldIgnoreAndDiagnostic.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.WithPrivateTargetPathGetterShouldIgnoreAndDiagnostic.verified.txt
@@ -6,8 +6,8 @@
       Severity: Info,
       WarningLevel: 1,
       Location: : (11,4)-(11,36),
-      MessageFormat: Cannot map member {0} to read only member {1},
-      Message: Cannot map member A.NestedValue of type C to read only member B.NestedValue of type D,
+      MessageFormat: Cannot map {0} to read only member {1},
+      Message: Cannot map A.NestedValue of type C to read only member B.NestedValue of type D,
       Category: Mapper
     },
     {

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.WithPrivateTargetSetterShouldIgnoreAndDiagnostic.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyTest.WithPrivateTargetSetterShouldIgnoreAndDiagnostic.verified.txt
@@ -6,8 +6,8 @@
       Severity: Info,
       WarningLevel: 1,
       Location: : (11,4)-(11,36),
-      MessageFormat: Cannot map member {0} to read only member {1},
-      Message: Cannot map member A.StringValue of type string to read only member B.StringValue of type string,
+      MessageFormat: Cannot map {0} to read only member {1},
+      Message: Cannot map A.StringValue of type string to read only member B.StringValue of type string,
       Category: Mapper
     },
     {


### PR DESCRIPTION
Rel #631
Removes mentioning "member" and "MapPropertyAttribute" from diagnostic messages as this would be constant values and "MapValueAttribute" with #631 