### PR TITLE
Introduce MapValueAttribute to map constant values and method provided values

### DIFF
--- a/docs/docs/configuration/before-after-map.md
+++ b/docs/docs/configuration/before-after-map.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 description: Run custom logic before or after the generated mapping.
 ---
 

--- a/docs/docs/configuration/constant-generated-values.mdx
+++ b/docs/docs/configuration/constant-generated-values.mdx
@@ -1,0 +1,48 @@
+---
+sidebar_position: 4
+description: Map constant and generated values
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Constant and generated values
+
+## Constant values
+
+To map a constant value to a member or a constructor parameter `MapValue` can be used.
+Make sure the value exactly matches the target type.
+
+<Tabs>
+  <TabItem value="declaration" label="Declaration" default>
+    ```csharp [MapValue(nameof(CarDto.SourceSystem), "C1")] partial CarDto
+    Map(Car car); ```
+  </TabItem>
+  <TabItem value="generated" label="Generated code" default>
+    ```csharp target.SourceSystem = "C1"; ```
+  </TabItem>
+</Tabs>
+
+## Method generated values
+
+To map a method generated value to a member or a constructor parameter `MapValue` can be used.
+Make sure the return type exactly matches the target type.
+
+<Tabs>
+    <TabItem value="declaration" label="Declaration" default>
+        ```csharp
+        [MapValue(nameof(CarDto.SourceSystem), nameof(GetSourceSystem))]
+        partial CarDto Map(Car car);
+
+        string GetSourceSystem() => "C1";
+        ```
+    </TabItem>
+    <TabItem value="generated" label="Generated code" default>
+        ```csharp
+        target.SourceSystem = GetSourceSystem();
+        ```
+    </TabItem>
+
+</Tabs>
+
+This also works for constructor parameters.

--- a/docs/docs/configuration/conversions.md
+++ b/docs/docs/configuration/conversions.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 15
 description: A list of conversions supported by Mapperly
 ---
 

--- a/docs/docs/configuration/ctor-mappings.md
+++ b/docs/docs/configuration/ctor-mappings.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 description: Constructor mappings
 ---
 

--- a/docs/docs/configuration/derived-type-mapping.md
+++ b/docs/docs/configuration/derived-type-mapping.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 description: Map derived types and interfaces
 ---
 

--- a/docs/docs/configuration/enum.mdx
+++ b/docs/docs/configuration/enum.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 description: Map enums
 ---
 

--- a/docs/docs/configuration/existing-target.md
+++ b/docs/docs/configuration/existing-target.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 description: Map to an existing target object
 ---
 

--- a/docs/docs/configuration/flattening.md
+++ b/docs/docs/configuration/flattening.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 description: Flatten properties and fields
 ---
 

--- a/docs/docs/configuration/generated-source.mdx
+++ b/docs/docs/configuration/generated-source.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 17
 description: How to inspect and check in the generated source into a version control system (VCS, GIT, ...)
 ---
 

--- a/docs/docs/configuration/generic-mapping.md
+++ b/docs/docs/configuration/generic-mapping.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 description: Create a generic mapping method
 ---
 

--- a/docs/docs/configuration/object-factories.md
+++ b/docs/docs/configuration/object-factories.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 description: Construct and resolve objects using object factories
 ---
 

--- a/docs/docs/configuration/private-member-mapping.md
+++ b/docs/docs/configuration/private-member-mapping.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 description: Private member mapping
 ---
 

--- a/docs/docs/configuration/queryable-projections.mdx
+++ b/docs/docs/configuration/queryable-projections.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 14
 description: Use queryable projections to map queryable objects and optimize ORM performance
 ---
 

--- a/docs/docs/configuration/reference-handling.md
+++ b/docs/docs/configuration/reference-handling.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 description: Use reference handling to handle reference loops
 ---
 

--- a/docs/docs/configuration/user-implemented-methods.mdx
+++ b/docs/docs/configuration/user-implemented-methods.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 description: Manually implement mappings
 ---
 

--- a/src/Riok.Mapperly.Abstractions/MapValueAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapValueAttribute.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics;
+
+namespace Riok.Mapperly.Abstractions;
+
+/// <summary>
+/// Specifies a constant value mapping.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+[Conditional("MAPPERLY_ABSTRACTIONS_SCOPE_RUNTIME")]
+public sealed class MapValueAttribute : Attribute
+{
+    private const string PropertyAccessSeparatorStr = ".";
+    private const char PropertyAccessSeparator = '.';
+
+    /// <summary>
+    /// Maps a constant value to a target member.
+    /// </summary>
+    /// <param name="target">The target member path.</param>
+    /// <param name="value">The value to assign to the <paramref name="target"/>, needs to be of the same type as the <paramref name="target"/>.</param>
+    public MapValueAttribute(string target, object? value)
+        : this(target.Split(PropertyAccessSeparator), value) { }
+
+    /// <summary>
+    /// Maps a constant value to a target member.
+    /// </summary>
+    /// <param name="target">The target member path.</param>
+    /// <param name="value">The value to assign to the <paramref name="target"/>, needs to be of the same type as the <paramref name="target"/>.</param>
+    public MapValueAttribute(string[] target, object? value)
+    {
+        Target = target;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Maps a method generated value to a target member.
+    /// Requires the usage of the <see cref="Use"/> property.
+    /// </summary>
+    /// <param name="target">The target member path.</param>
+    public MapValueAttribute(string target)
+        : this(target, null) { }
+
+    /// <summary>
+    /// Maps a method generated value to a target member.
+    /// Requires the usage of the <see cref="Use"/> property.
+    /// </summary>
+    /// <param name="target">The target member path, the usage of nameof is encouraged.</param>
+    public MapValueAttribute(string[] target)
+        : this(target, null) { }
+
+    /// <summary>
+    /// Gets the name of the target property.
+    /// </summary>
+    public IReadOnlyCollection<string> Target { get; }
+
+    /// <summary>
+    /// Gets the full name of the target property path.
+    /// </summary>
+    public string TargetFullName => string.Join(PropertyAccessSeparatorStr, Target);
+
+    /// <summary>
+    /// Gets the value to be assigned to <see cref="Target"/>.
+    /// </summary>
+    public object? Value { get; }
+
+    /// <summary>
+    /// Gets or sets the method name of the method which generates the value to be assigned to <see cref="Target"/>.
+    /// Either this property or <see cref="Value"/> needs to be set.
+    /// The return type of the referenced method must exactly match the type of <see cref="Target"/>
+    /// and needs to be parameterless.
+    /// The usage of nameof is encouraged.
+    /// </summary>
+    public string? Use { get; set; }
+}

--- a/src/Riok.Mapperly.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Riok.Mapperly.Abstractions/PublicAPI.Shipped.txt
@@ -171,3 +171,13 @@ Riok.Mapperly.Abstractions.MapPropertyFromSourceAttribute.FormatProvider.get -> 
 Riok.Mapperly.Abstractions.MapPropertyFromSourceAttribute.FormatProvider.set -> void
 Riok.Mapperly.Abstractions.MapPropertyFromSourceAttribute.Use.get -> string?
 Riok.Mapperly.Abstractions.MapPropertyFromSourceAttribute.Use.set -> void
+Riok.Mapperly.Abstractions.MapValueAttribute
+Riok.Mapperly.Abstractions.MapValueAttribute.Use.get -> string?
+Riok.Mapperly.Abstractions.MapValueAttribute.Use.set -> void
+Riok.Mapperly.Abstractions.MapValueAttribute.MapValueAttribute(string! target) -> void
+Riok.Mapperly.Abstractions.MapValueAttribute.MapValueAttribute(string! target, object? value) -> void
+Riok.Mapperly.Abstractions.MapValueAttribute.MapValueAttribute(string![]! target) -> void
+Riok.Mapperly.Abstractions.MapValueAttribute.MapValueAttribute(string![]! target, object? value) -> void
+Riok.Mapperly.Abstractions.MapValueAttribute.Target.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+Riok.Mapperly.Abstractions.MapValueAttribute.TargetFullName.get -> string!
+Riok.Mapperly.Abstractions.MapValueAttribute.Value.get -> object?

--- a/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
@@ -173,6 +173,12 @@ RMG073  | Mapper   | Warning  | The target type of the referenced mapping does n
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 RMG074  | Mapper   | Error    | Multiple mappings are configured for the same target member
+RMG075  | Mapper   | Error    | Invalid usage of the MapValueAttribute
+RMG076  | Mapper   | Warning  | Cannot assign null to non-nullable member
+RMG077  | Mapper   | Error    | Cannot assign constant value because the type of the value does not match the type of the target
+RMG078  | Mapper   | Error    | Cannot assign method return type because the type of the value does not match the type of the target
+RMG079  | Mapper   | Error    | The referenced method could not be found or has an unsupported signature
+RMG080  | Mapper   | Error    | The MapValueAttribute does not support types and arrays
 
 ### Removed Rules
 

--- a/src/Riok.Mapperly/Configuration/AttributeDataAccessor.cs
+++ b/src/Riok.Mapperly/Configuration/AttributeDataAccessor.cs
@@ -123,6 +123,8 @@ public class AttributeDataAccessor(SymbolAccessor symbolAccessor)
     {
         return arg.Kind switch
         {
+            _ when (targetType == typeof(AttributeValue?) || targetType == typeof(AttributeValue)) && syntax != null
+                => new AttributeValue(arg, syntax.Expression),
             _ when arg.IsNull => null,
             _ when targetType == typeof(StringMemberPath) => CreateMemberPath(arg, syntax),
             TypedConstantKind.Enum => GetEnumValue(arg, targetType),

--- a/src/Riok.Mapperly/Configuration/AttributeValue.cs
+++ b/src/Riok.Mapperly/Configuration/AttributeValue.cs
@@ -1,0 +1,12 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Riok.Mapperly.Configuration;
+
+/// <summary>
+/// Represents an attribute value provided by the user.
+/// Allows access to the intepreted value as well as the source syntax.
+/// </summary>
+/// <param name="ConstantValue">The interpreted compile-time constant value.</param>
+/// <param name="Expression">The syntax as written by the user.</param>
+public readonly record struct AttributeValue(TypedConstant ConstantValue, ExpressionSyntax Expression);

--- a/src/Riok.Mapperly/Configuration/MemberValueMappingConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/MemberValueMappingConfiguration.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics;
+
+namespace Riok.Mapperly.Configuration;
+
+[DebuggerDisplay("{Target}: {DescribeValue()}")]
+public record MemberValueMappingConfiguration(StringMemberPath Target, AttributeValue? Value) : HasSyntaxReference
+{
+    /// <summary>
+    /// Constructor used by <see cref="AttributeDataAccessor"/>.
+    /// </summary>
+    public MemberValueMappingConfiguration(StringMemberPath target)
+        : this(target, null) { }
+
+    public string? Use { get; set; }
+
+    public bool IsValid => Use != null ^ Value != null;
+
+    public string DescribeValue()
+    {
+        if (Use != null)
+            return Use + "()";
+
+        return Value?.Expression.ToFullString() ?? string.Empty;
+    }
+}

--- a/src/Riok.Mapperly/Configuration/MembersMappingConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/MembersMappingConfiguration.cs
@@ -6,6 +6,7 @@ namespace Riok.Mapperly.Configuration;
 public record MembersMappingConfiguration(
     IReadOnlyCollection<string> IgnoredSources,
     IReadOnlyCollection<string> IgnoredTargets,
+    IReadOnlyCollection<MemberValueMappingConfiguration> ValueMappings,
     IReadOnlyCollection<MemberMappingConfiguration> ExplicitMappings,
     IReadOnlyCollection<NestedMembersMappingConfiguration> NestedMappings,
     IgnoreObsoleteMembersStrategy IgnoreObsoleteMembersStrategy,
@@ -17,7 +18,8 @@ public record MembersMappingConfiguration(
         var members = sourceTarget switch
         {
             MappingSourceTarget.Source => ExplicitMappings.Where(x => x.Source.Path.Count > 0).Select(x => x.Source.Path[0]),
-            MappingSourceTarget.Target => ExplicitMappings.Select(x => x.Target.Path[0]),
+            MappingSourceTarget.Target
+                => ExplicitMappings.Select(x => x.Target.Path[0]).Concat(ValueMappings.Select(x => x.Target.Path[0])),
             _ => throw new ArgumentOutOfRangeException(nameof(sourceTarget), sourceTarget, "Neither source or target"),
         };
         return members.Distinct();

--- a/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
@@ -55,6 +55,7 @@ public class DescriptorBuilder
 
         _builderContext = new SimpleMappingBuilderContext(
             compilationContext,
+            mapperDeclaration,
             configurationReader,
             _symbolAccessor,
             new GenericTypeChecker(_symbolAccessor, _types),

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/IMembersBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/IMembersBuilderContext.cs
@@ -17,7 +17,7 @@ public interface IMembersBuilderContext<out T>
 
     void SetTargetMemberMapped(IMappableMember targetMember);
 
-    void ConsumeMemberConfig(MemberMappingInfo members);
+    void ConsumeMemberConfigs(MemberMappingInfo members);
 
     IEnumerable<IMappableMember> EnumerateUnmappedTargetMembers();
 

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MemberMappingDiagnosticReporter.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MemberMappingDiagnosticReporter.cs
@@ -34,7 +34,7 @@ internal static class MemberMappingDiagnosticReporter
 
     private static void AddUnmappedTargetMembersDiagnostics(MappingBuilderContext ctx, MembersMappingState state)
     {
-        foreach (var targetMember in state.UnmappedTargetMembers)
+        foreach (var targetMember in state.EnumerateUnmappedTargetMembers())
         {
             if (targetMember.IsRequired)
             {

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
@@ -25,6 +25,12 @@ public class MembersContainerBuilderContext<T>(MappingBuilderContext builderCont
     /// <param name="memberMapping">The member mapping to be applied if the source member is not null</param>
     public void AddNullDelegateMemberAssignmentMapping(IMemberAssignmentMapping memberMapping)
     {
+        if (memberMapping.MemberInfo.SourceMember == null)
+        {
+            AddMemberAssignmentMapping(memberMapping);
+            return;
+        }
+
         var nullConditionSourcePath = new NonEmptyMemberPath(
             memberMapping.MemberInfo.SourceMember.RootType,
             memberMapping.MemberInfo.SourceMember.PathWithoutTrailingNonNullable().ToList()

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingStateBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingStateBuilder.cs
@@ -11,6 +11,7 @@ internal static class MembersMappingStateBuilder
     {
         // build configurations
         var configuredTargetMembers = new HashSet<StringMemberPath>();
+        var memberValueConfigsByRootTargetName = BuildMemberValueConfigurations(ctx, configuredTargetMembers);
         var memberConfigsByRootTargetName = BuildMemberConfigurations(ctx, configuredTargetMembers);
 
         // build all members
@@ -36,6 +37,7 @@ internal static class MembersMappingStateBuilder
             unmappedTargetMemberNames,
             targetMemberCaseMapping,
             targetMembers,
+            memberValueConfigsByRootTargetName,
             memberConfigsByRootTargetName,
             ignoredSourceMemberNames
         );
@@ -49,6 +51,16 @@ internal static class MembersMappingStateBuilder
     private static Dictionary<string, IMappableMember> GetTargetMembers(MappingBuilderContext ctx)
     {
         return ctx.SymbolAccessor.GetAllAccessibleMappableMembers(ctx.Target).ToDictionary(x => x.Name);
+    }
+
+    private static Dictionary<string, List<MemberValueMappingConfiguration>> BuildMemberValueConfigurations(
+        MappingBuilderContext ctx,
+        HashSet<StringMemberPath> configuredTargetMembers
+    )
+    {
+        return GetUniqueTargetConfigurations(ctx, configuredTargetMembers, ctx.Configuration.Members.ValueMappings, x => x.Target)
+            .GroupBy(x => x.Target.Path[0])
+            .ToDictionary(x => x.Key, x => x.ToList());
     }
 
     private static Dictionary<string, List<MemberMappingConfiguration>> BuildMemberConfigurations(

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewInstanceContainerBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewInstanceContainerBuilderContext.cs
@@ -34,6 +34,17 @@ public class NewInstanceContainerBuilderContext<T>(MappingBuilderContext builder
         if (TryMatchMember(targetMember, out memberInfo))
             return true;
 
+        if (TryGetMemberValueConfigs(targetMember.Name, false, out var valueConfigs))
+        {
+            BuilderContext.ReportDiagnostic(
+                DiagnosticDescriptors.InitOnlyMemberDoesNotSupportPaths,
+                Mapping.TargetType,
+                valueConfigs[0].Target.FullName
+            );
+            ConsumeMemberConfig(valueConfigs[0]);
+            return false;
+        }
+
         if (TryGetMemberConfigs(targetMember.Name, false, out var configs))
         {
             BuilderContext.ReportDiagnostic(

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/MemberMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/MemberMappingBuilder.cs
@@ -28,7 +28,7 @@ internal static class MemberMappingBuilder
         [NotNullWhen(true)] out MemberAssignmentMapping? mapping
     )
     {
-        if (!TryBuild(ctx, memberInfo, CodeStyle.Statement, out var mappedSourceValue))
+        if (!SourceValueBuilder.TryBuildMappedSourceValue(ctx, memberInfo, CodeStyle.Statement, out var mappedSourceValue))
         {
             mapping = null;
             requiresNullHandling = false;
@@ -47,7 +47,7 @@ internal static class MemberMappingBuilder
         [NotNullWhen(true)] out MemberAssignmentMapping? mapping
     )
     {
-        if (!TryBuild(ctx, memberInfo, CodeStyle.Expression, out var mappedSourceValue))
+        if (!SourceValueBuilder.TryBuildMappedSourceValue(ctx, memberInfo, out var mappedSourceValue))
         {
             mapping = null;
             return false;
@@ -71,7 +71,7 @@ internal static class MemberMappingBuilder
             diagnosticLocation: memberMappingInfo.Configuration?.Location
         );
 
-        var sourceMember = memberMappingInfo.SourceMember;
+        var sourceMember = memberMappingInfo.SourceMember!;
         var targetMember = memberMappingInfo.TargetMember;
         if (delegateMapping == null)
         {

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
@@ -68,7 +68,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
         // consume member configs
         // to ensure no further mappings are created for these configurations,
         // even if a mapping validation fails
-        ctx.ConsumeMemberConfig(memberInfo);
+        ctx.ConsumeMemberConfigs(memberInfo);
 
         if (!ObjectMemberMappingBodyBuilder.ValidateMappingSpecification(ctx, memberInfo, true))
             return;
@@ -144,7 +144,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
         {
             if (
                 !ctx.TryMatchParameter(parameter, out var memberMappingInfo)
-                || !MemberMappingBuilder.TryBuild(ctx, memberMappingInfo, MemberMappingBuilder.CodeStyle.Expression, out var sourceValue)
+                || !SourceValueBuilder.TryBuildMappedSourceValue(ctx, memberMappingInfo, out var sourceValue)
             )
             {
                 // expressions do not allow skipping of optional parameters

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewValueTupleMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewValueTupleMappingBodyBuilder.cs
@@ -70,9 +70,7 @@ public static class NewValueTupleMappingBodyBuilder
                 return false;
             }
 
-            if (
-                !MemberMappingBuilder.TryBuild(ctx, memberMappingInfo, MemberMappingBuilder.CodeStyle.Expression, out var mappedSourceValue)
-            )
+            if (!SourceValueBuilder.TryBuildMappedSourceValue(ctx, memberMappingInfo, out var mappedSourceValue))
             {
                 ctx.SetTargetMemberMapped(targetMember);
                 return false;

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
@@ -112,10 +112,13 @@ public static class ObjectMemberMappingBodyBuilder
         // a source member path is write only or not accessible
         // an expressions source member path is only accessible with unsafe access
         if (
-            sourceMemberPath.Path.Any(p => !p.CanGet)
-            || (
-                ctx.BuilderContext.IsExpression
-                && sourceMemberPath.Path.Any(p => !ctx.BuilderContext.SymbolAccessor.IsDirectlyAccessible(p.MemberSymbol))
+            sourceMemberPath != null
+            && (
+                sourceMemberPath.Path.Any(p => !p.CanGet)
+                || (
+                    ctx.BuilderContext.IsExpression
+                    && sourceMemberPath.Path.Any(p => !ctx.BuilderContext.SymbolAccessor.IsDirectlyAccessible(p.MemberSymbol))
+                )
             )
         )
         {
@@ -128,7 +131,7 @@ public static class ObjectMemberMappingBodyBuilder
         }
 
         // cannot map from an indexed member
-        if (sourceMemberPath.Member?.IsIndexer == true)
+        if (sourceMemberPath?.Member?.IsIndexer == true)
         {
             ctx.BuilderContext.ReportDiagnostic(
                 DiagnosticDescriptors.CannotMapFromIndexedMember,
@@ -180,7 +183,7 @@ public static class ObjectMemberMappingBodyBuilder
         // consume member configs
         // to ensure no further mappings are created for these configurations,
         // even if a mapping validation fails
-        ctx.ConsumeMemberConfig(memberMappingInfo);
+        ctx.ConsumeMemberConfigs(memberMappingInfo);
 
         if (TryAddExistingTargetMapping(ctx, memberMappingInfo))
             return;
@@ -206,6 +209,10 @@ public static class ObjectMemberMappingBodyBuilder
         MemberMappingInfo memberMappingInfo
     )
     {
+        // can only map with an existing target from a source member
+        if (memberMappingInfo.SourceMember == null)
+            return false;
+
         var sourceMemberPath = memberMappingInfo.SourceMember;
         var targetMemberPath = memberMappingInfo.TargetMember;
 

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/SourceValueBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/SourceValueBuilder.cs
@@ -1,0 +1,205 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Configuration;
+using Riok.Mapperly.Descriptors.MappingBodyBuilders.BuilderContext;
+using Riok.Mapperly.Descriptors.Mappings;
+using Riok.Mapperly.Descriptors.Mappings.MemberMappings;
+using Riok.Mapperly.Descriptors.Mappings.MemberMappings.SourceValue;
+using Riok.Mapperly.Diagnostics;
+using Riok.Mapperly.Helpers;
+using static Riok.Mapperly.Emit.Syntax.SyntaxFactoryHelper;
+
+namespace Riok.Mapperly.Descriptors.MappingBodyBuilders;
+
+internal static class SourceValueBuilder
+{
+    /// <summary>
+    /// Tries to build an <see cref="ISourceValue"/> instance which serializes as an expression,
+    /// with a value that is assignable to the target member requested in the <paramref name="memberMappingInfo"/>.
+    /// </summary>
+    public static bool TryBuildMappedSourceValue(
+        IMembersBuilderContext<IMapping> ctx,
+        MemberMappingInfo memberMappingInfo,
+        [NotNullWhen(true)] out ISourceValue? sourceValue
+    ) => TryBuildMappedSourceValue(ctx, memberMappingInfo, MemberMappingBuilder.CodeStyle.Expression, out sourceValue);
+
+    /// <summary>
+    /// Tries to build an <see cref="ISourceValue"/> instance,
+    /// with a value that is assignable to the target member requested in the <paramref name="memberMappingInfo"/>.
+    /// </summary>
+    public static bool TryBuildMappedSourceValue(
+        IMembersBuilderContext<IMapping> ctx,
+        MemberMappingInfo memberMappingInfo,
+        MemberMappingBuilder.CodeStyle codeStyle,
+        [NotNullWhen(true)] out ISourceValue? sourceValue
+    )
+    {
+        if (memberMappingInfo.ValueConfiguration != null)
+            return TryBuildValue(ctx, memberMappingInfo, out sourceValue);
+
+        if (memberMappingInfo.SourceMember != null)
+            return MemberMappingBuilder.TryBuild(ctx, memberMappingInfo, codeStyle, out sourceValue);
+
+        sourceValue = null;
+        return false;
+    }
+
+    private static bool TryBuildValue(
+        IMembersBuilderContext<IMapping> ctx,
+        MemberMappingInfo memberMappingInfo,
+        [NotNullWhen(true)] out ISourceValue? sourceValue
+    )
+    {
+        // set the target member as mapped
+        // if the mapping does not work
+        // another diagnostic is reported as error
+        ctx.SetTargetMemberMapped(memberMappingInfo.TargetMember.Member);
+
+        if (memberMappingInfo.ValueConfiguration!.Value != null)
+            return TryBuildConstantSourceValue(ctx, memberMappingInfo, out sourceValue);
+
+        if (memberMappingInfo.ValueConfiguration!.Use != null)
+            return TryBuildMethodProvidedSourceValue(ctx, memberMappingInfo, out sourceValue);
+
+        throw new InvalidOperationException($"Illegal {nameof(MemberValueMappingConfiguration)}");
+    }
+
+    private static bool TryBuildConstantSourceValue(
+        IMembersBuilderContext<IMapping> ctx,
+        MemberMappingInfo memberMappingInfo,
+        [NotNullWhen(true)] out ISourceValue? sourceValue
+    )
+    {
+        var value = memberMappingInfo.ValueConfiguration!.Value!.Value;
+
+        // the target is a non-nullable reference type,
+        // but the provided value is null or default (for default IsNullable is also true)
+        if (
+            value.ConstantValue.IsNull
+            && memberMappingInfo.TargetMember.MemberType.IsReferenceType
+            && !memberMappingInfo.TargetMember.Member.IsNullable
+        )
+        {
+            ctx.BuilderContext.ReportDiagnostic(
+                DiagnosticDescriptors.CannotMapValueNullToNonNullable,
+                memberMappingInfo.TargetMember.ToDisplayString()
+            );
+            sourceValue = new ConstantSourceValue(SuppressNullableWarning(value.Expression));
+            return true;
+        }
+
+        // target is value type but value is null
+        if (
+            value.ConstantValue.IsNull
+            && memberMappingInfo.TargetMember.MemberType.IsValueType
+            && !memberMappingInfo.TargetMember.MemberType.IsNullableValueType()
+            && value.Expression.IsKind(SyntaxKind.NullLiteralExpression)
+        )
+        {
+            ctx.BuilderContext.ReportDiagnostic(
+                DiagnosticDescriptors.CannotMapValueNullToNonNullable,
+                memberMappingInfo.TargetMember.ToDisplayString()
+            );
+            sourceValue = new ConstantSourceValue(DefaultLiteral());
+            return true;
+        }
+
+        // the target accepts null and the value is null or default
+        // use the expression instant of a constant null literal
+        // to use "default" or "null" depending on what the user specified in the attribute
+        if (value.ConstantValue.IsNull)
+        {
+            sourceValue = new ConstantSourceValue(value.Expression);
+            return true;
+        }
+
+        if (!SymbolEqualityComparer.Default.Equals(value.ConstantValue.Type, memberMappingInfo.TargetMember.MemberType))
+        {
+            ctx.BuilderContext.ReportDiagnostic(
+                DiagnosticDescriptors.MapValueTypeMismatch,
+                value.Expression.ToFullString(),
+                value.ConstantValue.Type?.ToDisplayString() ?? "unknown",
+                memberMappingInfo.TargetMember.ToDisplayString()
+            );
+            sourceValue = null;
+            return false;
+        }
+
+        switch (value.ConstantValue.Kind)
+        {
+            case TypedConstantKind.Primitive:
+                sourceValue = new ConstantSourceValue(value.Expression);
+                return true;
+            case TypedConstantKind.Enum:
+                // expand enum member access to fully qualified identifier
+                // use simple member name approach instead of slower visitor pattern on the expression
+                var enumMemberName = ((MemberAccessExpressionSyntax)value.Expression).Name.Identifier.Text;
+                var enumTypeFullName = FullyQualifiedIdentifier(memberMappingInfo.TargetMember.MemberType);
+                sourceValue = new ConstantSourceValue(MemberAccess(enumTypeFullName, enumMemberName));
+                return true;
+            case TypedConstantKind.Type:
+            case TypedConstantKind.Array:
+                ctx.BuilderContext.ReportDiagnostic(DiagnosticDescriptors.MapValueUnsupportedType, value.ConstantValue.Kind.ToString());
+                break;
+        }
+
+        sourceValue = null;
+        return false;
+    }
+
+    private static bool TryBuildMethodProvidedSourceValue(
+        IMembersBuilderContext<IMapping> ctx,
+        MemberMappingInfo memberMappingInfo,
+        [NotNullWhen(true)] out ISourceValue? sourceValue
+    )
+    {
+        if (ValidateValueProviderMethod(ctx, memberMappingInfo))
+        {
+            sourceValue = new MethodProvidedSourceValue(memberMappingInfo.ValueConfiguration!.Use!);
+            return true;
+        }
+
+        sourceValue = null;
+        return false;
+    }
+
+    private static bool ValidateValueProviderMethod(IMembersBuilderContext<IMapping> ctx, MemberMappingInfo memberMappingInfo)
+    {
+        var methodName = memberMappingInfo.ValueConfiguration!.Use!;
+        var namedMethodCandidates = ctx
+            .BuilderContext.MapperDeclaration.Symbol.GetMembers(methodName)
+            .OfType<IMethodSymbol>()
+            .Where(m => m is { IsAsync: false, ReturnsVoid: false, IsGenericMethod: false, Parameters.Length: 0 })
+            .ToList();
+
+        if (namedMethodCandidates.Count == 0)
+        {
+            ctx.BuilderContext.ReportDiagnostic(DiagnosticDescriptors.MapValueReferencedMethodNotFound, methodName);
+            return false;
+        }
+
+        var methodCandidates = namedMethodCandidates.Where(x =>
+            SymbolEqualityComparer.Default.Equals(x.ReturnType, memberMappingInfo.TargetMember.MemberType)
+        );
+
+        if (!memberMappingInfo.TargetMember.Member.IsNullable)
+        {
+            // only assume annotated is nullable, none is threated as non-nullable here
+            methodCandidates = methodCandidates.Where(m => m.ReturnNullableAnnotation != NullableAnnotation.Annotated);
+        }
+
+        var method = methodCandidates.FirstOrDefault();
+        if (method != null)
+            return true;
+
+        ctx.BuilderContext.ReportDiagnostic(
+            DiagnosticDescriptors.MapValueMethodTypeMismatch,
+            methodName,
+            namedMethodCandidates[0].ReturnType.ToDisplayString(),
+            memberMappingInfo.TargetMember.ToDisplayString()
+        );
+        return false;
+    }
+}

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberMappingInfo.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberMappingInfo.cs
@@ -5,9 +5,20 @@ using Riok.Mapperly.Symbols;
 namespace Riok.Mapperly.Descriptors.Mappings.MemberMappings;
 
 [DebuggerDisplay("{DebuggerDisplay}")]
-public record MemberMappingInfo(MemberPath SourceMember, NonEmptyMemberPath TargetMember, MemberMappingConfiguration? Configuration = null)
+public record MemberMappingInfo(
+    MemberPath? SourceMember,
+    NonEmptyMemberPath TargetMember,
+    MemberValueMappingConfiguration? ValueConfiguration = null,
+    MemberMappingConfiguration? Configuration = null
+)
 {
-    private string DebuggerDisplay => $"{SourceMember.FullName} => {TargetMember.FullName}";
+    public MemberMappingInfo(MemberPath? sourceMember, NonEmptyMemberPath targetMember, MemberMappingConfiguration? configuration)
+        : this(sourceMember, targetMember, null, configuration) { }
+
+    public MemberMappingInfo(NonEmptyMemberPath targetMember, MemberValueMappingConfiguration configuration)
+        : this(null, targetMember, configuration) { }
+
+    private string DebuggerDisplay => $"{SourceMember?.FullName ?? ValueConfiguration?.DescribeValue()} => {TargetMember.FullName}";
 
     public TypeMappingKey ToTypeMappingKey()
     {
@@ -17,5 +28,8 @@ public record MemberMappingInfo(MemberPath SourceMember, NonEmptyMemberPath Targ
         return new TypeMappingKey(SourceMember.MemberType, TargetMember.MemberType, Configuration?.ToTypeMappingConfiguration());
     }
 
-    public string DescribeSource() => SourceMember.ToDisplayString(includeMemberType: false);
+    public string DescribeSource()
+    {
+        return SourceMember?.ToDisplayString(includeMemberType: false) ?? ValueConfiguration?.DescribeValue() ?? string.Empty;
+    }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/SourceValue/ConstantSourceValue.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/SourceValue/ConstantSourceValue.cs
@@ -1,0 +1,14 @@
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Riok.Mapperly.Descriptors.Mappings.MemberMappings.SourceValue;
+
+/// <summary>
+/// A constant source value.
+/// <example>"fooBar"</example>
+/// <example>1</example>
+/// <example>MyEnum.MyValue</example>
+/// </summary>
+public class ConstantSourceValue(ExpressionSyntax value) : ISourceValue
+{
+    public ExpressionSyntax Build(TypeMappingBuildContext ctx) => value;
+}

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/SourceValue/MethodProvidedSourceValue.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/SourceValue/MethodProvidedSourceValue.cs
@@ -1,0 +1,12 @@
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Riok.Mapperly.Emit.Syntax.SyntaxFactoryHelper;
+
+namespace Riok.Mapperly.Descriptors.Mappings.MemberMappings.SourceValue;
+
+/// <summary>
+/// A source value which is provided by a method.
+/// </summary>
+public class MethodProvidedSourceValue(string methodName) : ISourceValue
+{
+    public ExpressionSyntax Build(TypeMappingBuildContext ctx) => Invocation(methodName);
+}

--- a/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
@@ -13,6 +13,7 @@ namespace Riok.Mapperly.Descriptors;
 /// </summary>
 public class SimpleMappingBuilderContext(
     CompilationContext compilationContext,
+    MapperDeclaration mapperDeclaration,
     MapperConfigurationReader configurationReader,
     SymbolAccessor symbolAccessor,
     GenericTypeChecker genericTypeChecker,
@@ -33,6 +34,7 @@ public class SimpleMappingBuilderContext(
     protected SimpleMappingBuilderContext(SimpleMappingBuilderContext ctx, Location? diagnosticLocation)
         : this(
             ctx._compilationContext,
+            ctx.MapperDeclaration,
             ctx._configurationReader,
             ctx.SymbolAccessor,
             ctx.GenericTypeChecker,
@@ -44,6 +46,8 @@ public class SimpleMappingBuilderContext(
             ctx.InlinedMappings,
             diagnosticLocation ?? ctx._diagnosticLocation
         ) { }
+
+    public MapperDeclaration MapperDeclaration { get; } = mapperDeclaration;
 
     public Compilation Compilation => _compilationContext.Compilation;
 

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -697,6 +697,66 @@ public static class DiagnosticDescriptors
             true
         );
 
+    public static readonly DiagnosticDescriptor InvalidMapValueAttributeUsage =
+        new(
+            "RMG075",
+            "Invalid usage of the " + nameof(MapValueAttribute),
+            "Invalid usage of the " + nameof(MapValueAttribute),
+            DiagnosticCategories.Mapper,
+            DiagnosticSeverity.Error,
+            true
+        );
+
+    public static readonly DiagnosticDescriptor CannotMapValueNullToNonNullable =
+        new(
+            "RMG076",
+            "Cannot assign null to non-nullable member",
+            "Cannot assign null to non-nullable member {0}",
+            DiagnosticCategories.Mapper,
+            DiagnosticSeverity.Warning,
+            true
+        );
+
+    public static readonly DiagnosticDescriptor MapValueTypeMismatch =
+        new(
+            "RMG077",
+            "Cannot assign constant value because the type of the value does not match the type of the target",
+            "Cannot assign constant value {0} of type {1} to {2}",
+            DiagnosticCategories.Mapper,
+            DiagnosticSeverity.Error,
+            true
+        );
+
+    public static readonly DiagnosticDescriptor MapValueMethodTypeMismatch =
+        new(
+            "RMG078",
+            "Cannot assign method return type because the type of the value does not match the type of the target",
+            "Cannot assign method return type {1} of {0}() to {2}",
+            DiagnosticCategories.Mapper,
+            DiagnosticSeverity.Error,
+            true
+        );
+
+    public static readonly DiagnosticDescriptor MapValueReferencedMethodNotFound =
+        new(
+            "RMG079",
+            "The referenced method could not be found or has an unsupported signature",
+            "The referenced method {0} could not be found or has an unsupported signature",
+            DiagnosticCategories.Mapper,
+            DiagnosticSeverity.Error,
+            true
+        );
+
+    public static readonly DiagnosticDescriptor MapValueUnsupportedType =
+        new(
+            "RMG080",
+            $"The {nameof(MapValueAttribute)} does not support types and arrays",
+            $"The {nameof(MapValueAttribute)} does not support types and arrays",
+            DiagnosticCategories.Mapper,
+            DiagnosticSeverity.Error,
+            true
+        );
+
     private static string BuildHelpUri(string id)
     {
 #if ENV_NEXT

--- a/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Invocation.cs
+++ b/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Invocation.cs
@@ -44,6 +44,8 @@ public partial struct SyntaxFactoryHelper
         return InvocationExpression(method).WithArgumentList(ArgumentList(arguments));
     }
 
+    public static InvocationExpressionSyntax Invocation(string methodName) => Invocation(IdentifierName(methodName));
+
     public static InvocationExpressionSyntax Invocation(ExpressionSyntax method) => Invocation(method, Array.Empty<ArgumentSyntax>());
 
     public static InvocationExpressionSyntax Invocation(ExpressionSyntax method, params ArgumentSyntax[] arguments)

--- a/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Null.cs
+++ b/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Null.cs
@@ -60,4 +60,7 @@ public partial struct SyntaxFactoryHelper
 
         return If(IsNull(expression), ifExpression);
     }
+
+    public static ExpressionSyntax SuppressNullableWarning(ExpressionSyntax expression) =>
+        PostfixUnaryExpression(SyntaxKind.SuppressNullableWarningExpression, expression);
 }

--- a/test/Riok.Mapperly.IntegrationTests/Dto/ConstantValuesDto.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Dto/ConstantValuesDto.cs
@@ -1,0 +1,18 @@
+namespace Riok.Mapperly.IntegrationTests.Dto
+{
+    public class ConstantValuesDto
+    {
+        public ConstantValuesDto(string ctorConstantValue, int ctorMappedValue)
+        {
+            CtorMappedValue = ctorMappedValue;
+            CtorConstantValue = ctorConstantValue;
+        }
+
+        public int MappedValue { get; set; }
+        public int CtorMappedValue { get; }
+        public string CtorConstantValue { get; }
+
+        public int ConstantValue { get; set; }
+        public int ConstantValueByMethod { get; set; }
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/StaticTestMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/StaticTestMapper.cs
@@ -134,5 +134,12 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
 
         [MapEnum(EnumMappingStrategy.ByName, FallbackValue = TestEnum.Value10)]
         public static partial TestEnum MapToEnumByNameWithFallback(TestEnumDtoByName v);
+
+        [MapValue(nameof(ConstantValuesDto.CtorConstantValue), "fooBar")]
+        [MapValue(nameof(ConstantValuesDto.ConstantValue), 1)]
+        [MapValue(nameof(ConstantValuesDto.ConstantValueByMethod), Use = nameof(IntValueBuilder))]
+        public static partial ConstantValuesDto MapConstantValues(ConstantValuesObject source);
+
+        private static int IntValueBuilder() => 2;
     }
 }

--- a/test/Riok.Mapperly.IntegrationTests/Models/ConstantValuesObject.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Models/ConstantValuesObject.cs
@@ -1,0 +1,8 @@
+namespace Riok.Mapperly.IntegrationTests.Models
+{
+    public class ConstantValuesObject
+    {
+        public int MappedValue { get; set; }
+        public int CtorMappedValue { get; set; }
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/Riok.Mapperly.IntegrationTests.csproj
+++ b/test/Riok.Mapperly.IntegrationTests/Riok.Mapperly.IntegrationTests.csproj
@@ -38,6 +38,11 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.5" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
+  <!-- diffplex is only compatible with net7.0 up to 2.x-->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0'">
+    <PackageReference Update="Verify.DiffPlex" Version="2.2.1" />
+  </ItemGroup>
+
   <!-- cannot use source generated polyfills since they require language version 11 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />

--- a/test/Riok.Mapperly.IntegrationTests/StaticMapperTest.cs
+++ b/test/Riok.Mapperly.IntegrationTests/StaticMapperTest.cs
@@ -63,5 +63,13 @@ namespace Riok.Mapperly.IntegrationTests
             var dto = StaticTestMapper.MapGeneric<TestObject, TestObjectDto>(obj);
             dto.IntValue.Should().Be(obj.IntValue);
         }
+
+        [Fact]
+        public Task ConstantValuesShouldWork()
+        {
+            var obj = new ConstantValuesObject { CtorMappedValue = 10, MappedValue = 11 };
+            var dto = StaticTestMapper.MapConstantValues(obj);
+            return Verifier.Verify(dto);
+        }
     }
 }

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.ConstantValuesShouldWork.verified.txt
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.ConstantValuesShouldWork.verified.txt
@@ -1,0 +1,7 @@
+{
+  MappedValue: 11,
+  CtorMappedValue: 10,
+  CtorConstantValue: fooBar,
+  ConstantValue: 1,
+  ConstantValueByMethod: 2
+}

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -521,6 +521,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 string x when targetType.IsAssignableFrom(typeof(int)) => ParseableInt(x),
                 global::Riok.Mapperly.IntegrationTests.Models.TestObject x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto)) => MapToDto(x),
                 global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Models.TestObject)) => MapFromDto(x),
+                global::Riok.Mapperly.IntegrationTests.Models.ConstantValuesObject x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.ConstantValuesDto)) => MapConstantValues(x),
                 global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Models.TestObject> x when targetType.IsAssignableFrom(typeof(global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto>)) => MapAllDtos(x),
                 object x when targetType.IsAssignableFrom(typeof(object)) => DerivedTypes(x),
                 _ => throw new System.ArgumentException($"Cannot map {source.GetType()} to {targetType} as there is no known type mapping", nameof(source)),
@@ -545,6 +546,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 string x when targetType.IsAssignableFrom(typeof(int)) => ParseableInt(x),
                 global::Riok.Mapperly.IntegrationTests.Models.TestObject x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto)) => MapToDto(x),
                 global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Models.TestObject)) => MapFromDto(x),
+                global::Riok.Mapperly.IntegrationTests.Models.ConstantValuesObject x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.ConstantValuesDto)) => MapConstantValues(x),
                 global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Models.TestObject> x when targetType.IsAssignableFrom(typeof(global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto>)) => MapAllDtos(x),
                 object x when targetType.IsAssignableFrom(typeof(object)) => DerivedTypes(x),
                 null => default,
@@ -570,6 +572,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 string x when typeof(TTarget).IsAssignableFrom(typeof(int)) => (TTarget)(object)ParseableInt(x),
                 global::Riok.Mapperly.IntegrationTests.Models.TestObject x when typeof(TTarget).IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto)) => (TTarget)(object)MapToDto(x),
                 global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto x when typeof(TTarget).IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Models.TestObject)) => (TTarget)(object)MapFromDto(x),
+                global::Riok.Mapperly.IntegrationTests.Models.ConstantValuesObject x when typeof(TTarget).IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.ConstantValuesDto)) => (TTarget)(object)MapConstantValues(x),
                 global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Models.TestObject> x when typeof(TTarget).IsAssignableFrom(typeof(global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto>)) => (TTarget)(object)MapAllDtos(x),
                 object x when typeof(TTarget).IsAssignableFrom(typeof(object)) => (TTarget)(object)DerivedTypes(x),
                 null => throw new System.ArgumentNullException(nameof(source)),
@@ -671,6 +674,16 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName.Value30 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
                 _ => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value10,
             };
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        public static partial global::Riok.Mapperly.IntegrationTests.Dto.ConstantValuesDto MapConstantValues(global::Riok.Mapperly.IntegrationTests.Models.ConstantValuesObject source)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Dto.ConstantValuesDto("fooBar", DirectInt(source.CtorMappedValue));
+            target.MappedValue = DirectInt(source.MappedValue);
+            target.ConstantValue = 1;
+            target.ConstantValueByMethod = IntValueBuilder();
+            return target;
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
@@ -530,6 +530,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 string x when targetType.IsAssignableFrom(typeof(int)) => ParseableInt(x),
                 global::Riok.Mapperly.IntegrationTests.Models.TestObject x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto)) => MapToDto(x),
                 global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Models.TestObject)) => MapFromDto(x),
+                global::Riok.Mapperly.IntegrationTests.Models.ConstantValuesObject x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.ConstantValuesDto)) => MapConstantValues(x),
                 global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Models.TestObject> x when targetType.IsAssignableFrom(typeof(global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto>)) => MapAllDtos(x),
                 object x when targetType.IsAssignableFrom(typeof(object)) => DerivedTypes(x),
                 _ => throw new System.ArgumentException($"Cannot map {source.GetType()} to {targetType} as there is no known type mapping", nameof(source)),
@@ -554,6 +555,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 string x when targetType.IsAssignableFrom(typeof(int)) => ParseableInt(x),
                 global::Riok.Mapperly.IntegrationTests.Models.TestObject x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto)) => MapToDto(x),
                 global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Models.TestObject)) => MapFromDto(x),
+                global::Riok.Mapperly.IntegrationTests.Models.ConstantValuesObject x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.ConstantValuesDto)) => MapConstantValues(x),
                 global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Models.TestObject> x when targetType.IsAssignableFrom(typeof(global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto>)) => MapAllDtos(x),
                 object x when targetType.IsAssignableFrom(typeof(object)) => DerivedTypes(x),
                 null => default,
@@ -579,6 +581,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 string x when typeof(TTarget).IsAssignableFrom(typeof(int)) => (TTarget)(object)ParseableInt(x),
                 global::Riok.Mapperly.IntegrationTests.Models.TestObject x when typeof(TTarget).IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto)) => (TTarget)(object)MapToDto(x),
                 global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto x when typeof(TTarget).IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Models.TestObject)) => (TTarget)(object)MapFromDto(x),
+                global::Riok.Mapperly.IntegrationTests.Models.ConstantValuesObject x when typeof(TTarget).IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.ConstantValuesDto)) => (TTarget)(object)MapConstantValues(x),
                 global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Models.TestObject> x when typeof(TTarget).IsAssignableFrom(typeof(global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto>)) => (TTarget)(object)MapAllDtos(x),
                 object x when typeof(TTarget).IsAssignableFrom(typeof(object)) => (TTarget)(object)DerivedTypes(x),
                 null => throw new System.ArgumentNullException(nameof(source)),
@@ -680,6 +683,16 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName.Value30 => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
                 _ => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value10,
             };
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        public static partial global::Riok.Mapperly.IntegrationTests.Dto.ConstantValuesDto MapConstantValues(global::Riok.Mapperly.IntegrationTests.Models.ConstantValuesObject source)
+        {
+            var target = new global::Riok.Mapperly.IntegrationTests.Dto.ConstantValuesDto("fooBar", DirectInt(source.CtorMappedValue));
+            target.MappedValue = DirectInt(source.MappedValue);
+            target.ConstantValue = 1;
+            target.ConstantValueByMethod = IntValueBuilder();
+            return target;
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
@@ -453,7 +453,7 @@ public class ObjectPropertyFlatteningTest
     public Task ManualUnflattenedPropertySourcePropertyNotFoundShouldDiagnostic()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
-            "[MapProperty($\"MyValueIdXXX\", \"Value.Id\")] private partial B Map(A source);",
+            "[MapProperty(\"MyValueIdXXX\", \"Value.Id\")] private partial B Map(A source);",
             "class A { public string MyValueId { get; set; } }",
             "class B { public C? Value { get; set; } }",
             "class C { public C(string arg) {} public string Id { get; set; } }"
@@ -479,7 +479,7 @@ public class ObjectPropertyFlatteningTest
     public Task ManualUnflattenedPropertyTargetPropertyNotFoundShouldDiagnostic()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
-            "[MapProperty($\"MyValueId\", \"Value.IdXXX\")] private partial B Map(A source);",
+            "[MapProperty(\"MyValueId\", \"Value.IdXXX\")] private partial B Map(A source);",
             "class A { public string MyValueId { get; set; } }",
             "class B { public C? Value { get; set; } }",
             "class C { public C(string arg) {} public string Id { get; set; } }"

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
@@ -499,6 +499,14 @@ public class ObjectPropertyTest
                 "The member NestedValue on the mapping target type B was not found on the mapping source type A"
             )
             .HaveDiagnostic(
+                DiagnosticDescriptors.SourceMemberNotMapped,
+                "The member StringValue on the mapping source type A is not mapped to any member on the mapping target type B"
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.SourceMemberNotFound,
+                "The member NestedValue on the mapping target type B was not found on the mapping source type A"
+            )
+            .HaveDiagnostic(
                 DiagnosticDescriptors.CannotMapToTemporarySourceMember,
                 "Cannot map from member A.StringValue to member path B.NestedValue.StringValue of type string because C.NestedValue is a value type, returning a temporary value, see CS1612"
             )

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyValueMethodTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyValueMethodTest.cs
@@ -1,0 +1,277 @@
+using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Diagnostics;
+
+namespace Riok.Mapperly.Tests.Mapping;
+
+public class ObjectPropertyValueMethodTest
+{
+    [Fact]
+    public void MethodToProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("GuidValue", Use = nameof(NewGuid))] partial B Map(A source);
+            Guid NewGuid() => Guid.NewGuid();
+            """,
+            "class A;",
+            "class B { public Guid GuidValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.GuidValue = NewGuid();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MethodToNestedProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("Nested.Value", Use = nameof(NewGuid))] partial B Map(A source);
+            Guid NewGuid() => Guid.NewGuid();
+            """,
+            "class A;",
+            "class B { public C Nested { get; set; } }",
+            "class C { public Guid Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Nested.Value = NewGuid();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MethodToPrivateProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("GuidValue", Use = nameof(NewGuid))] partial B Map(A source);
+            Guid NewGuid() => Guid.NewGuid();
+            """,
+            TestSourceBuilderOptions.Default with
+            {
+                IncludedMembers = MemberVisibility.Private
+            },
+            "class A;",
+            "class B { private Guid GuidValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                target.SetGuidValue(NewGuid());
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MethodToNestedPrivateProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("Nested.Value", Use = nameof(NewGuid))] partial B Map(A source);
+            Guid NewGuid() => Guid.NewGuid();
+            """,
+            TestSourceBuilderOptions.Default with
+            {
+                IncludedMembers = MemberVisibility.All
+            },
+            "class A;",
+            "class B { private C Nested { get; set; } }",
+            "class C { public Guid Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                target.GetNested().Value = NewGuid();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MethodReturnTypeMismatchShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("GuidValue", Use = nameof(NewId))] partial B Map(A source);
+            int NewId() => 1;
+            """,
+            "class A;",
+            "class B { public Guid GuidValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.MapValueMethodTypeMismatch,
+                "Cannot assign method return type int of NewId() to B.GuidValue of type System.Guid"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MethodReturnTypeNullMismatchShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("Value", Use = nameof(BuildC))] partial B Map(A source);
+            C? BuildC() => new C();
+            """,
+            "class A;",
+            "class B { public C Value { get; set; } }",
+            "class C;"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.MapValueMethodTypeMismatch,
+                "Cannot assign method return type C? of BuildC() to B.Value of type C"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MethodReturnTypeInDisabledNullableContext()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("Value", Use = nameof(BuildC))] partial B Map(A source);
+            #nullable disable
+            C BuildC() => new C();
+            #nullable enable
+            """,
+            "class A;",
+            "class B { public C Value { get; set; } }",
+            "class C;"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = BuildC();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ValueAndMethodShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("Value", 10, Use = nameof(NewValue))] partial B Map(A source);
+            int NewValue() => 11;
+            """,
+            "class A;",
+            "class B { private int Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.InvalidMapValueAttributeUsage, "Invalid usage of the MapValueAttribute")
+            .HaveAssertedAllDiagnostics()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void UnknownMethodShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("GuidValue", Use = nameof(NewGuid))] partial B Map(A source);
+            """,
+            "class A;",
+            "class B { public Guid GuidValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.MapValueReferencedMethodNotFound,
+                "The referenced method NewGuid could not be found or has an unsupported signature"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void InvalidMethodSignatureAsyncShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("GuidValue", Use = nameof(NewGuid))] partial B Map(A source);
+            async Task<Guid> NewGuid() => await Task.FromResult(Guid.NewGuid());
+            """,
+            "class A;",
+            "class B { public Guid GuidValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.MapValueReferencedMethodNotFound,
+                "The referenced method NewGuid could not be found or has an unsupported signature"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+}

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyValueTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyValueTest.cs
@@ -1,0 +1,715 @@
+using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Diagnostics;
+
+namespace Riok.Mapperly.Tests.Mapping;
+
+public class ObjectPropertyValueTest
+{
+    [Fact]
+    public void StringToProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("StringValue", "fooBar")] partial B Map(A source);""",
+            "class A;",
+            "class B { public string StringValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.StringValue = "fooBar";
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void StringToField()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("StringValue", "fooBar")] partial B Map(A source);""",
+            "class A;",
+            "class B { public string StringValue; }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.StringValue = "fooBar";
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void StringToNestedProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("Nested.Value", "fooBar")] partial B Map(A source);""",
+            "class A;",
+            "class B { public C Nested { get; set; } }",
+            "class C { public string Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Nested.Value = "fooBar";
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void StringToNestedPropertyWithArrayAttributeCtor()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue(new string[]{"Nested", "Value"}, "fooBar")] partial B Map(A source);""",
+            "class A;",
+            "class B { public C Nested { get; set; } }",
+            "class C { public string Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Nested.Value = "fooBar";
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void StringToNestedNullableProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("Nested.Value", "fooBar")] partial B Map(A source);""",
+            "class A;",
+            "class B { public C? Nested { get; set; } }",
+            "class C { public string Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Nested ??= new();
+                target.Nested.Value = "fooBar";
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void StringToNestedPropertyWithMapProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapProperty("Value", "Nested")]
+            [MapValue("Nested.Value", "fooBar")]
+            partial B Map(A source);
+            """,
+            "class A { public D Value { get; set; } }",
+            "class B { public C Nested { get; set; } }",
+            "class C { public int Id { get; set; } public string Value { get; set; } }",
+            "class D { public int Id { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            // this diagnostic is emitted for the MapToC mapping
+            .HaveDiagnostic(
+                DiagnosticDescriptors.SourceMemberNotFound,
+                "The member Value on the mapping target type C was not found on the mapping source type D"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                target.Nested = MapToC(source.Value);
+                target.Nested.Value = "fooBar";
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void StringToPrivateField()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("_stringValue", "fooBar")] partial B Map(A source);""",
+            TestSourceBuilderOptions.Default with
+            {
+                IncludedMembers = MemberVisibility.Private
+            },
+            "class A;",
+            "class B { private string _stringValue; }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                target.GetStringValue() = "fooBar";
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void IntegerToStringPropertyShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("StringValue", 10)] partial B Map(A source);""",
+            "class A;",
+            "class B { public string StringValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.MapValueTypeMismatch,
+                "Cannot assign constant value 10 of type int to B.StringValue of type string"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void IntegerToProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("IntValue", 1234)] partial B Map(A source);""",
+            "class A;",
+            "class B { public int IntValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.IntValue = 1234;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void IntegerToCtorParameter()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("intValue", 1234)] partial B Map(A source);""",
+            "class A;",
+            "class B { public B(int intValue) {} }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B(1234);
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void IntegerToCtorParameterCaseInsensitive()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("intValue", 1234)] partial B Map(A source);""",
+            "class A;",
+            "class B { public B(int intValue) {} }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B(1234);
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void IntegerToRecord()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("IntValue", 1234)] partial B Map(A source);""",
+            "class A;",
+            "record B(int IntValue);"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B(1234);
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void IntegerToInitOnly()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("IntValue", 1234)] partial B Map(A source);""",
+            "class A;",
+            "class B { public int IntValue { get; init; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B()
+                {
+                    IntValue = 1234,
+                };
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void IntegerToReadOnlyShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("IntValue", 1234)] partial B Map(A source);""",
+            "class A;",
+            "class B { public int IntValue { get; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.CannotMapToReadOnlyMember, "Cannot map 1234 to read only member B.IntValue")
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void TypeToPropertyShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("Value", typeof(A))] partial B Map(A source);""",
+            "class A;",
+            "class B { public Type Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.MapValueUnsupportedType, "The MapValueAttribute does not support types and arrays")
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ArrayToPropertyShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("Value", new int[] {1,2,3})] partial B Map(A source);""",
+            "class A;",
+            "class B { public int[] Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.MapValueUnsupportedType, "The MapValueAttribute does not support types and arrays")
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ExplicitNullToProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("StringValue", null)] partial B Map(A source);""",
+            "class A;",
+            "class B { public string? StringValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.StringValue = null;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ExplicitDefaultToProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("StringValue", default)] partial B Map(A source);""",
+            "class A;",
+            "class B { public string? StringValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.StringValue = default;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void NullToProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("StringValue", null)] partial B Map(A source);""",
+            "class A;",
+            "class B { public string? StringValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.StringValue = null;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ExplicitNullToNonNullablePropertyShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("StringValue", null)] partial B Map(A source);""",
+            "class A;",
+            "class B { public string StringValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.CannotMapValueNullToNonNullable,
+                "Cannot assign null to non-nullable member B.StringValue of type string"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.StringValue = null!;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ExplicitDefaultToNonNullablePropertyShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("StringValue", default)] partial B Map(A source);""",
+            "class A;",
+            "class B { public string StringValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.CannotMapValueNullToNonNullable,
+                "Cannot assign null to non-nullable member B.StringValue of type string"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.StringValue = default!;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ExplicitDefaultToValueProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("IntValue", default)] partial B Map(A source);""",
+            "class A;",
+            "class B { public int IntValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.IntValue = default;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ExplicitNullToValuePropertyShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("IntValue", null)] partial B Map(A source);""",
+            "class A;",
+            "class B { public int IntValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.CannotMapValueNullToNonNullable,
+                "Cannot assign null to non-nullable member B.IntValue of type int"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.IntValue = default;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ExplicitNullToNullableValueProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("IntValue", null)] partial B Map(A source);""",
+            "class A;",
+            "class B { public int? IntValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.IntValue = null;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void EnumToProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("EnumValue", E1.Value2)] partial B Map(A source);""",
+            "class A;",
+            "enum E1 { Value1, Value2 }",
+            "class B { public E1 EnumValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.EnumValue = global::E1.Value2;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void NamespacedEnumToProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("EnumValue", MyNamespace.E1.Value2)] partial B Map(A source);""",
+            "class A;",
+            "namespace MyNamespace { enum E1 { Value1, Value2 } }",
+            "class B { public MyNamespace.E1 EnumValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.EnumValue = global::MyNamespace.E1.Value2;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void EnumTypeMismatchShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("EnumValue", 1)] partial B Map(A source);""",
+            "class A;",
+            "enum E1 { Value1, Value2 }",
+            "class B { public E1 EnumValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.MapValueTypeMismatch,
+                "Cannot assign constant value 1 of type int to B.EnumValue of type E1"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MapValueDuplicateForSameTargetMemberShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("Value", 10)]
+            [MapValue("Value", 20)]
+            partial B Map(A source);
+            """,
+            "class A;",
+            "class B { public int Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.MultipleConfigurationsForTargetMember,
+                "Multiple mappings are configured for the same target member B.Value"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                target.Value = 10;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MapValueAndPropertyAttributeForSameTargetShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("Value", 10)]
+            [MapProperty("SourceValue", "Value")]
+            partial B Map(A source);
+            int NewValue() => 11;
+            """,
+            "class A { public int SourceValue { get; } }",
+            "class B { public int Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.MultipleConfigurationsForTargetMember,
+                "Multiple mappings are configured for the same target member B.Value"
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.SourceMemberNotMapped,
+                "The member SourceValue on the mapping source type A is not mapped to any member on the mapping target type B"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                target.Value = 10;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void StringToInitOnlyPathShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """[MapValue("Nested.Value", "fooBar")] partial B Map(A source);""",
+            "class A;",
+            "class B { public C Nested { get; init; } }",
+            "class C { public string Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.InitOnlyMemberDoesNotSupportPaths, "Cannot map to init only member path B.Nested.Value")
+            .HaveDiagnostic(
+                DiagnosticDescriptors.SourceMemberNotFound,
+                "The member Nested on the mapping target type B was not found on the mapping source type A"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
+}

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyFlatteningTest.ManualUnflattenedPropertySourcePropertyNotFoundShouldDiagnostic.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyFlatteningTest.ManualUnflattenedPropertySourcePropertyNotFoundShouldDiagnostic.verified.txt
@@ -5,7 +5,7 @@
       Title: Mapping source member not found,
       Severity: Error,
       WarningLevel: 0,
-      Location: : (11,4)-(11,79),
+      Location: : (11,4)-(11,78),
       MessageFormat: Specified member {0} on source type {1} was not found,
       Message: Specified member MyValueIdXXX on source type A was not found,
       Category: Mapper
@@ -15,7 +15,7 @@
       Title: Source member is not mapped to any target member,
       Severity: Info,
       WarningLevel: 1,
-      Location: : (11,4)-(11,79),
+      Location: : (11,4)-(11,78),
       MessageFormat: The member {0} on the mapping source type {1} is not mapped to any member on the mapping target type {2},
       Message: The member MyValueId on the mapping source type A is not mapped to any member on the mapping target type B,
       Category: Mapper
@@ -25,7 +25,7 @@
       Title: Source member was not found for target member,
       Severity: Info,
       WarningLevel: 1,
-      Location: : (11,4)-(11,79),
+      Location: : (11,4)-(11,78),
       MessageFormat: The member {0} on the mapping target type {1} was not found on the mapping source type {2},
       Message: The member Value on the mapping target type B was not found on the mapping source type A,
       Category: Mapper
@@ -35,7 +35,7 @@
       Title: No members are mapped in an object mapping,
       Severity: Warning,
       WarningLevel: 1,
-      Location: : (11,4)-(11,79),
+      Location: : (11,4)-(11,78),
       HelpLink: https://localhost:3000/docs/configuration/analyzer-diagnostics/RMG066,
       MessageFormat: No members are mapped in the object mapping from {0} to {1},
       Message: No members are mapped in the object mapping from A to B,

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyFlatteningTest.ManualUnflattenedPropertyTargetPropertyNotFoundShouldDiagnostic.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyFlatteningTest.ManualUnflattenedPropertyTargetPropertyNotFoundShouldDiagnostic.verified.txt
@@ -5,7 +5,7 @@
       Title: Mapping target member not found,
       Severity: Error,
       WarningLevel: 0,
-      Location: : (11,4)-(11,79),
+      Location: : (11,4)-(11,78),
       MessageFormat: Specified member {0} on mapping target type {1} was not found,
       Message: Specified member Value.IdXXX on mapping target type B was not found,
       Category: Mapper
@@ -15,7 +15,7 @@
       Title: Source member is not mapped to any target member,
       Severity: Info,
       WarningLevel: 1,
-      Location: : (11,4)-(11,79),
+      Location: : (11,4)-(11,78),
       MessageFormat: The member {0} on the mapping source type {1} is not mapped to any member on the mapping target type {2},
       Message: The member MyValueId on the mapping source type A is not mapped to any member on the mapping target type B,
       Category: Mapper
@@ -25,7 +25,7 @@
       Title: Source member was not found for target member,
       Severity: Info,
       WarningLevel: 1,
-      Location: : (11,4)-(11,79),
+      Location: : (11,4)-(11,78),
       MessageFormat: The member {0} on the mapping target type {1} was not found on the mapping source type {2},
       Message: The member Value on the mapping target type B was not found on the mapping source type A,
       Category: Mapper
@@ -35,7 +35,7 @@
       Title: No members are mapped in an object mapping,
       Severity: Warning,
       WarningLevel: 1,
-      Location: : (11,4)-(11,79),
+      Location: : (11,4)-(11,78),
       HelpLink: https://localhost:3000/docs/configuration/analyzer-diagnostics/RMG066,
       MessageFormat: No members are mapped in the object mapping from {0} to {1},
       Message: No members are mapped in the object mapping from A to B,


### PR DESCRIPTION
# MapValueAttribute

Introduces a new MapValueAttribute which allows mapping constant values and method provided values to target members.

Fixes #631

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
