### PR TITLE
fix: ignore indexed properties

### DIFF
--- a/docs/docs/breaking-changes/3-0.md
+++ b/docs/docs/breaking-changes/3-0.md
@@ -9,7 +9,7 @@ description: How to upgrade to Mapperly v3.0 and a list of all its breaking chan
 [![NuGet v3.0.0](https://img.shields.io/badge/NuGet-v3.0-blue?style=flat-square)](https://www.nuget.org/packages/Riok.Mapperly/3.0.0)
 [![API Diff v3.0.0 / v2.8.0](https://img.shields.io/badge/API--Diff-v3.0_%2F_v2.8-yellow?style=flat-square)](https://www.fuget.org/packages/Riok.Mapperly/3.0.0/lib/netstandard2.0/diff/2.8.0/)
 
-## Migration guide
+## Migration guide from v2.8.0
 
 - Replace usages of `MapperIgnoreAttribute` with `MapperIgnoreTargetAttribute` ([details](#mapperignoreattribute-was-removed))
 - If your mapper is nested in a class, or the mapped objects include internal members: Add `MapperIgnoreSource`/`MapperIgnoreTarget` for newly included private/internal but unneeded members ([details](#all-accessible-members-are-mapped-by-default))

--- a/docs/docs/breaking-changes/4-0.md
+++ b/docs/docs/breaking-changes/4-0.md
@@ -1,0 +1,22 @@
+---
+sidebar_position: 2
+description: How to upgrade to Mapperly v4.0 and a list of all its breaking changes
+---
+
+# v4.0
+
+[![Release notes v4.0.0](https://img.shields.io/badge/Release_notes-v4.0-green?style=flat-square)](https://github.com/riok/mapperly/releases/tag/v4.0.0)
+[![NuGet v4.0.0](https://img.shields.io/badge/NuGet-v4.0-blue?style=flat-square)](https://www.nuget.org/packages/Riok.Mapperly/4.0.0)
+[![API Diff v4.0.0 / v3.6.0](https://img.shields.io/badge/API--Diff-v4.0_%2F_v3.6-yellow?style=flat-square)](https://www.fuget.org/packages/Riok.Mapperly/4.0.0/lib/netstandard2.0/diff/3.6.0/)
+
+## Migration guide from v3.6.0
+
+- Adjust `.editorconfig` as needed, see [removed and replaced diagnostics](#removed-and-replaced-diagnostics)
+
+## Removed and replaced diagnostics
+
+The following diagnostics are removed or replaced. You may need to update the `.editorconfig` files.
+
+- `RMG017: An init only member can have one configuration at max` and `RMG027: A constructor parameter can have one configuration at max` merged into the new `RMG074: Multiple mappings are configured for the same target member`
+- `RMG026: Cannot map from indexed member` is removed, starting with 4.0 indexed members are ignored
+- `RMG028: Constructor parameter cannot handle target paths` is removed as this is now supported.

--- a/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
@@ -185,5 +185,6 @@ RMG080  | Mapper   | Error    | The MapValueAttribute does not support types and
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 RMG017  | Mapper   | Warning  | An init only member can have one configuration at max
+RMG026  | Mapper   | Info     | Cannot map from indexed member
 RMG027  | Mapper   | Warning  | A constructor parameter can have one configuration at max
 RMG028  | Mapper   | Warning  | Constructor parameter cannot handle target paths

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
@@ -130,19 +130,6 @@ public static class ObjectMemberMappingBodyBuilder
             return false;
         }
 
-        // cannot map from an indexed member
-        if (sourceMemberPath?.Member?.IsIndexer == true)
-        {
-            ctx.BuilderContext.ReportDiagnostic(
-                DiagnosticDescriptors.CannotMapFromIndexedMember,
-                ctx.Mapping.SourceType,
-                sourceMemberPath.FullName,
-                ctx.Mapping.TargetType,
-                targetMemberPath.FullName
-            );
-            return false;
-        }
-
         return true;
     }
 

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -225,16 +225,6 @@ public static class DiagnosticDescriptors
             true
         );
 
-    public static readonly DiagnosticDescriptor CannotMapFromIndexedMember =
-        new(
-            "RMG026",
-            "Cannot map from indexed member",
-            "Cannot map from indexed member {0}.{1} to member {2}.{3}",
-            DiagnosticCategories.Mapper,
-            DiagnosticSeverity.Info,
-            true
-        );
-
     public static readonly DiagnosticDescriptor QueryableProjectionMappingsDoNotSupportReferenceHandling =
         new(
             "RMG029",

--- a/src/Riok.Mapperly/Symbols/MappableMember.cs
+++ b/src/Riok.Mapperly/Symbols/MappableMember.cs
@@ -7,7 +7,7 @@ internal static class MappableMember
 {
     public static IMappableMember? Create(SymbolAccessor accessor, ISymbol symbol)
     {
-        if (!accessor.IsAccessible(symbol))
+        if (!accessor.IsAccessible(symbol) || !symbol.CanBeReferencedByName)
             return null;
 
         return symbol switch

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectNoMemberMappingsTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectNoMemberMappingsTest.cs
@@ -9,7 +9,7 @@ public class ObjectNoMemberMappingsTest
     {
         var source = TestSourceBuilder.Mapping("A", "B", "class A;", "class B;");
         TestHelper
-            .GenerateMapper(source, TestHelperOptions.AllowAndIncludeDiagnostics)
+            .GenerateMapper(source, TestHelperOptions.AllowAndIncludeAllDiagnostics)
             .Should()
             .HaveDiagnostic(DiagnosticDescriptors.NoMemberMappings, "No members are mapped in the object mapping from A to B")
             .HaveAssertedAllDiagnostics();
@@ -27,7 +27,7 @@ public class ObjectNoMemberMappingsTest
             "class D;"
         );
         TestHelper
-            .GenerateMapper(source, TestHelperOptions.AllowAndIncludeDiagnostics)
+            .GenerateMapper(source, TestHelperOptions.AllowAndIncludeAllDiagnostics)
             .Should()
             .HaveDiagnostic(DiagnosticDescriptors.NoMemberMappings, "No members are mapped in the object mapping from C to D")
             .HaveAssertedAllDiagnostics();

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
@@ -120,7 +120,7 @@ public class ObjectPropertyTest
     }
 
     [Fact]
-    public void ShouldIgnoreIndexedPropertyOnSourceWithDiagnostic()
+    public void ShouldIgnoreIndexedProperty()
     {
         var source = TestSourceBuilder.Mapping(
             "A",
@@ -130,9 +130,16 @@ public class ObjectPropertyTest
         );
 
         TestHelper
-            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .GenerateMapper(source, TestHelperOptions.AllowAndIncludeAllDiagnostics)
             .Should()
-            .HaveDiagnostic(DiagnosticDescriptors.CannotMapFromIndexedMember, "Cannot map from indexed member A.this[] to member B.this[]");
+            .HaveDiagnostic(DiagnosticDescriptors.NoMemberMappings, "No members are mapped in the object mapping from A to B")
+            .HaveAssertedAllDiagnostics()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
     }
 
     [Fact]

--- a/test/Riok.Mapperly.Tests/TestHelperOptions.cs
+++ b/test/Riok.Mapperly.Tests/TestHelperOptions.cs
@@ -35,7 +35,7 @@ public record TestHelperOptions(
     /// <summary>
     /// Includes all ignored diagnostics.
     /// </summary>
-    public static readonly TestHelperOptions AllowAndIncludeDiagnostics = AllowDiagnostics with { IgnoredDiagnostics = null, };
+    public static readonly TestHelperOptions AllowAndIncludeAllDiagnostics = AllowDiagnostics with { IgnoredDiagnostics = null, };
 
     public static readonly TestHelperOptions AllowInfoDiagnostics = Default with
     {


### PR DESCRIPTION
* Removes RMG026 and simply ignores indexed properties to simplify referencable member mapping logic

