### PR TITLE
feat!: add enum underlying type conversion

### DIFF
--- a/docs/docs/breaking-changes/4-0.md
+++ b/docs/docs/breaking-changes/4-0.md
@@ -12,6 +12,7 @@ description: How to upgrade to Mapperly v4.0 and a list of all its breaking chan
 ## Migration guide from v3.6.0
 
 - Adjust `.editorconfig` as needed, see [removed and replaced diagnostics](#removed-and-replaced-diagnostics)
+- If the `ExplicitCast` conversion is disabled, disable the new `EnumUnderlyingType` conversion too
 
 ## Removed and replaced diagnostics
 
@@ -20,3 +21,11 @@ The following diagnostics are removed or replaced. You may need to update the `.
 - `RMG017: An init only member can have one configuration at max` and `RMG027: A constructor parameter can have one configuration at max` merged into the new `RMG074: Multiple mappings are configured for the same target member`
 - `RMG026: Cannot map from indexed member` is removed, starting with 4.0 indexed members are ignored
 - `RMG028: Constructor parameter cannot handle target paths` is removed as this is now supported.
+
+## Enum underlying type conversion
+
+A new `EnumUnderlyingType` conversion is added.
+Whenever Mapperly tries to map from/to an enum and does not succeed,
+Mapperly tries to map from/to the underlying type of the enum and explicitly cast the resulting value to the enum type.
+Until v3.6.0 Mapperly used the `ExplicitCast` to enable/disable this conversion.
+Starting with v4.0 Mapperly introduces a new `EnumUnderlyingType` conversion to enable/disable this conversion.

--- a/src/Riok.Mapperly.Abstractions/MappingConversionType.cs
+++ b/src/Riok.Mapperly.Abstractions/MappingConversionType.cs
@@ -115,6 +115,11 @@ public enum MappingConversionType
     Tuple = 1 << 15,
 
     /// <summary>
+    /// Allow using the underlying type of an enum to map from or to an enum type.
+    /// </summary>
+    EnumUnderlyingType = 1 << 16,
+
+    /// <summary>
     /// Enables all supported conversions.
     /// </summary>
     All = ~None,

--- a/src/Riok.Mapperly.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Riok.Mapperly.Abstractions/PublicAPI.Shipped.txt
@@ -83,6 +83,7 @@ Riok.Mapperly.Abstractions.MappingConversionType.StringToEnum = 32 -> Riok.Mappe
 Riok.Mapperly.Abstractions.MappingConversionType.ToStringMethod = 16 -> Riok.Mapperly.Abstractions.MappingConversionType
 Riok.Mapperly.Abstractions.MappingConversionType.Tuple = 32768 -> Riok.Mapperly.Abstractions.MappingConversionType
 Riok.Mapperly.Abstractions.MappingConversionType.Queryable = 1024 -> Riok.Mapperly.Abstractions.MappingConversionType
+Riok.Mapperly.Abstractions.MappingConversionType.EnumUnderlyingType = 65536 -> Riok.Mapperly.Abstractions.MappingConversionType
 Riok.Mapperly.Abstractions.MapperAttribute.UseReferenceHandling.get -> bool
 Riok.Mapperly.Abstractions.MapperAttribute.UseReferenceHandling.set -> void
 Riok.Mapperly.Abstractions.ReferenceHandling.IReferenceHandler

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumMappingBuilder.cs
@@ -22,7 +22,7 @@ public static class EnumMappingBuilder
         if (!sourceIsEnum || !targetIsEnum)
         {
             return
-                ctx.IsConversionEnabled(MappingConversionType.ExplicitCast)
+                ctx.IsConversionEnabled(MappingConversionType.EnumUnderlyingType)
                 && ctx.FindOrBuildMapping(sourceEnumType ?? ctx.Source, targetEnumType ?? ctx.Target) is { } delegateMapping
                 ? new CastMapping(ctx.Source, ctx.Target, delegateMapping)
                 : null;

--- a/test/Riok.Mapperly.Tests/Mapping/EnumTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumTest.cs
@@ -446,4 +446,33 @@ public class EnumTest
             .HaveDiagnostic(DiagnosticDescriptors.EnumConfigurationOnNonEnumMapping)
             .HaveAssertedAllDiagnostics();
     }
+
+    [Fact]
+    public void FromEnumUnderlyingTypeMapping()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial A Map(string source);",
+            TestSourceBuilderOptions.WithDisabledMappingConversion(MappingConversionType.StringToEnum),
+            "enum A { V1, V2 }"
+        );
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::A)int.Parse(source);");
+    }
+
+    [Fact]
+    public void FromEnumUnderlyingTypeMappingDisabledUnderlayingConversion()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial A Map(string source);",
+            TestSourceBuilderOptions.WithDisabledMappingConversion(
+                MappingConversionType.StringToEnum,
+                MappingConversionType.EnumUnderlyingType
+            ),
+            "enum A { V1, V2 }"
+        );
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.CouldNotCreateMapping)
+            .HaveAssertedAllDiagnostics();
+    }
 }


### PR DESCRIPTION
BREAKING CHANGE: For enum underlying type conversions the new EnumUnderlyingType conversion is used instead of ExplicitCast
