### PR TITLE
 fix: Replace invalid MapPropertyAttribute constructors with valid versions

### DIFF
--- a/docs/docs/breaking-changes/4-0.md
+++ b/docs/docs/breaking-changes/4-0.md
@@ -11,9 +11,17 @@ description: How to upgrade to Mapperly v4.0 and a list of all its breaking chan
 
 ## Migration guide from v3.6.0
 
+- `MapPropertyAttribute.ctor(string[], string[])` is marked as obsolete, replace either with `MapPropertyAttribute.ctor(string[], string)` or `MapPropertyAttribute.ctor(string, string[])`.
 - Strict mappings are enabled by default, either use `MapperAttribute.RequiredMappingStrategy`/`MapperRequiredMappingAttribute` or revert to non-strict mappings (see [strict mappings by default](#strict-mappings-by-default)).
 - If the `ExplicitCast` conversion is disabled, disable the new `EnumUnderlyingType` conversion too.
 - To account for changed diagnostics adjust your `.editorconfig` as needed, see [updated diagnostics](#updated-diagnostics).
+
+## MapPropertyAttribute constructors
+
+Since Mapperly does not support source nested member to target nested member mappings,
+the constructor `MapPropertyAttribute.ctor(string[], string[])` is marked as obsolete
+and will be removed in a future release.
+Use `MapPropertyAttribute.ctor(string[], string)` or `MapPropertyAttribute.ctor(string, string[])` instead.
 
 ## Strict mappings by default
 

--- a/docs/docs/configuration/flattening.md
+++ b/docs/docs/configuration/flattening.md
@@ -11,7 +11,7 @@ If Mapperly can't resolve the target or source property correctly, it is possibl
 by either using the source and target property path names as arrays or using a dot separated property access path string
 
 ```csharp
-[MapProperty([nameof(Car.Make), nameof(Car.Make.Id)], [nameof(CarDto.MakeId)])]
+[MapProperty([nameof(Car.Make), nameof(Car.Make.Id)], nameof(CarDto.MakeId))]
 // Or alternatively
 [MapProperty("Make.Id", "MakeId")]
 // Or
@@ -29,9 +29,9 @@ If a property has many members that need to be flattened but that cannot be figu
 This will bring all sub-members of a specified member into scope as if they were defined on the source object:
 
 ```csharp
-[MapProperty([nameof(Car.Engine), nameof(Car.Engine.Horsepower)], [nameof(CarDto.Horsepower)])]
-[MapProperty([nameof(Car.Engine), nameof(Car.Engine.FuelType)], [nameof(CarDto.FuelType)])]
-[MapProperty([nameof(Car.Engine), nameof(Car.Engine.Cylinders)], [nameof(CarDto.Cylinders)])]
+[MapProperty([nameof(Car.Engine), nameof(Car.Engine.Horsepower)], nameof(CarDto.Horsepower))]
+[MapProperty([nameof(Car.Engine), nameof(Car.Engine.FuelType)], nameof(CarDto.FuelType))]
+[MapProperty([nameof(Car.Engine), nameof(Car.Engine.Cylinders)], nameof(CarDto.Cylinders))]
 // Is equivalent to:
 // highlight-start
 [MapNestedProperties(nameof(Car.Engine))]

--- a/src/Riok.Mapperly.Abstractions/MapPropertyAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapPropertyAttribute.cs
@@ -18,13 +18,39 @@ public sealed class MapPropertyAttribute : Attribute
     /// <param name="source">The name of the source property. The use of `nameof()` is encouraged. A path can be specified by joining property names with a '.'.</param>
     /// <param name="target">The name of the target property. The use of `nameof()` is encouraged. A path can be specified by joining property names with a '.'.</param>
     public MapPropertyAttribute(string source, string target)
-        : this(source.Split(PropertyAccessSeparator), target.Split(PropertyAccessSeparator)) { }
+    {
+        Source = source.Split(PropertyAccessSeparator);
+        Target = target.Split(PropertyAccessSeparator);
+    }
+
+    /// <summary>
+    /// Maps a specified source property to the specified target property.
+    /// </summary>
+    /// <param name="source">The path of the source property. The use of `nameof()` is encouraged.</param>
+    /// <param name="target">The name of the target property. The use of `nameof()` is encouraged. A path can be specified by joining property names with a '.'.</param>
+    public MapPropertyAttribute(string[] source, string target)
+    {
+        Source = source;
+        Target = target.Split(PropertyAccessSeparator);
+    }
 
     /// <summary>
     /// Maps a specified source property to the specified target property.
     /// </summary>
     /// <param name="source">The path of the source property. The use of `nameof()` is encouraged.</param>
     /// <param name="target">The path of the target property. The use of `nameof()` is encouraged.</param>
+    public MapPropertyAttribute(string source, string[] target)
+    {
+        Source = source.Split(PropertyAccessSeparator);
+        Target = target;
+    }
+
+    /// <summary>
+    /// Maps a specified source property to the specified target property.
+    /// </summary>
+    /// <param name="source">The path of the source property. The use of `nameof()` is encouraged.</param>
+    /// <param name="target">The path of the target property. The use of `nameof()` is encouraged.</param>
+    [Obsolete("Use MapPropertyAttribute(string[], string) or MapPropertyAttribute(string, string[]) instead.")]
     public MapPropertyAttribute(string[] source, string[] target)
     {
         Source = source;

--- a/src/Riok.Mapperly.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Riok.Mapperly.Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Riok.Mapperly.Abstractions.MapPropertyAttribute.MapPropertyAttribute(string! source, string![]! target) -> void
+Riok.Mapperly.Abstractions.MapPropertyAttribute.MapPropertyAttribute(string![]! source, string! target) -> void

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/StaticTestMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/StaticTestMapper.cs
@@ -52,7 +52,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
 
         [MapProperty(nameof(TestObject.RenamedStringValue), nameof(TestObjectDto.RenamedStringValue2))]
         [MapProperty(
-            new[] { nameof(TestObject.UnflatteningIdValue) },
+            nameof(TestObject.UnflatteningIdValue),
             new[] { nameof(TestObjectDto.Unflattening), nameof(TestObjectDto.Unflattening.IdValue) }
         )]
         [MapProperty(

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/TestMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/TestMapper.cs
@@ -69,7 +69,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         )]
         [MapProperty(nameof(TestObject.RenamedStringValue), nameof(TestObjectDto.RenamedStringValue2))]
         [MapProperty(
-            new[] { nameof(TestObject.UnflatteningIdValue) },
+            nameof(TestObject.UnflatteningIdValue),
             new[] { nameof(TestObjectDto.Unflattening), nameof(TestObjectDto.Unflattening.IdValue) }
         )]
         [MapProperty(


### PR DESCRIPTION
* Marks `MapPropertyattribute.ctor(string[], string[])` as obsolete
* Adds `MapPropertyAttribute.ctor(string[], string)`
* Adds `MapPropertyAttribute.ctor(string, string[])`
