### PR TITLE
Support inline expression with casting

### DIFF
--- a/src/Riok.Mapperly/Descriptors/InlineExpressionRewriter.cs
+++ b/src/Riok.Mapperly/Descriptors/InlineExpressionRewriter.cs
@@ -70,7 +70,11 @@ public class InlineExpressionRewriter(SemanticModel semanticModel, Func<IMethodS
     {
         var result = base.VisitCastExpression(node);
 
-        if (result is CastExpressionSyntax typedResult && semanticModel.GetSymbolInfo(node.Type).Symbol is ITypeSymbol namedTypeSymbol)
+        if (
+            CanBeInlined
+            && result is CastExpressionSyntax typedResult
+            && semanticModel.GetSymbolInfo(node.Type).Symbol is ITypeSymbol namedTypeSymbol
+        )
         {
             var fullyQualifiedType = FullyQualifiedIdentifier(namedTypeSymbol);
 
@@ -85,7 +89,8 @@ public class InlineExpressionRewriter(SemanticModel semanticModel, Func<IMethodS
         var result = base.VisitBinaryExpression(node);
 
         if (
-            result is BinaryExpressionSyntax typedResult
+            CanBeInlined
+            && result is BinaryExpressionSyntax typedResult
             && typedResult.IsKind(SyntaxKind.AsExpression)
             && semanticModel.GetSymbolInfo(node.Right).Symbol is ITypeSymbol namedTypeSymbol
         )

--- a/src/Riok.Mapperly/Descriptors/InlineExpressionRewriter.cs
+++ b/src/Riok.Mapperly/Descriptors/InlineExpressionRewriter.cs
@@ -86,7 +86,7 @@ public class InlineExpressionRewriter(SemanticModel semanticModel, Func<IMethodS
 
         if (
             result is BinaryExpressionSyntax typedResult
-            && typedResult.Kind() is SyntaxKind.AsExpression
+            && typedResult.IsKind(SyntaxKind.AsExpression)
             && semanticModel.GetSymbolInfo(node.Right).Symbol is ITypeSymbol namedTypeSymbol
         )
         {

--- a/test/Riok.Mapperly.Tests/Helpers/InlineExpressionRewriterTest.cs
+++ b/test/Riok.Mapperly.Tests/Helpers/InlineExpressionRewriterTest.cs
@@ -20,7 +20,7 @@ public class InlineExpressionRewriterTest
     [InlineData("new TestRecord[2].ToString()", true, "new global::TestRecord[2].ToString()")]
     [InlineData("base.ToString()", false)] // CS0831
     [InlineData("(1,2).ToString()", false)] // CS8143
-    [InlineData("((string?)source)?.ToString()!", false)] // CS8072
+    [InlineData("((string)source)?.ToString()!", false)] // CS8072
     [InlineData("source switch { _ => \"fooBar\" }", false)] // CS8514
     [InlineData("throw new Exception()", false)] // CS8188
     [InlineData(
@@ -61,6 +61,104 @@ public class InlineExpressionRewriterTest
         );
         inlineOk.Should().Be(canBeInlined);
         result.Should().Be(inlinedExpression ?? expression);
+    }
+
+    [Fact]
+    public void RewriteExpressionContainingCasting()
+    {
+        var (result, inlineOk) = Rewrite(
+            """
+            using AnotherAssembly;
+
+            public class Test
+            {
+                public bool MapExpression(int value) => ((MyEnum) value & MyEnum.OptionA) > 0;
+            }
+
+            namespace AnotherAssembly {
+                enum MyEnum
+                {
+                    OptionA = 1,
+                    OptionB = 2,
+                }
+            }
+            """
+        );
+
+        inlineOk.Should().BeTrue();
+        result.Should().Be("((global::AnotherAssembly.MyEnum) value & global::AnotherAssembly.MyEnum.OptionA) > 0");
+    }
+
+    [Fact]
+    public void RewriteExpressionContainingBinaryAnd()
+    {
+        var (result, inlineOk) = Rewrite(
+            """
+            using AnotherAssembly;
+
+            public class Test
+            {
+                public bool MapExpression(MyEnum value) => (value & MyEnum.OptionA) > 0;
+            }
+
+            namespace AnotherAssembly {
+                enum MyEnum
+                {
+                    OptionA = 1,
+                    OptionB = 2,
+                }
+            }
+            """
+        );
+
+        inlineOk.Should().BeTrue();
+        result.Should().Be("(value & global::AnotherAssembly.MyEnum.OptionA) > 0");
+    }
+
+    [Fact]
+    public void RewriteExpressionContainingAsStatement()
+    {
+        var (result, inlineOk) = Rewrite(
+            """
+            using AnotherAssembly;
+
+            public class Test
+            {
+                public int MapExpression(A value) => (value as B).Value;
+            }
+
+            namespace AnotherAssembly {
+                record A;
+                record B(int Value) : A;
+            }
+            """
+        );
+
+        inlineOk.Should().BeTrue();
+        result.Should().Be("(value as global::AnotherAssembly.B).Value");
+    }
+
+    [Fact]
+    public void RewriteExpressionContainingAsStatementAndCasting()
+    {
+        var (result, inlineOk) = Rewrite(
+            """
+            using AnotherAssembly;
+
+            public class Test
+            {
+                public string MapExpression(A value) => (string)(object)(value as B).Value;
+            }
+
+            namespace AnotherAssembly {
+                record A;
+                record B(string Value) : A;
+            }
+            """
+        );
+
+        inlineOk.Should().BeTrue();
+        result.Should().Be("(string)(object)(value as global::AnotherAssembly.B).Value");
     }
 
     private (string Result, bool CanBeInlined) Rewrite([StringSyntax(StringSyntax.CSharp)] string source)

--- a/test/Riok.Mapperly.Tests/Helpers/InlineExpressionRewriterTest.cs
+++ b/test/Riok.Mapperly.Tests/Helpers/InlineExpressionRewriterTest.cs
@@ -20,7 +20,7 @@ public class InlineExpressionRewriterTest
     [InlineData("new TestRecord[2].ToString()", true, "new global::TestRecord[2].ToString()")]
     [InlineData("base.ToString()", false)] // CS0831
     [InlineData("(1,2).ToString()", false)] // CS8143
-    [InlineData("((string)source)?.ToString()!", false)] // CS8072
+    [InlineData("((string?)source)?.ToString()!", false)] // CS8072
     [InlineData("source switch { _ => \"fooBar\" }", false)] // CS8514
     [InlineData("throw new Exception()", false)] // CS8188
     [InlineData(


### PR DESCRIPTION
# Support inline expression with casting

## Description

When using `Use = nameof()`, which contains casting, e.g. `((MyEnum) value & MyEnum.OptionA) > 0` generated mapping does not resolve the fully qualified type of the casted type.

## Checklist

- [x] The existing code style is followed
- [ ] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
