### PR TITLE
fix: improve member matching performance for member names with lots of upper case letters

### DIFF
--- a/docs/docs/breaking-changes/4-0.md
+++ b/docs/docs/breaking-changes/4-0.md
@@ -18,6 +18,7 @@ description: How to upgrade to Mapperly v4.0 and a list of all its breaking chan
 - To account for changed diagnostics adjust your `.editorconfig` as needed, see [updated diagnostics](#updated-diagnostics).
 - The ordering of the member assignments in mappings may change, if you rely on the order of members being mapped, you may need to diff and verify the generated source code.
 - Well-known .NET immutable types are not copied, even if `UseDeepCloning` is enabled.
+- For long property names, auto-flattening may not work anymore and may need to be configured manually by applying the `MapPropertyAttribute`.
 
 ## MapPropertyAttribute constructors
 
@@ -48,6 +49,14 @@ ForEach mappings now also map members and constructor parameters the same way as
 This may break existing code because a member that wasn't mapped before may now be mapped.
 New diagnostics can also be reported for existing mappings
 (e.g., if a new member is being mapped, but Mapperly cannot create a conversion for its types).
+
+## Limited auto-flattening
+
+Mapperly tries to flatten properties automatically.
+For this Mapperly tries to access object members based on the pascal case member name notation of C#.
+Starting with 4.0 Mapperly will only try up to 256 member path permutations.
+Before all possible permutations were tried.
+Auto-flattening can always be overwritten by applying the `MapPropertyAttribute`.
 
 ## Updated diagnostics
 

--- a/src/Riok.Mapperly/Configuration/StringMemberPath.cs
+++ b/src/Riok.Mapperly/Configuration/StringMemberPath.cs
@@ -2,9 +2,12 @@ using Riok.Mapperly.Helpers;
 
 namespace Riok.Mapperly.Configuration;
 
-public record StringMemberPath(ImmutableEquatableArray<string> Path)
+public readonly record struct StringMemberPath(ImmutableEquatableArray<string> Path)
 {
     public static readonly StringMemberPath Empty = new(ImmutableEquatableArray<string>.Empty);
+
+    public StringMemberPath(IEnumerable<string> path)
+        : this(path.ToImmutableEquatableArray()) { }
 
     public const char MemberAccessSeparator = '.';
     private const string MemberAccessSeparatorString = ".";
@@ -12,4 +15,6 @@ public record StringMemberPath(ImmutableEquatableArray<string> Path)
     public string FullName => string.Join(MemberAccessSeparatorString, Path);
 
     public override string ToString() => FullName;
+
+    public StringMemberPath SkipRoot() => new(Path.Skip(1).ToImmutableEquatableArray());
 }

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
@@ -127,7 +127,7 @@ public abstract class MembersMappingBuilderContext<T>(MappingBuilderContext buil
     ) => _state.TryGetMemberValueConfigs(targetMemberName, ignoreCase, out memberConfigs);
 
     protected virtual bool TryFindSourcePath(
-        IReadOnlyList<IReadOnlyList<string>> pathCandidates,
+        IEnumerable<StringMemberPath> pathCandidates,
         bool ignoreCase,
         [NotNullWhen(true)] out SourceMemberPath? sourcePath
     )
@@ -183,7 +183,7 @@ public abstract class MembersMappingBuilderContext<T>(MappingBuilderContext buil
     private MemberMappingInfo? ResolveMemberMappingInfo(MemberValueMappingConfiguration config)
     {
         if (
-            !BuilderContext.SymbolAccessor.TryFindMemberPath(Mapping.TargetType, config.Target.Path, out var foundMemberPath)
+            !BuilderContext.SymbolAccessor.TryFindMemberPath(Mapping.TargetType, config.Target, out var foundMemberPath)
             || foundMemberPath is not NonEmptyMemberPath targetMemberPath
         )
         {
@@ -205,7 +205,7 @@ public abstract class MembersMappingBuilderContext<T>(MappingBuilderContext buil
     private MemberMappingInfo? ResolveMemberMappingInfo(MemberMappingConfiguration config)
     {
         if (
-            !BuilderContext.SymbolAccessor.TryFindMemberPath(Mapping.TargetType, config.Target.Path, out var foundMemberPath)
+            !BuilderContext.SymbolAccessor.TryFindMemberPath(Mapping.TargetType, config.Target, out var foundMemberPath)
             || foundMemberPath is not NonEmptyMemberPath targetMemberPath
         )
         {
@@ -229,7 +229,7 @@ public abstract class MembersMappingBuilderContext<T>(MappingBuilderContext buil
 
     private bool ResolveMemberConfigSourcePath(MemberMappingConfiguration config, [NotNullWhen(true)] out SourceMemberPath? sourcePath)
     {
-        if (!BuilderContext.SymbolAccessor.TryFindMemberPath(Mapping.SourceType, config.Source.Path, out var sourceMemberPath))
+        if (!BuilderContext.SymbolAccessor.TryFindMemberPath(Mapping.SourceType, config.Source, out var sourceMemberPath))
         {
             BuilderContext.ReportDiagnostic(
                 DiagnosticDescriptors.ConfiguredMappingSourceMemberNotFound,
@@ -255,7 +255,7 @@ public abstract class MembersMappingBuilderContext<T>(MappingBuilderContext buil
     )
     {
         ignoreCase ??= BuilderContext.Configuration.Mapper.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseInsensitive;
-        var pathCandidates = MemberPathCandidateBuilder.BuildMemberPathCandidates(targetMemberName).Select(cs => cs.ToList()).ToList();
+        var pathCandidates = MemberPathCandidateBuilder.BuildMemberPathCandidates(targetMemberName);
 
         // First, try to find the property on (a sub-path of) the source type itself. (If this is undesired, an Ignore property can be used.)
         if (TryFindSourcePath(pathCandidates, ignoreCase.Value, out sourceMemberPath))

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NestedMappingsContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NestedMappingsContext.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Riok.Mapperly.Configuration;
 using Riok.Mapperly.Diagnostics;
 using Riok.Mapperly.Symbols.Members;
 
@@ -28,7 +29,7 @@ public class NestedMappingsContext
 
         foreach (var nestedMemberConfig in ctx.Configuration.Members.NestedMappings)
         {
-            if (!ctx.SymbolAccessor.TryFindMemberPath(ctx.Source, nestedMemberConfig.Source.Path, out var memberPath))
+            if (!ctx.SymbolAccessor.TryFindMemberPath(ctx.Source, nestedMemberConfig.Source, out var memberPath))
             {
                 ctx.ReportDiagnostic(
                     DiagnosticDescriptors.ConfiguredMappingNestedMemberNotFound,
@@ -45,7 +46,7 @@ public class NestedMappingsContext
     }
 
     public bool TryFindNestedSourcePath(
-        List<List<string>> pathCandidates,
+        IEnumerable<StringMemberPath> pathCandidates,
         bool ignoreCase,
         [NotNullWhen(true)] out SourceMemberPath? sourceMemberPath
     )
@@ -61,7 +62,7 @@ public class NestedMappingsContext
     }
 
     private bool TryFindNestedSourcePath(
-        List<List<string>> pathCandidates,
+        IEnumerable<StringMemberPath> pathCandidates,
         bool ignoreCase,
         MemberPath nestedMemberPath,
         [NotNullWhen(true)] out SourceMemberPath? sourceMemberPath

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewValueTupleConstructorBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewValueTupleConstructorBuilderContext.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
+using Riok.Mapperly.Configuration;
 using Riok.Mapperly.Descriptors.Mappings;
 using Riok.Mapperly.Descriptors.Mappings.MemberMappings;
 using Riok.Mapperly.Symbols.Members;
@@ -54,7 +55,7 @@ public class NewValueTupleConstructorBuilderContext<T> : MembersMappingBuilderCo
     }
 
     protected override bool TryFindSourcePath(
-        IReadOnlyList<IReadOnlyList<string>> pathCandidates,
+        IEnumerable<StringMemberPath> pathCandidates,
         bool ignoreCase,
         [NotNullWhen(true)] out SourceMemberPath? sourceMemberPath
     )
@@ -69,16 +70,16 @@ public class NewValueTupleConstructorBuilderContext<T> : MembersMappingBuilderCo
     }
 
     private bool TryFindSecondaryTupleSourceField(
-        IReadOnlyList<IReadOnlyList<string>> pathCandidates,
+        IEnumerable<StringMemberPath> pathCandidates,
         [NotNullWhen(true)] out SourceMemberPath? sourcePath
     )
     {
         foreach (var pathParts in pathCandidates)
         {
-            if (pathParts.Count != 1)
+            if (pathParts.Path.Count != 1)
                 continue;
 
-            var name = pathParts[0];
+            var name = pathParts.Path[0];
             if (_secondarySourceNames.TryGetValue(name, out var sourceField))
             {
                 var sourceFieldMember = new FieldMember(sourceField, BuilderContext.SymbolAccessor);

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewValueTupleExpressionBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NewValueTupleExpressionBuilderContext.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
+using Riok.Mapperly.Configuration;
 using Riok.Mapperly.Descriptors.Mappings;
 using Riok.Mapperly.Descriptors.Mappings.MemberMappings;
 using Riok.Mapperly.Symbols.Members;
@@ -54,7 +55,7 @@ public class NewValueTupleExpressionBuilderContext<T> : MembersContainerBuilderC
     }
 
     protected override bool TryFindSourcePath(
-        IReadOnlyList<IReadOnlyList<string>> pathCandidates,
+        IEnumerable<StringMemberPath> pathCandidates,
         bool ignoreCase,
         [NotNullWhen(true)] out SourceMemberPath? sourceMemberPath
     )
@@ -69,16 +70,16 @@ public class NewValueTupleExpressionBuilderContext<T> : MembersContainerBuilderC
     }
 
     private bool TryFindSecondaryTupleSourceField(
-        IReadOnlyList<IReadOnlyList<string>> pathCandidates,
+        IEnumerable<StringMemberPath> pathCandidates,
         [NotNullWhen(true)] out SourceMemberPath? sourcePath
     )
     {
         foreach (var pathParts in pathCandidates)
         {
-            if (pathParts.Count != 1)
+            if (pathParts.Path.Count != 1)
                 continue;
 
-            var name = pathParts[0];
+            var name = pathParts.Path[0];
             if (_secondarySourceNames.TryGetValue(name, out var sourceField))
             {
                 var sourceFieldMember = new FieldMember(sourceField, BuilderContext.SymbolAccessor);

--- a/src/Riok.Mapperly/Descriptors/MemberPathCandidateBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MemberPathCandidateBuilder.cs
@@ -1,32 +1,42 @@
+using Riok.Mapperly.Configuration;
+
 namespace Riok.Mapperly.Descriptors;
 
 public static class MemberPathCandidateBuilder
 {
+    /// <summary>
+    /// Maximum number of indices which are considered to compute the member path candidates.
+    /// </summary>
+    private const int MaxPascalCaseIndices = 8;
+
     /// <summary>
     /// Splits a name into pascal case chunks and joins them together in all possible combinations.
     /// <example><c>"MyValueId"</c> leads to <c>[["MyValueId"], ["My", "ValueId"], ["MyValue", "Id"], ["My", "Value", "Id"]</c></example>
     /// </summary>
     /// <param name="name">The name to build candidates from.</param>
     /// <returns>The joined member path groups.</returns>
-    public static IEnumerable<IEnumerable<string>> BuildMemberPathCandidates(string name)
+    public static IEnumerable<StringMemberPath> BuildMemberPathCandidates(string name)
     {
         if (name.Length == 0)
             yield break;
 
         // yield full string
-        yield return new[] { name };
+        // as a fast path (often member match by their exact name)
+        yield return new StringMemberPath([name]);
 
-        var indices = GetPascalCaseSplitIndices(name).ToArray();
+        var indices = GetPascalCaseSplitIndices(name).Take(MaxPascalCaseIndices).ToArray();
+        if (indices.Length == 0)
+            yield break;
 
         // try all permutations, skipping the first because the full string is already yielded
         var permutationsCount = 1 << indices.Length;
         for (var i = 1; i < permutationsCount; i++)
         {
-            yield return BuildName(name, indices, i);
+            yield return new StringMemberPath(BuildPermutationParts(name, indices, i));
         }
     }
 
-    private static IEnumerable<string> BuildName(string source, int[] splitIndices, int enabledSplitPositions)
+    private static IEnumerable<string> BuildPermutationParts(string source, int[] splitIndices, int enabledSplitPositions)
     {
         var lastSplitIndex = 0;
         var currentSplitPosition = 1;

--- a/src/Riok.Mapperly/Helpers/ImmutableEquatableArray.cs
+++ b/src/Riok.Mapperly/Helpers/ImmutableEquatableArray.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Runtime.CompilerServices;
 
 namespace Riok.Mapperly.Helpers;
 
 /// <summary>
 /// Provides an immutable list implementation which implements sequence equality.
 /// </summary>
+[CollectionBuilder(typeof(ImmutableEquatableArray), nameof(ImmutableEquatableArray.Create))]
 public sealed class ImmutableEquatableArray<T> : IEquatable<ImmutableEquatableArray<T>>, IReadOnlyList<T>
     where T : IEquatable<T>
 {
@@ -19,6 +21,9 @@ public sealed class ImmutableEquatableArray<T> : IEquatable<ImmutableEquatableAr
     public int Count => _values.Length;
 
     public ImmutableEquatableArray(IEnumerable<T> values)
+        : this(values.ToArray()) { }
+
+    public ImmutableEquatableArray(ReadOnlySpan<T> values)
         : this(values.ToArray()) { }
 
     /// <summary>
@@ -33,7 +38,7 @@ public sealed class ImmutableEquatableArray<T> : IEquatable<ImmutableEquatableAr
 
     public static ImmutableEquatableArray<T> Empty => _empty ??= new([]);
 
-    public bool Equals(ImmutableEquatableArray<T>? other) => other != null && ((ReadOnlySpan<T>)_values).SequenceEqual(other._values);
+    public bool Equals(ImmutableEquatableArray<T> other) => _values.SequenceEqual(other._values);
 
     public override bool Equals(object? obj) => obj is ImmutableEquatableArray<T> other && Equals(other);
 
@@ -83,5 +88,8 @@ public sealed class ImmutableEquatableArray<T> : IEquatable<ImmutableEquatableAr
 public static class ImmutableEquatableArray
 {
     public static ImmutableEquatableArray<T> ToImmutableEquatableArray<T>(this IEnumerable<T> values)
+        where T : IEquatable<T> => new(values);
+
+    public static ImmutableEquatableArray<T> Create<T>(ReadOnlySpan<T> values)
         where T : IEquatable<T> => new(values);
 }

--- a/test/Riok.Mapperly.Tests/Descriptors/MemberPathCandidateBuilderTest.cs
+++ b/test/Riok.Mapperly.Tests/Descriptors/MemberPathCandidateBuilderTest.cs
@@ -31,8 +31,14 @@ public class MemberPathCandidateBuilderTest
     {
         MemberPathCandidateBuilder
             .BuildMemberPathCandidates(name)
-            .Select(x => string.Join(".", x))
+            .Select(x => x.FullName)
             .Should()
             .BeEquivalentTo(chunks, o => o.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void BuildMemberPathCandidatesWithPascalCaseShouldLimitPermutations()
+    {
+        MemberPathCandidateBuilder.BuildMemberPathCandidates("NOT_A_PASCAL_CASE_STRING").Should().HaveCount(256);
     }
 }


### PR DESCRIPTION
* Only compute member name permutations until a match is found
* Limit number of computed member permutations

Fixes #1444 