### PR TITLE
feat: improve constructor mapping readability

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Constructors/InstanceConstructor.cs
+++ b/src/Riok.Mapperly/Descriptors/Constructors/InstanceConstructor.cs
@@ -1,7 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Riok.Mapperly.Descriptors.Mappings;
-using Riok.Mapperly.Emit.Syntax;
 
 namespace Riok.Mapperly.Descriptors.Constructors;
 
@@ -13,5 +12,5 @@ public class InstanceConstructor(INamedTypeSymbol type) : IInstanceConstructor
         TypeMappingBuildContext ctx,
         IEnumerable<ArgumentSyntax> args,
         InitializerExpressionSyntax? initializer = null
-    ) => SyntaxFactoryHelper.CreateInstance(type, args).WithInitializer(initializer);
+    ) => ctx.SyntaxFactory.CreateInstance(type, args).WithInitializer(initializer);
 }

--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityInfo.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityInfo.cs
@@ -24,6 +24,6 @@ public abstract class EnsureCapacityInfo
             sum = Add(sourceCount, targetCount);
         }
 
-        return syntaxFactory.ExpressionStatement(Invocation(MemberAccess(target, EnsureCapacityName), sum));
+        return syntaxFactory.ExpressionStatement(syntaxFactory.Invocation(MemberAccess(target, EnsureCapacityName), sum));
     }
 }

--- a/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityNonEnumerated.cs
+++ b/src/Riok.Mapperly/Descriptors/Enumerables/EnsureCapacity/EnsureCapacityNonEnumerated.cs
@@ -31,7 +31,7 @@ public class EnsureCapacityNonEnumerated(IMemberGetter? targetAccessor, IMethodS
         var enumerableArgument = Argument(ctx.Source);
         var outVarArgument = OutVarArgument(sourceCountName);
 
-        var getNonEnumeratedInvocation = StaticInvocation(getNonEnumeratedMethod, enumerableArgument, outVarArgument);
+        var getNonEnumeratedInvocation = ctx.SyntaxFactory.StaticInvocation(getNonEnumeratedMethod, enumerableArgument, outVarArgument);
         var ensureCapacity = EnsureCapacityStatement(
             ctx.SyntaxFactory.AddIndentation(),
             target,

--- a/src/Riok.Mapperly/Descriptors/Mappings/DerivedExistingTargetTypeSwitchMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/DerivedExistingTargetTypeSwitchMapping.cs
@@ -66,8 +66,8 @@ public class DerivedExistingTargetTypeSwitchMapping(
         var defaultCaseLabel = DefaultSwitchLabel().AddLeadingLineFeed(sectionCtx.Indentation);
 
         // throw new ArgumentException(msg, nameof(ctx.Source)),
-        var sourceTypeExpr = Invocation(MemberAccess(ctx.Source, GetTypeMethodName));
-        var targetTypeExpr = Invocation(MemberAccess(target, GetTypeMethodName));
+        var sourceTypeExpr = ctx.SyntaxFactory.Invocation(MemberAccess(ctx.Source, GetTypeMethodName));
+        var targetTypeExpr = ctx.SyntaxFactory.Invocation(MemberAccess(target, GetTypeMethodName));
         var statementContext = sectionCtx.AddIndentation();
         var throwExpression = ThrowArgumentExpression(
                 InterpolatedString($"Cannot map {sourceTypeExpr} to {targetTypeExpr} as there is no known derived type mapping"),

--- a/src/Riok.Mapperly/Descriptors/Mappings/DerivedTypeSwitchMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/DerivedTypeSwitchMapping.cs
@@ -18,7 +18,7 @@ public class DerivedTypeSwitchMapping(ITypeSymbol sourceType, ITypeSymbol target
     public override ExpressionSyntax Build(TypeMappingBuildContext ctx)
     {
         // _ => throw new ArgumentException(msg, nameof(ctx.Source)),
-        var sourceTypeExpr = Invocation(MemberAccess(ctx.Source, GetTypeMethodName));
+        var sourceTypeExpr = ctx.SyntaxFactory.Invocation(MemberAccess(ctx.Source, GetTypeMethodName));
         var fallbackArm = SwitchArm(
             DiscardPattern(),
             ThrowArgumentExpression(

--- a/src/Riok.Mapperly/Descriptors/Mappings/Enums/EnumFromStringParseMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/Enums/EnumFromStringParseMapping.cs
@@ -22,7 +22,7 @@ public class EnumFromStringParseMapping(ITypeSymbol sourceType, ITypeSymbol targ
         // System.Enum.Parse<TargetType>(source, ignoreCase)
         if (genericParseMethodSupported)
         {
-            return GenericInvocation(
+            return ctx.SyntaxFactory.GenericInvocation(
                 EnumClassName,
                 ParseMethodName,
                 new[] { FullyQualifiedIdentifier(TargetType) },
@@ -32,7 +32,7 @@ public class EnumFromStringParseMapping(ITypeSymbol sourceType, ITypeSymbol targ
         }
 
         // (TargetType)System.Enum.Parse(typeof(TargetType), source, ignoreCase)
-        var enumParseInvocation = Invocation(
+        var enumParseInvocation = ctx.SyntaxFactory.Invocation(
             MemberAccess(EnumClassName, ParseMethodName),
             TypeOfExpression(FullyQualifiedIdentifier(TargetType)),
             ctx.Source,

--- a/src/Riok.Mapperly/Descriptors/Mappings/Enums/EnumFromStringSwitchMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/Enums/EnumFromStringSwitchMapping.cs
@@ -52,7 +52,7 @@ public class EnumFromStringSwitchMapping(
 
         // when s.Equals(nameof(source.Value1), StringComparison.OrdinalIgnoreCase)
         var whenClause = SwitchWhen(
-            Invocation(
+            InvocationWithoutIndention(
                 MemberAccess(ignoreCaseSwitchDesignatedVariableName, StringEqualsMethodName),
                 NameOf(typeMemberAccess),
                 IdentifierName(StringComparisonFullName)

--- a/src/Riok.Mapperly/Descriptors/Mappings/Enums/EnumToStringMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/Enums/EnumToStringMapping.cs
@@ -19,7 +19,7 @@ public class EnumToStringMapping(ITypeSymbol sourceType, ITypeSymbol targetType,
     public override IEnumerable<StatementSyntax> BuildBody(TypeMappingBuildContext ctx)
     {
         // fallback switch arm: _ => source.ToString()
-        var fallbackArm = SwitchArm(DiscardPattern(), Invocation(MemberAccess(ctx.Source, ToStringMethodName)));
+        var fallbackArm = SwitchArm(DiscardPattern(), ctx.SyntaxFactory.Invocation(MemberAccess(ctx.Source, ToStringMethodName)));
 
         // switch for each name to the enum value
         // eg: Enum1.Value1 => "Value1"

--- a/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/ForEachAddEnumerableExistingTargetMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/ForEachAddEnumerableExistingTargetMapping.cs
@@ -38,7 +38,7 @@ public class ForEachAddEnumerableExistingTargetMapping(
         var (loopItemCtx, loopItemVariableName) = ctx.WithNewSource(LoopItemVariableName);
         var convertedSourceItemExpression = elementMapping.Build(loopItemCtx);
         var addMethod = MemberAccess(target, insertMethodName);
-        var body = Invocation(addMethod, convertedSourceItemExpression);
+        var body = ctx.SyntaxFactory.Invocation(addMethod, convertedSourceItemExpression);
         yield return ctx.SyntaxFactory.ForEach(loopItemVariableName, ctx.Source, body);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/LinqConstructorMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/LinqConstructorMapping.cs
@@ -24,13 +24,13 @@ public class LinqConstructorMapping(
             var (lambdaCtx, lambdaSourceName) = ctx.WithNewScopedSource();
             var sourceMapExpression = elementMapping.Build(lambdaCtx);
             var convertLambda = Lambda(lambdaSourceName, sourceMapExpression);
-            mappedSource = Invocation(selectMethod, ctx.Source, convertLambda);
+            mappedSource = ctx.SyntaxFactory.Invocation(selectMethod, ctx.Source, convertLambda);
         }
         else
         {
             mappedSource = elementMapping.Build(ctx);
         }
 
-        return CreateInstance(TargetType, mappedSource);
+        return ctx.SyntaxFactory.CreateInstance(TargetType, mappedSource);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/LinqDictionaryMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/LinqDictionaryMapping.cs
@@ -23,7 +23,7 @@ public class LinqDictionaryMapping(
         // if key and value types do not change then use a simple call
         // ie: source.ToImmutableDictionary();
         if (keyMapping.IsSynthetic && valueMapping.IsSynthetic)
-            return Invocation(collectMethod, ctx.Source);
+            return ctx.SyntaxFactory.Invocation(collectMethod, ctx.Source);
 
         // create expressions mapping the key and value and then create the final expression
         // ie: source.ToImmutableDictionary(x => x.Key, x => (int)x.Value);
@@ -35,6 +35,6 @@ public class LinqDictionaryMapping(
         var valueMapExpression = valueMapping.Build(valueLambdaCtx);
         var valueExpression = Lambda(valueLambdaParamName, valueMapExpression);
 
-        return Invocation(collectMethod, ctx.Source, keyExpression, valueExpression);
+        return ctx.SyntaxFactory.Invocation(collectMethod, ctx.Source, keyExpression, valueExpression);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/LinqEnumerableMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/LinqEnumerableMapping.cs
@@ -25,13 +25,13 @@ public class LinqEnumerableMapping(
             var (lambdaCtx, lambdaSourceName) = ctx.WithNewScopedSource();
             var sourceMapExpression = elementMapping.Build(lambdaCtx);
             var convertLambda = Lambda(lambdaSourceName, sourceMapExpression);
-            mappedSource = Invocation(selectMethod, ctx.Source, convertLambda);
+            mappedSource = ctx.SyntaxFactory.Invocation(selectMethod, ctx.Source, convertLambda);
         }
         else
         {
             mappedSource = elementMapping.Build(ctx);
         }
 
-        return collectMethod == null ? mappedSource : Invocation(collectMethod, mappedSource);
+        return collectMethod == null ? mappedSource : ctx.SyntaxFactory.Invocation(collectMethod, mappedSource);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberNullDelegateAssignmentMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberNullDelegateAssignmentMapping.cs
@@ -74,7 +74,7 @@ public class MemberNullDelegateAssignmentMapping(
                 nullConditional: false,
                 skipTrailingNonNullable: true
             );
-            return new[] { ctx.SyntaxFactory.ExpressionStatement(ThrowArgumentNullException(nameofSourceAccess)) };
+            return [ctx.SyntaxFactory.ExpressionStatement(ThrowArgumentNullException(nameofSourceAccess))];
         }
 
         // target.A = null;

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/SourceValue/MethodProvidedSourceValue.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/SourceValue/MethodProvidedSourceValue.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using static Riok.Mapperly.Emit.Syntax.SyntaxFactoryHelper;
 
 namespace Riok.Mapperly.Descriptors.Mappings.MemberMappings.SourceValue;
 
@@ -8,5 +7,5 @@ namespace Riok.Mapperly.Descriptors.Mappings.MemberMappings.SourceValue;
 /// </summary>
 public class MethodProvidedSourceValue(string methodName) : ISourceValue
 {
-    public ExpressionSyntax Build(TypeMappingBuildContext ctx) => Invocation(methodName);
+    public ExpressionSyntax Build(TypeMappingBuildContext ctx) => ctx.SyntaxFactory.Invocation(methodName);
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/MethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MethodMapping.cs
@@ -79,7 +79,11 @@ public abstract class MethodMapping : ITypeMapping
     public bool IsSynthetic => false;
 
     public virtual ExpressionSyntax Build(TypeMappingBuildContext ctx) =>
-        Invocation(MethodName, SourceParameter.WithArgument(ctx.Source), ReferenceHandlerParameter?.WithArgument(ctx.ReferenceHandler));
+        ctx.SyntaxFactory.Invocation(
+            MethodName,
+            SourceParameter.WithArgument(ctx.Source),
+            ReferenceHandlerParameter?.WithArgument(ctx.ReferenceHandler)
+        );
 
     public virtual MethodDeclarationSyntax BuildMethod(SourceEmitterContext ctx)
     {

--- a/src/Riok.Mapperly/Descriptors/Mappings/NewValueTupleConstructorMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/NewValueTupleConstructorMapping.cs
@@ -24,6 +24,6 @@ public class NewValueTupleConstructorMapping(ITypeSymbol sourceType, ITypeSymbol
         // new ValueTuple<T..>(ctorArgs)
         var ctorArgs = _constructorPropertyMappings.Select(x => x.BuildArgument(ctx, emitFieldName: false));
         var typeArguments = TypeArgumentList(((INamedTypeSymbol)TargetType).TypeArguments.Select(NonNullableIdentifier));
-        return CreateGenericInstance(ValueTupleName, typeArguments, ctorArgs);
+        return ctx.SyntaxFactory.CreateGenericInstance(ValueTupleName, typeArguments, ctorArgs);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/QueryableProjectionMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/QueryableProjectionMapping.cs
@@ -25,13 +25,11 @@ public class QueryableProjectionMapping(ITypeSymbol sourceType, ITypeSymbol targ
 
         var delegateMappingSyntax = delegateMapping.Build(lambdaCtx);
         var projectionLambda = Lambda(lambdaSourceName, delegateMappingSyntax);
-        var select = StaticInvocation(QueryableReceiverName, SelectMethodName, ctx.Source, projectionLambda);
+        var select = ctx.SyntaxFactory.StaticInvocation(QueryableReceiverName, SelectMethodName, ctx.Source, projectionLambda);
         var returnStatement = ctx.SyntaxFactory.Return(select);
-        return new[]
-        {
-            returnStatement
-                .WithLeadingTrivia(returnStatement.GetLeadingTrivia().Insert(0, ElasticCarriageReturnLineFeed).Insert(1, Nullable(false)))
-                .WithTrailingTrivia(returnStatement.GetTrailingTrivia().Insert(0, ElasticCarriageReturnLineFeed).Insert(1, Nullable(true)))
-        };
+        var leadingTrivia = returnStatement.GetLeadingTrivia().Insert(0, ElasticCarriageReturnLineFeed).Insert(1, Nullable(false));
+        var trailingTrivia = returnStatement.GetTrailingTrivia().Insert(0, ElasticCarriageReturnLineFeed).Insert(1, Nullable(true));
+        returnStatement = returnStatement.WithLeadingTrivia(leadingTrivia).WithTrailingTrivia(trailingTrivia);
+        return [returnStatement];
     }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/SourceObjectMethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/SourceObjectMethodMapping.cs
@@ -22,7 +22,10 @@ public class SourceObjectMethodMapping(
 {
     public override ExpressionSyntax Build(TypeMappingBuildContext ctx)
     {
-        var sourceExpression = Invocation(MemberAccess(ctx.Source, methodName), BuildArguments(ctx).WhereNotNull().ToArray());
+        var sourceExpression = ctx.SyntaxFactory.Invocation(
+            MemberAccess(ctx.Source, methodName),
+            BuildArguments(ctx).WhereNotNull().ToArray()
+        );
         return delegateMapping == null ? sourceExpression : delegateMapping.Build(ctx.WithSource(sourceExpression));
     }
 

--- a/src/Riok.Mapperly/Descriptors/Mappings/StaticMethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/StaticMethodMapping.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using static Riok.Mapperly.Emit.Syntax.SyntaxFactoryHelper;
 
 namespace Riok.Mapperly.Descriptors.Mappings;
 
@@ -9,5 +8,5 @@ namespace Riok.Mapperly.Descriptors.Mappings;
 /// </summary>
 public class StaticMethodMapping(IMethodSymbol method) : NewInstanceMapping(method.Parameters.Single().Type, method.ReturnType)
 {
-    public override ExpressionSyntax Build(TypeMappingBuildContext ctx) => StaticInvocation(method, ctx.Source);
+    public override ExpressionSyntax Build(TypeMappingBuildContext ctx) => ctx.SyntaxFactory.StaticInvocation(method, ctx.Source);
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedExistingTargetMethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedExistingTargetMethodMapping.cs
@@ -44,7 +44,7 @@ public class UserDefinedExistingTargetMethodMapping(
     public IEnumerable<StatementSyntax> Build(TypeMappingBuildContext ctx, ExpressionSyntax target)
     {
         return ctx.SyntaxFactory.SingleStatement(
-            Invocation(
+            ctx.SyntaxFactory.Invocation(
                 MethodName,
                 SourceParameter.WithArgument(ctx.Source),
                 TargetParameter.WithArgument(target),

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceRuntimeTargetTypeMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceRuntimeTargetTypeMapping.cs
@@ -63,7 +63,7 @@ public abstract class UserDefinedNewInstanceRuntimeTargetTypeMapping(
         var targetTypeExpr = BuildTargetType();
 
         // _ => throw new ArgumentException(msg, nameof(ctx.Source)),
-        var sourceType = Invocation(MemberAccess(ctx.Source, GetTypeMethodName));
+        var sourceType = ctx.SyntaxFactory.Invocation(MemberAccess(ctx.Source, GetTypeMethodName));
         var fallbackArm = SwitchArm(
             DiscardPattern(),
             ThrowArgumentExpression(
@@ -92,7 +92,7 @@ public abstract class UserDefinedNewInstanceRuntimeTargetTypeMapping(
     protected virtual ExpressionSyntax? BuildSwitchArmWhenClause(ExpressionSyntax runtimeTargetType, RuntimeTargetTypeMapping mapping)
     {
         // targetType.IsAssignableFrom(typeof(ADto))
-        return Invocation(
+        return InvocationWithoutIndention(
             MemberAccess(runtimeTargetType, IsAssignableFromMethodName),
             TypeOfExpression(FullyQualifiedIdentifier(mapping.Mapping.TargetType.NonNullable()))
         );

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserImplementedExistingTargetMethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserImplementedExistingTargetMethodMapping.cs
@@ -33,7 +33,7 @@ public class UserImplementedExistingTargetMethodMapping(
         if (Method.ReceiverType?.TypeKind != TypeKind.Interface)
         {
             yield return ctx.SyntaxFactory.ExpressionStatement(
-                Invocation(
+                ctx.SyntaxFactory.Invocation(
                     receiver == null ? IdentifierName(Method.Name) : MemberAccess(receiver, Method.Name),
                     sourceParameter.WithArgument(ctx.Source),
                     targetParameter.WithArgument(target),
@@ -49,7 +49,7 @@ public class UserImplementedExistingTargetMethodMapping(
         );
         var methodExpr = MemberAccess(ParenthesizedExpression(castedThis), Method.Name);
         yield return ctx.SyntaxFactory.ExpressionStatement(
-            Invocation(
+            ctx.SyntaxFactory.Invocation(
                 methodExpr,
                 sourceParameter.WithArgument(ctx.Source),
                 targetParameter.WithArgument(target),

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserImplementedMethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserImplementedMethodMapping.cs
@@ -29,7 +29,7 @@ public class UserImplementedMethodMapping(
         // if the user implemented method is on an interface,
         // we explicitly cast to be able to use the default interface implementation or explicit implementations
         if (Method.ReceiverType?.TypeKind != TypeKind.Interface)
-            return Invocation(
+            return ctx.SyntaxFactory.Invocation(
                 receiver == null ? IdentifierName(Method.Name) : MemberAccess(receiver, Method.Name),
                 sourceParameter.WithArgument(ctx.Source),
                 referenceHandlerParameter?.WithArgument(ctx.ReferenceHandler)
@@ -40,7 +40,7 @@ public class UserImplementedMethodMapping(
             receiver == null ? ThisExpression() : IdentifierName(receiver)
         );
         var methodExpr = MemberAccess(ParenthesizedExpression(castedReceiver), Method.Name);
-        return Invocation(
+        return ctx.SyntaxFactory.Invocation(
             methodExpr,
             sourceParameter.WithArgument(ctx.Source),
             referenceHandlerParameter?.WithArgument(ctx.ReferenceHandler)

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericSourceObjectFactory.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericSourceObjectFactory.cs
@@ -18,5 +18,5 @@ public class GenericSourceObjectFactory(GenericTypeChecker typeChecker, SymbolAc
         && typeChecker.CheckTypes((Method.TypeParameters[0], sourceType));
 
     protected override ExpressionSyntax BuildCreateType(ITypeSymbol sourceType, ITypeSymbol targetTypeToCreate, ExpressionSyntax source) =>
-        GenericInvocation(Method.Name, [NonNullableIdentifier(sourceType)], source);
+        GenericInvocationWithoutIndention(Method.Name, [NonNullableIdentifier(sourceType)], source);
 }

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericSourceTargetObjectFactory.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericSourceTargetObjectFactory.cs
@@ -25,6 +25,6 @@ public class GenericSourceTargetObjectFactory(
         var typeParams = new TypeSyntax[2];
         typeParams[sourceTypeParameterIndex] = NonNullableIdentifier(sourceType);
         typeParams[_targetTypeParameterIndex] = NonNullableIdentifier(targetTypeToCreate);
-        return GenericInvocation(Method.Name, typeParams, source);
+        return GenericInvocationWithoutIndention(Method.Name, typeParams, source);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericTargetObjectFactory.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericTargetObjectFactory.cs
@@ -17,5 +17,5 @@ public class GenericTargetObjectFactory(GenericTypeChecker typeChecker, SymbolAc
         typeChecker.CheckTypes((Method.TypeParameters[0], targetTypeToCreate));
 
     protected override ExpressionSyntax BuildCreateType(ITypeSymbol sourceType, ITypeSymbol targetTypeToCreate, ExpressionSyntax source) =>
-        GenericInvocation(Method.Name, new[] { NonNullableIdentifier(targetTypeToCreate) });
+        GenericInvocationWithoutIndention(Method.Name, [NonNullableIdentifier(targetTypeToCreate)]);
 }

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericTargetObjectFactoryWithSource.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/GenericTargetObjectFactoryWithSource.cs
@@ -18,5 +18,5 @@ public class GenericTargetObjectFactoryWithSource(GenericTypeChecker typeChecker
         && SymbolEqualityComparer.Default.Equals(Method.Parameters[0].Type, sourceType);
 
     protected override ExpressionSyntax BuildCreateType(ITypeSymbol sourceType, ITypeSymbol targetTypeToCreate, ExpressionSyntax source) =>
-        GenericInvocation(Method.Name, new[] { NonNullableIdentifier(targetTypeToCreate) }, source);
+        GenericInvocationWithoutIndention(Method.Name, [NonNullableIdentifier(targetTypeToCreate)], source);
 }

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/SimpleObjectFactory.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/SimpleObjectFactory.cs
@@ -14,5 +14,5 @@ public class SimpleObjectFactory(SymbolAccessor symbolAccessor, IMethodSymbol me
         SymbolEqualityComparer.Default.Equals(Method.ReturnType, targetTypeToCreate);
 
     protected override ExpressionSyntax BuildCreateType(ITypeSymbol sourceType, ITypeSymbol targetTypeToCreate, ExpressionSyntax source) =>
-        Invocation(Method.Name, Array.Empty<ExpressionSyntax>());
+        InvocationWithoutIndention(Method.Name);
 }

--- a/src/Riok.Mapperly/Descriptors/ObjectFactories/SimpleObjectFactoryWithSource.cs
+++ b/src/Riok.Mapperly/Descriptors/ObjectFactories/SimpleObjectFactoryWithSource.cs
@@ -17,5 +17,5 @@ public class SimpleObjectFactoryWithSource(SymbolAccessor symbolAccessor, IMetho
         && SymbolEqualityComparer.Default.Equals(sourceType, Method.Parameters[0].Type);
 
     protected override ExpressionSyntax BuildCreateType(ITypeSymbol sourceType, ITypeSymbol targetTypeToCreate, ExpressionSyntax source) =>
-        Invocation(Method.Name, source);
+        InvocationWithoutIndention(Method.Name, source);
 }

--- a/src/Riok.Mapperly/Descriptors/UnsafeAccess/UnsafeConstructorAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/UnsafeAccess/UnsafeConstructorAccessor.cs
@@ -28,6 +28,6 @@ public class UnsafeConstructorAccessor(IMethodSymbol symbol, string className, s
         InitializerExpressionSyntax? initializer = null
     )
     {
-        return StaticInvocation(className, methodName, args);
+        return ctx.SyntaxFactory.StaticInvocation(className, methodName, args);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/UnsafeAccess/UnsafeFieldAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/UnsafeAccess/UnsafeFieldAccessor.cs
@@ -44,7 +44,7 @@ public class UnsafeFieldAccessor(IFieldSymbol symbol, string methodName) : IUnsa
             throw new ArgumentNullException(nameof(baseAccess));
 
         ExpressionSyntax method = nullConditional ? ConditionalAccess(baseAccess, methodName) : MemberAccess(baseAccess, methodName);
-        return Invocation(method);
+        return InvocationWithoutIndention(method);
     }
 
     public ExpressionSyntax BuildAssignment(ExpressionSyntax? baseAccess, ExpressionSyntax valueToAssign, bool coalesceAssignment = false)

--- a/src/Riok.Mapperly/Descriptors/UnsafeAccess/UnsafeGetPropertyAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/UnsafeAccess/UnsafeGetPropertyAccessor.cs
@@ -44,6 +44,6 @@ public class UnsafeGetPropertyAccessor(IPropertySymbol symbol, string methodName
             throw new ArgumentNullException(nameof(baseAccess));
 
         ExpressionSyntax method = nullConditional ? ConditionalAccess(baseAccess, methodName) : MemberAccess(baseAccess, methodName);
-        return Invocation(method);
+        return InvocationWithoutIndention(method);
     }
 }

--- a/src/Riok.Mapperly/Descriptors/UnsafeAccess/UnsafeSetPropertyAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/UnsafeAccess/UnsafeSetPropertyAccessor.cs
@@ -50,6 +50,6 @@ public class UnsafeSetPropertyAccessor(IPropertySymbol symbol, string methodName
         if (baseAccess == null)
             throw new ArgumentNullException(nameof(baseAccess));
 
-        return Invocation(MemberAccess(baseAccess, methodName), valueToAssign);
+        return InvocationWithoutIndention(MemberAccess(baseAccess, methodName), valueToAssign);
     }
 }

--- a/src/Riok.Mapperly/Emit/ReferenceHandlingSyntaxFactoryHelper.cs
+++ b/src/Riok.Mapperly/Emit/ReferenceHandlingSyntaxFactoryHelper.cs
@@ -29,7 +29,7 @@ public static class ReferenceHandlingSyntaxFactoryHelper
             .WithRefOrOutKeyword(TrailingSpacedToken(SyntaxKind.OutKeyword));
 
         // GetReference<TSource, TTarget>(source, out var target)
-        var invocation = Invocation(method, Argument(ctx.Source), targetArgument);
+        var invocation = ctx.SyntaxFactory.Invocation(method, Argument(ctx.Source), targetArgument);
 
         // if (_referenceHandler.GetReference<TSource, TTarget>(source, out var target))
         //   return target;
@@ -46,6 +46,6 @@ public static class ReferenceHandlingSyntaxFactoryHelper
             );
         var method = MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, refHandler, methodName);
 
-        return Invocation(method, ctx.Source, target);
+        return ctx.SyntaxFactory.Invocation(method, ctx.Source, target);
     }
 }

--- a/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Exception.cs
+++ b/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Exception.cs
@@ -17,16 +17,16 @@ public partial struct SyntaxFactoryHelper
     public static ThrowExpressionSyntax ThrowNullReferenceException(string message) => ThrowNullReferenceException(StringLiteral(message));
 
     private static ThrowExpressionSyntax ThrowNullReferenceException(ExpressionSyntax arg) =>
-        Throw(NullReferenceExceptionClassName, ArgumentList(arg));
+        Throw(NullReferenceExceptionClassName, ArgumentListWithoutIndention([arg]));
 
     public static ThrowExpressionSyntax ThrowArgumentOutOfRangeException(ExpressionSyntax arg, string message) =>
-        Throw(ArgumentOutOfRangeExceptionClassName, ArgumentList(NameOf(arg), arg, StringLiteral(message)));
+        Throw(ArgumentOutOfRangeExceptionClassName, ArgumentListWithoutIndention([NameOf(arg), arg, StringLiteral(message)]));
 
     public static ThrowExpressionSyntax ThrowArgumentNullException(ExpressionSyntax arg) =>
-        Throw(ArgumentNullExceptionClassName, ArgumentList(NameOf(arg)));
+        Throw(ArgumentNullExceptionClassName, ArgumentListWithoutIndention([NameOf(arg)]));
 
     public static ThrowExpressionSyntax ThrowArgumentExpression(ExpressionSyntax message, ExpressionSyntax arg) =>
-        Throw(ArgumentExceptionClassName, ArgumentList(message, NameOf(arg)));
+        Throw(ArgumentExceptionClassName, ArgumentListWithoutIndention([message, NameOf(arg)]));
 
     public ThrowExpressionSyntax ThrowMappingNotImplementedExceptionStatement()
     {

--- a/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.New.cs
+++ b/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.New.cs
@@ -13,7 +13,7 @@ public partial struct SyntaxFactoryHelper
         return CreateObject(type, SyntaxFactory.ArgumentList());
     }
 
-    public static ObjectCreationExpressionSyntax CreateGenericInstance(
+    public ObjectCreationExpressionSyntax CreateGenericInstance(
         string typeName,
         TypeArgumentListSyntax typeArguments,
         IEnumerable<ArgumentSyntax> arguments
@@ -29,16 +29,13 @@ public partial struct SyntaxFactoryHelper
         return CreateObject(type, SyntaxFactory.ArgumentList());
     }
 
-    public static ObjectCreationExpressionSyntax CreateInstance(ITypeSymbol typeSymbol, params ExpressionSyntax[] args)
+    public ObjectCreationExpressionSyntax CreateInstance(ITypeSymbol typeSymbol, params ExpressionSyntax[] args)
     {
         var type = NonNullableIdentifier(typeSymbol);
         return CreateObject(type, ArgumentList(args));
     }
 
-    public static ObjectCreationExpressionSyntax CreateInstance(ITypeSymbol typeSymbol, params ArgumentSyntax[] args) =>
-        CreateInstance(typeSymbol, (IEnumerable<ArgumentSyntax>)args);
-
-    public static ObjectCreationExpressionSyntax CreateInstance(ITypeSymbol typeSymbol, IEnumerable<ArgumentSyntax> args)
+    public ObjectCreationExpressionSyntax CreateInstance(ITypeSymbol typeSymbol, IEnumerable<ArgumentSyntax> args)
     {
         var type = NonNullableIdentifier(typeSymbol);
         return CreateObject(type, ArgumentList(args));

--- a/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.String.cs
+++ b/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.String.cs
@@ -15,7 +15,8 @@ public partial struct SyntaxFactoryHelper
     private static readonly Regex _formattableStringPlaceholder =
         new(@"\{(?<placeholder>\d+)\}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
 
-    public static InvocationExpressionSyntax NameOf(ExpressionSyntax expression) => Invocation(_nameofIdentifier, expression);
+    public static InvocationExpressionSyntax NameOf(ExpressionSyntax expression) =>
+        InvocationWithoutIndention(_nameofIdentifier, expression);
 
     public static IdentifierNameSyntax FullyQualifiedIdentifier(ITypeSymbol typeSymbol) =>
         IdentifierName(typeSymbol.FullyQualifiedIdentifierName());

--- a/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Token.cs
+++ b/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Token.cs
@@ -13,6 +13,11 @@ public partial struct SyntaxFactoryHelper
         return Token(SyntaxTriviaList.Empty.AddLineFeedAndIndentation(Indentation), kind, SyntaxTriviaList.Empty);
     }
 
+    private SyntaxToken TrailingLineFeedToken(SyntaxKind kind, int indentation)
+    {
+        return Token(SyntaxTriviaList.Empty, kind, SyntaxTriviaList.Empty.AddLineFeedAndIndentation(indentation));
+    }
+
     private SyntaxToken LeadingLineFeedTrailingSpaceToken(SyntaxKind kind)
     {
         return Token(SyntaxTriviaList.Empty.AddLineFeedAndIndentation(Indentation), kind, _spaceTriviaList);

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/CircularReferenceMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/CircularReferenceMapperTest.SnapshotGeneratedSource.verified.cs
@@ -7,7 +7,10 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         public static partial global::Riok.Mapperly.IntegrationTests.Dto.CircularReferenceDto ToDto(global::Riok.Mapperly.IntegrationTests.Models.CircularReferenceObject obj)
         {
-            return MapToCircularReferenceDto(obj, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+            return MapToCircularReferenceDto(
+                obj,
+                new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+            );
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource.verified.cs
@@ -55,7 +55,10 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private partial global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto MapToDtoInternal(global::Riok.Mapperly.IntegrationTests.Models.TestObject testObject)
         {
-            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto(DirectInt(testObject.CtorValue), ctorValue2: DirectInt(testObject.CtorValue2))
+            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto(
+                DirectInt(testObject.CtorValue),
+                ctorValue2: DirectInt(testObject.CtorValue2)
+            )
             {
                 IntInitOnlyValue = DirectInt(testObject.IntInitOnlyValue),
                 RequiredValue = DirectInt(testObject.RequiredValue),
@@ -130,16 +133,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(testObject.ImmutableListValue, x => ParseableInt(x)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(testObject.ImmutableHashSetValue, x => ParseableInt(x)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x => ParseableInt(x)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x => ParseableInt(x)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x => ParseableInt(x)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(testObject.ImmutableDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(testObject.ImmutableSortedDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
+            target.StackValue = new global::System.Collections.Generic.Stack<int>(
+                global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
+                global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableListValue, x => ParseableInt(x))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableHashSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x => ParseableInt(x))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                testObject.ImmutableDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                testObject.ImmutableSortedDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
             foreach (var item in testObject.ExistingISet)
             {
                 target.ExistingISet.Add(ParseableInt(item));
@@ -156,9 +183,15 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x)));
+            target.ISet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x))
+            );
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
+                global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)testObject.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestFlagsEnumDto)testObject.FlagsEnumValue;
             target.EnumName = MapToEnumDtoByName(testObject.EnumName);
@@ -236,16 +269,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.NullableReadOnlyObjectCollection = null;
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<string>(global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString(_formatDeCh)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<string>(global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(dto.ImmutableListValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(dto.ImmutableHashSetValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(dto.ImmutableDictionaryValue, x => x.Key.ToString(_formatDeCh), x => x.Value.ToString(_formatDeCh));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(dto.ImmutableSortedDictionaryValue, x => x.Key.ToString(_formatDeCh), x => x.Value.ToString(_formatDeCh));
+            target.StackValue = new global::System.Collections.Generic.Stack<string>(
+                global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString(_formatDeCh))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<string>(
+                global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(dto.ImmutableListValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(dto.ImmutableHashSetValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                dto.ImmutableDictionaryValue,
+                x => x.Key.ToString(_formatDeCh),
+                x => x.Value.ToString(_formatDeCh)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                dto.ImmutableSortedDictionaryValue,
+                x => x.Key.ToString(_formatDeCh),
+                x => x.Value.ToString(_formatDeCh)
+            );
             foreach (var item in dto.ExistingISet)
             {
                 target.ExistingISet.Add(item.ToString(_formatDeCh));
@@ -262,9 +319,15 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(item3.ToString(_formatDeCh));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.ISet, x => x.ToString(_formatDeCh)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.HashSet, x => x.ToString(_formatDeCh)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString(_formatDeCh)));
+            target.ISet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(dto.ISet, x => x.ToString(_formatDeCh))
+            );
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(dto.HashSet, x => x.ToString(_formatDeCh))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(
+                global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString(_formatDeCh))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Models.TestFlagsEnum)dto.FlagsEnumValue;
             target.EnumName = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumName;
@@ -342,16 +405,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(source.SpanValue);
             target.MemoryValue = MapToInt32Array1(source.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(source.ImmutableListValue, x => ParseableInt(x)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(source.ImmutableHashSetValue, x => ParseableInt(x)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x => ParseableInt(x)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x => ParseableInt(x)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x => ParseableInt(x)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(source.ImmutableDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(source.ImmutableSortedDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
+            target.StackValue = new global::System.Collections.Generic.Stack<int>(
+                global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
+                global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(source.ImmutableListValue, x => ParseableInt(x))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(source.ImmutableHashSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x => ParseableInt(x))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                source.ImmutableDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                source.ImmutableSortedDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
             foreach (var item in source.ExistingISet)
             {
                 target.ExistingISet.Add(ParseableInt(item));
@@ -368,9 +455,15 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x)));
+            target.ISet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x))
+            );
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
+                global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)source.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestFlagsEnumDto)source.FlagsEnumValue;
             target.EnumName = MapToEnumDtoByName(source.EnumName);
@@ -477,7 +570,11 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 nameof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue.DtoValue1) => global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue.DtoValue1,
                 nameof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue.DtoValue2) => global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue.DtoValue2,
                 nameof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue.DtoValue3) => global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue.DtoValue3,
-                _ => (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)System.Enum.Parse(typeof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue), source, false),
+                _ => (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)System.Enum.Parse(
+                typeof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue),
+                source,
+                false
+            ),
             };
         }
 
@@ -535,7 +632,11 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 nameof(global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value10) => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value10,
                 nameof(global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value20) => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value20,
                 nameof(global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30) => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
-                _ => (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)System.Enum.Parse(typeof(global::Riok.Mapperly.IntegrationTests.Models.TestEnum), source, false),
+                _ => (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)System.Enum.Parse(
+                typeof(global::Riok.Mapperly.IntegrationTests.Models.TestEnum),
+                source,
+                false
+            ),
             };
         }
 

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
@@ -55,7 +55,10 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private partial global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto MapToDtoInternal(global::Riok.Mapperly.IntegrationTests.Models.TestObject testObject)
         {
-            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto(DirectInt(testObject.CtorValue), ctorValue2: DirectInt(testObject.CtorValue2))
+            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto(
+                DirectInt(testObject.CtorValue),
+                ctorValue2: DirectInt(testObject.CtorValue2)
+            )
             {
                 IntInitOnlyValue = DirectInt(testObject.IntInitOnlyValue),
                 RequiredValue = DirectInt(testObject.RequiredValue),
@@ -130,16 +133,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(testObject.ImmutableListValue, x => ParseableInt(x)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(testObject.ImmutableHashSetValue, x => ParseableInt(x)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x => ParseableInt(x)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x => ParseableInt(x)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x => ParseableInt(x)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(testObject.ImmutableDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(testObject.ImmutableSortedDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
+            target.StackValue = new global::System.Collections.Generic.Stack<int>(
+                global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
+                global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableListValue, x => ParseableInt(x))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableHashSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x => ParseableInt(x))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                testObject.ImmutableDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                testObject.ImmutableSortedDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
             foreach (var item in testObject.ExistingISet)
             {
                 target.ExistingISet.Add(ParseableInt(item));
@@ -158,10 +185,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x)));
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(testObject.IReadOnlySet, x => ParseableInt(x)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x)));
+            target.ISet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x))
+            );
+            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(testObject.IReadOnlySet, x => ParseableInt(x))
+            );
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
+                global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)testObject.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestFlagsEnumDto)testObject.FlagsEnumValue;
             target.EnumName = MapToEnumDtoByName(testObject.EnumName);
@@ -239,16 +274,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.NullableReadOnlyObjectCollection = null;
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<string>(global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString(_formatDeCh)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<string>(global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(dto.ImmutableListValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(dto.ImmutableHashSetValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(dto.ImmutableDictionaryValue, x => x.Key.ToString(_formatDeCh), x => x.Value.ToString(_formatDeCh));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(dto.ImmutableSortedDictionaryValue, x => x.Key.ToString(_formatDeCh), x => x.Value.ToString(_formatDeCh));
+            target.StackValue = new global::System.Collections.Generic.Stack<string>(
+                global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString(_formatDeCh))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<string>(
+                global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(dto.ImmutableListValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(dto.ImmutableHashSetValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                dto.ImmutableDictionaryValue,
+                x => x.Key.ToString(_formatDeCh),
+                x => x.Value.ToString(_formatDeCh)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                dto.ImmutableSortedDictionaryValue,
+                x => x.Key.ToString(_formatDeCh),
+                x => x.Value.ToString(_formatDeCh)
+            );
             foreach (var item in dto.ExistingISet)
             {
                 target.ExistingISet.Add(item.ToString(_formatDeCh));
@@ -267,10 +326,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(item3.ToString(_formatDeCh));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.ISet, x => x.ToString(_formatDeCh)));
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.IReadOnlySet, x => x.ToString(_formatDeCh)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.HashSet, x => x.ToString(_formatDeCh)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString(_formatDeCh)));
+            target.ISet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(dto.ISet, x => x.ToString(_formatDeCh))
+            );
+            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(dto.IReadOnlySet, x => x.ToString(_formatDeCh))
+            );
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(dto.HashSet, x => x.ToString(_formatDeCh))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(
+                global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString(_formatDeCh))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Models.TestFlagsEnum)dto.FlagsEnumValue;
             target.EnumName = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumName;
@@ -348,16 +415,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(source.SpanValue);
             target.MemoryValue = MapToInt32Array1(source.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(source.ImmutableListValue, x => ParseableInt(x)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(source.ImmutableHashSetValue, x => ParseableInt(x)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x => ParseableInt(x)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x => ParseableInt(x)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x => ParseableInt(x)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(source.ImmutableDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(source.ImmutableSortedDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
+            target.StackValue = new global::System.Collections.Generic.Stack<int>(
+                global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
+                global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(source.ImmutableListValue, x => ParseableInt(x))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(source.ImmutableHashSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x => ParseableInt(x))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                source.ImmutableDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                source.ImmutableSortedDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
             foreach (var item in source.ExistingISet)
             {
                 target.ExistingISet.Add(ParseableInt(item));
@@ -376,10 +467,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x)));
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(source.IReadOnlySet, x => ParseableInt(x)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x)));
+            target.ISet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x))
+            );
+            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(source.IReadOnlySet, x => ParseableInt(x))
+            );
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
+                global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)source.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestFlagsEnumDto)source.FlagsEnumValue;
             target.EnumName = MapToEnumDtoByName(source.EnumName);

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
@@ -55,7 +55,10 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private partial global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto MapToDtoInternal(global::Riok.Mapperly.IntegrationTests.Models.TestObject testObject)
         {
-            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto(DirectInt(testObject.CtorValue), ctorValue2: DirectInt(testObject.CtorValue2))
+            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto(
+                DirectInt(testObject.CtorValue),
+                ctorValue2: DirectInt(testObject.CtorValue2)
+            )
             {
                 IntInitOnlyValue = DirectInt(testObject.IntInitOnlyValue),
                 RequiredValue = DirectInt(testObject.RequiredValue),
@@ -130,16 +133,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(testObject.ImmutableListValue, x => ParseableInt(x)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(testObject.ImmutableHashSetValue, x => ParseableInt(x)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x => ParseableInt(x)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x => ParseableInt(x)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x => ParseableInt(x)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(testObject.ImmutableDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(testObject.ImmutableSortedDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
+            target.StackValue = new global::System.Collections.Generic.Stack<int>(
+                global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
+                global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableListValue, x => ParseableInt(x))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableHashSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x => ParseableInt(x))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                testObject.ImmutableDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                testObject.ImmutableSortedDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
             foreach (var item in testObject.ExistingISet)
             {
                 target.ExistingISet.Add(ParseableInt(item));
@@ -158,10 +185,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x)));
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(testObject.IReadOnlySet, x => ParseableInt(x)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x)));
+            target.ISet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x))
+            );
+            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(testObject.IReadOnlySet, x => ParseableInt(x))
+            );
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
+                global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)testObject.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestFlagsEnumDto)testObject.FlagsEnumValue;
             target.EnumName = MapToEnumDtoByName(testObject.EnumName);
@@ -240,16 +275,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.NullableReadOnlyObjectCollection = null;
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<string>(global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString(_formatDeCh)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<string>(global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(dto.ImmutableListValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(dto.ImmutableHashSetValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x => x.ToString(_formatDeCh)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(dto.ImmutableDictionaryValue, x => x.Key.ToString(_formatDeCh), x => x.Value.ToString(_formatDeCh));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(dto.ImmutableSortedDictionaryValue, x => x.Key.ToString(_formatDeCh), x => x.Value.ToString(_formatDeCh));
+            target.StackValue = new global::System.Collections.Generic.Stack<string>(
+                global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString(_formatDeCh))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<string>(
+                global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(dto.ImmutableListValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(dto.ImmutableHashSetValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x => x.ToString(_formatDeCh))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                dto.ImmutableDictionaryValue,
+                x => x.Key.ToString(_formatDeCh),
+                x => x.Value.ToString(_formatDeCh)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                dto.ImmutableSortedDictionaryValue,
+                x => x.Key.ToString(_formatDeCh),
+                x => x.Value.ToString(_formatDeCh)
+            );
             foreach (var item in dto.ExistingISet)
             {
                 target.ExistingISet.Add(item.ToString(_formatDeCh));
@@ -268,10 +327,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(item3.ToString(_formatDeCh));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.ISet, x => x.ToString(_formatDeCh)));
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.IReadOnlySet, x => x.ToString(_formatDeCh)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.HashSet, x => x.ToString(_formatDeCh)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString(_formatDeCh)));
+            target.ISet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(dto.ISet, x => x.ToString(_formatDeCh))
+            );
+            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(dto.IReadOnlySet, x => x.ToString(_formatDeCh))
+            );
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(dto.HashSet, x => x.ToString(_formatDeCh))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(
+                global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString(_formatDeCh))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Models.TestFlagsEnum)dto.FlagsEnumValue;
             target.EnumName = (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)dto.EnumName;
@@ -350,16 +417,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(source.SpanValue);
             target.MemoryValue = MapToInt32Array1(source.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(source.ImmutableListValue, x => ParseableInt(x)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(source.ImmutableHashSetValue, x => ParseableInt(x)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x => ParseableInt(x)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x => ParseableInt(x)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x => ParseableInt(x)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(source.ImmutableDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(source.ImmutableSortedDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
+            target.StackValue = new global::System.Collections.Generic.Stack<int>(
+                global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
+                global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(source.ImmutableListValue, x => ParseableInt(x))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(source.ImmutableHashSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x => ParseableInt(x))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                source.ImmutableDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                source.ImmutableSortedDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
             foreach (var item in source.ExistingISet)
             {
                 target.ExistingISet.Add(ParseableInt(item));
@@ -378,10 +469,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x)));
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(source.IReadOnlySet, x => ParseableInt(x)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x)));
+            target.ISet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x))
+            );
+            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(source.IReadOnlySet, x => ParseableInt(x))
+            );
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
+                global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)source.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestFlagsEnumDto)source.FlagsEnumValue;
             target.EnumName = MapToEnumDtoByName(source.EnumName);

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/ProjectionMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/ProjectionMapperTest.SnapshotGeneratedSource.verified.cs
@@ -8,51 +8,65 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         public static partial global::System.Linq.IQueryable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjection> ProjectToDto(this global::System.Linq.IQueryable<global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjection> q)
         {
 #nullable disable
-            return System.Linq.Queryable.Select(q, x => new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjection(x.CtorValue)
-            {
-                IntValue = x.IntValue,
-                IntInitOnlyValue = x.IntInitOnlyValue,
-                RequiredValue = x.RequiredValue,
-                StringValue = x.StringValue,
-                RenamedStringValue2 = x.RenamedStringValue,
-                FlatteningIdValue = x.Flattening.IdValue,
-                NullableFlatteningIdValue = x.NullableFlattening != null ? x.NullableFlattening.IdValue : default(int?),
-                NestedNullableIntValue = x.NestedNullable != null ? x.NestedNullable.IntValue : default,
-                NestedNullable = x.NestedNullable != null ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto()
+            return System.Linq.Queryable.Select(
+                q,
+                x => new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjection(x.CtorValue)
                 {
-                    IntValue = x.NestedNullable.IntValue,
-                } : default,
-                NestedNullableTargetNotNullable = x.NestedNullableTargetNotNullable != null ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto()
-                {
-                    IntValue = x.NestedNullableTargetNotNullable.IntValue,
-                } : new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto(),
-                StringNullableTargetNotNullable = x.StringNullableTargetNotNullable ?? "",
-                SourceTargetSameObjectType = x.SourceTargetSameObjectType,
-                NullableReadOnlyObjectCollection = x.NullableReadOnlyObjectCollection != null ? global::System.Linq.Enumerable.ToArray(global::System.Linq.Enumerable.Select(x.NullableReadOnlyObjectCollection, x1 => new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto()
-                {
-                    IntValue = x1.IntValue,
-                })) : default,
-                EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)x.EnumValue,
-                EnumName = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName)x.EnumName,
-                EnumRawValue = (byte)x.EnumRawValue,
-                EnumStringValue = (string)x.EnumStringValue.ToString(),
-                EnumReverseStringValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName)System.Enum.Parse(typeof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName), x.EnumReverseStringValue, false),
-                SubObject = x.SubObject != null ? new global::Riok.Mapperly.IntegrationTests.Dto.InheritanceSubObjectDto()
-                {
-                    SubIntValue = x.SubObject.SubIntValue,
-                    BaseIntValue = x.SubObject.BaseIntValue,
-                } : default,
-                DateTimeValueTargetDateOnly = global::System.DateOnly.FromDateTime(x.DateTimeValueTargetDateOnly),
-                DateTimeValueTargetTimeOnly = global::System.TimeOnly.FromDateTime(x.DateTimeValueTargetTimeOnly),
-                ManuallyMapped = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoManuallyMappedProjection(100) { StringValue = x.ManuallyMapped },
-                ManuallyMappedModified = x.ManuallyMappedModified + 10,
-                ManuallyMappedList = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.Select(x.ManuallyMappedList, x1 => x1.Value)),
-                IntegerValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.OrderBy(x.IntegerValues, x => x.Value)),
-                DecimalValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.Select(global::System.Linq.Enumerable.OrderBy(x.DecimalValues, x => x.Value), x => new global::Riok.Mapperly.IntegrationTests.Dto.LongValueDto()
-                {
-                    Value = x.Value,
-                })),
-            });
+                    IntValue = x.IntValue,
+                    IntInitOnlyValue = x.IntInitOnlyValue,
+                    RequiredValue = x.RequiredValue,
+                    StringValue = x.StringValue,
+                    RenamedStringValue2 = x.RenamedStringValue,
+                    FlatteningIdValue = x.Flattening.IdValue,
+                    NullableFlatteningIdValue = x.NullableFlattening != null ? x.NullableFlattening.IdValue : default(int?),
+                    NestedNullableIntValue = x.NestedNullable != null ? x.NestedNullable.IntValue : default,
+                    NestedNullable = x.NestedNullable != null ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto()
+                    {
+                        IntValue = x.NestedNullable.IntValue,
+                    } : default,
+                    NestedNullableTargetNotNullable = x.NestedNullableTargetNotNullable != null ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto()
+                    {
+                        IntValue = x.NestedNullableTargetNotNullable.IntValue,
+                    } : new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto(),
+                    StringNullableTargetNotNullable = x.StringNullableTargetNotNullable ?? "",
+                    SourceTargetSameObjectType = x.SourceTargetSameObjectType,
+                    NullableReadOnlyObjectCollection = x.NullableReadOnlyObjectCollection != null ? global::System.Linq.Enumerable.ToArray(
+                        global::System.Linq.Enumerable.Select(
+                            x.NullableReadOnlyObjectCollection,
+                            x1 => new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto()
+                            {
+                                IntValue = x1.IntValue,
+                            }
+                        )
+                    ) : default,
+                    EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)x.EnumValue,
+                    EnumName = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName)x.EnumName,
+                    EnumRawValue = (byte)x.EnumRawValue,
+                    EnumStringValue = (string)x.EnumStringValue.ToString(),
+                    EnumReverseStringValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName)System.Enum.Parse(
+                        typeof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName),
+                        x.EnumReverseStringValue,
+                        false
+                    ),
+                    SubObject = x.SubObject != null ? new global::Riok.Mapperly.IntegrationTests.Dto.InheritanceSubObjectDto()
+                    {
+                        SubIntValue = x.SubObject.SubIntValue,
+                        BaseIntValue = x.SubObject.BaseIntValue,
+                    } : default,
+                    DateTimeValueTargetDateOnly = global::System.DateOnly.FromDateTime(x.DateTimeValueTargetDateOnly),
+                    DateTimeValueTargetTimeOnly = global::System.TimeOnly.FromDateTime(x.DateTimeValueTargetTimeOnly),
+                    ManuallyMapped = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoManuallyMappedProjection(100) { StringValue = x.ManuallyMapped },
+                    ManuallyMappedModified = x.ManuallyMappedModified + 10,
+                    ManuallyMappedList = global::System.Linq.Enumerable.ToList(
+                        global::System.Linq.Enumerable.Select(x.ManuallyMappedList, x1 => x1.Value)
+                    ),
+                    IntegerValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.OrderBy(x.IntegerValues, x => x.Value)),
+                    DecimalValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.Select(global::System.Linq.Enumerable.OrderBy(x.DecimalValues, x => x.Value), x => new global::Riok.Mapperly.IntegrationTests.Dto.LongValueDto()
+                    {
+                        Value = x.Value,
+                    })),
+                }
+            );
 #nullable enable
         }
 
@@ -60,17 +74,20 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         public static partial global::System.Linq.IQueryable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType> ProjectToDto(this global::System.Linq.IQueryable<global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionBaseType> q)
         {
 #nullable disable
-            return System.Linq.Queryable.Select(q, x => (global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType)(x is global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeA()
-            {
-                ValueA = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).ValueA,
-                Id = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).Id,
-                BaseValue = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).BaseValue,
-            } : x is global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeB()
-            {
-                ValueB = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).ValueB,
-                Id = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).Id,
-                BaseValue = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).BaseValue,
-            } : default));
+            return System.Linq.Queryable.Select(
+                q,
+                x => (global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType)(x is global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeA()
+                {
+                    ValueA = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).ValueA,
+                    Id = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).Id,
+                    BaseValue = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).BaseValue,
+                } : x is global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeB()
+                {
+                    ValueB = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).ValueB,
+                    Id = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).Id,
+                    BaseValue = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).BaseValue,
+                } : default)
+            );
 #nullable enable
         }
 
@@ -216,7 +233,11 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 nameof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName.Value10) => global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName.Value10,
                 nameof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName.Value20) => global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName.Value20,
                 nameof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName.Value30) => global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName.Value30,
-                _ => (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName)System.Enum.Parse(typeof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName), source, false),
+                _ => (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName)System.Enum.Parse(
+                typeof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName),
+                source,
+                false
+            ),
             };
         }
 

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/ProjectionMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/ProjectionMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
@@ -8,51 +8,61 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         public static partial global::System.Linq.IQueryable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjection> ProjectToDto(this global::System.Linq.IQueryable<global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjection> q)
         {
 #nullable disable
-            return System.Linq.Queryable.Select(q, x => new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjection(x.CtorValue)
-            {
-                IntValue = x.IntValue,
-                IntInitOnlyValue = x.IntInitOnlyValue,
-                RequiredValue = x.RequiredValue,
-                StringValue = x.StringValue,
-                RenamedStringValue2 = x.RenamedStringValue,
-                FlatteningIdValue = x.Flattening.IdValue,
-                NullableFlatteningIdValue = x.NullableFlattening != null ? x.NullableFlattening.IdValue : default(int?),
-                NestedNullableIntValue = x.NestedNullable != null ? x.NestedNullable.IntValue : default,
-                NestedNullable = x.NestedNullable != null ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto()
+            return System.Linq.Queryable.Select(
+                q,
+                x => new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjection(x.CtorValue)
                 {
-                    IntValue = x.NestedNullable.IntValue,
-                } : default,
-                NestedNullableTargetNotNullable = x.NestedNullableTargetNotNullable != null ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto()
-                {
-                    IntValue = x.NestedNullableTargetNotNullable.IntValue,
-                } : new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto(),
-                StringNullableTargetNotNullable = x.StringNullableTargetNotNullable ?? "",
-                SourceTargetSameObjectType = x.SourceTargetSameObjectType,
-                NullableReadOnlyObjectCollection = x.NullableReadOnlyObjectCollection != null ? global::System.Linq.Enumerable.ToArray(global::System.Linq.Enumerable.Select(x.NullableReadOnlyObjectCollection, x1 => new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto()
-                {
-                    IntValue = x1.IntValue,
-                })) : default,
-                EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)x.EnumValue,
-                EnumName = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName)x.EnumName,
-                EnumRawValue = (byte)x.EnumRawValue,
-                EnumStringValue = (string)x.EnumStringValue.ToString(),
-                EnumReverseStringValue = System.Enum.Parse<global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName>(x.EnumReverseStringValue, false),
-                SubObject = x.SubObject != null ? new global::Riok.Mapperly.IntegrationTests.Dto.InheritanceSubObjectDto()
-                {
-                    SubIntValue = x.SubObject.SubIntValue,
-                    BaseIntValue = x.SubObject.BaseIntValue,
-                } : default,
-                DateTimeValueTargetDateOnly = global::System.DateOnly.FromDateTime(x.DateTimeValueTargetDateOnly),
-                DateTimeValueTargetTimeOnly = global::System.TimeOnly.FromDateTime(x.DateTimeValueTargetTimeOnly),
-                ManuallyMapped = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoManuallyMappedProjection(100) { StringValue = x.ManuallyMapped },
-                ManuallyMappedModified = x.ManuallyMappedModified + 10,
-                ManuallyMappedList = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.Select(x.ManuallyMappedList, x1 => x1.Value)),
-                IntegerValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.OrderBy(x.IntegerValues, x => x.Value)),
-                DecimalValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.Select(global::System.Linq.Enumerable.OrderBy(x.DecimalValues, x => x.Value), x => new global::Riok.Mapperly.IntegrationTests.Dto.LongValueDto()
-                {
-                    Value = x.Value,
-                })),
-            });
+                    IntValue = x.IntValue,
+                    IntInitOnlyValue = x.IntInitOnlyValue,
+                    RequiredValue = x.RequiredValue,
+                    StringValue = x.StringValue,
+                    RenamedStringValue2 = x.RenamedStringValue,
+                    FlatteningIdValue = x.Flattening.IdValue,
+                    NullableFlatteningIdValue = x.NullableFlattening != null ? x.NullableFlattening.IdValue : default(int?),
+                    NestedNullableIntValue = x.NestedNullable != null ? x.NestedNullable.IntValue : default,
+                    NestedNullable = x.NestedNullable != null ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto()
+                    {
+                        IntValue = x.NestedNullable.IntValue,
+                    } : default,
+                    NestedNullableTargetNotNullable = x.NestedNullableTargetNotNullable != null ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto()
+                    {
+                        IntValue = x.NestedNullableTargetNotNullable.IntValue,
+                    } : new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto(),
+                    StringNullableTargetNotNullable = x.StringNullableTargetNotNullable ?? "",
+                    SourceTargetSameObjectType = x.SourceTargetSameObjectType,
+                    NullableReadOnlyObjectCollection = x.NullableReadOnlyObjectCollection != null ? global::System.Linq.Enumerable.ToArray(
+                        global::System.Linq.Enumerable.Select(
+                            x.NullableReadOnlyObjectCollection,
+                            x1 => new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectNestedDto()
+                            {
+                                IntValue = x1.IntValue,
+                            }
+                        )
+                    ) : default,
+                    EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)x.EnumValue,
+                    EnumName = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName)x.EnumName,
+                    EnumRawValue = (byte)x.EnumRawValue,
+                    EnumStringValue = (string)x.EnumStringValue.ToString(),
+                    EnumReverseStringValue = System.Enum.Parse<global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByName>(x.EnumReverseStringValue, false),
+                    SubObject = x.SubObject != null ? new global::Riok.Mapperly.IntegrationTests.Dto.InheritanceSubObjectDto()
+                    {
+                        SubIntValue = x.SubObject.SubIntValue,
+                        BaseIntValue = x.SubObject.BaseIntValue,
+                    } : default,
+                    DateTimeValueTargetDateOnly = global::System.DateOnly.FromDateTime(x.DateTimeValueTargetDateOnly),
+                    DateTimeValueTargetTimeOnly = global::System.TimeOnly.FromDateTime(x.DateTimeValueTargetTimeOnly),
+                    ManuallyMapped = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoManuallyMappedProjection(100) { StringValue = x.ManuallyMapped },
+                    ManuallyMappedModified = x.ManuallyMappedModified + 10,
+                    ManuallyMappedList = global::System.Linq.Enumerable.ToList(
+                        global::System.Linq.Enumerable.Select(x.ManuallyMappedList, x1 => x1.Value)
+                    ),
+                    IntegerValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.OrderBy(x.IntegerValues, x => x.Value)),
+                    DecimalValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.Select(global::System.Linq.Enumerable.OrderBy(x.DecimalValues, x => x.Value), x => new global::Riok.Mapperly.IntegrationTests.Dto.LongValueDto()
+                    {
+                        Value = x.Value,
+                    })),
+                }
+            );
 #nullable enable
         }
 
@@ -60,17 +70,20 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         public static partial global::System.Linq.IQueryable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType> ProjectToDto(this global::System.Linq.IQueryable<global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionBaseType> q)
         {
 #nullable disable
-            return System.Linq.Queryable.Select(q, x => (global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType)(x is global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeA()
-            {
-                ValueA = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).ValueA,
-                Id = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).Id,
-                BaseValue = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).BaseValue,
-            } : x is global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeB()
-            {
-                ValueB = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).ValueB,
-                Id = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).Id,
-                BaseValue = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).BaseValue,
-            } : default));
+            return System.Linq.Queryable.Select(
+                q,
+                x => (global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionBaseType)(x is global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeA()
+                {
+                    ValueA = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).ValueA,
+                    Id = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).Id,
+                    BaseValue = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeA)x).BaseValue,
+                } : x is global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB ? new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDtoProjectionTypeB()
+                {
+                    ValueB = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).ValueB,
+                    Id = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).Id,
+                    BaseValue = ((global::Riok.Mapperly.IntegrationTests.Models.TestObjectProjectionTypeB)x).BaseValue,
+                } : default)
+            );
 #nullable enable
         }
 

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -146,16 +146,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array1(src.SpanValue);
             target.MemoryValue = MapToInt32Array2(src.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(global::System.Linq.Enumerable.Select(src.StackValue, x => ParseableInt(x)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(global::System.Linq.Enumerable.Select(src.QueueValue, x => ParseableInt(x)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(src.ImmutableArrayValue, x => ParseableInt(x)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(src.ImmutableListValue, x => ParseableInt(x)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(src.ImmutableHashSetValue, x => ParseableInt(x)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(src.ImmutableQueueValue, x => ParseableInt(x)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(src.ImmutableStackValue, x => ParseableInt(x)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(src.ImmutableSortedSetValue, x => ParseableInt(x)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(src.ImmutableDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(src.ImmutableSortedDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
+            target.StackValue = new global::System.Collections.Generic.Stack<int>(
+                global::System.Linq.Enumerable.Select(src.StackValue, x => ParseableInt(x))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
+                global::System.Linq.Enumerable.Select(src.QueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(src.ImmutableArrayValue, x => ParseableInt(x))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(src.ImmutableListValue, x => ParseableInt(x))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(src.ImmutableHashSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(src.ImmutableQueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(src.ImmutableStackValue, x => ParseableInt(x))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(src.ImmutableSortedSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                src.ImmutableDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                src.ImmutableSortedDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
             foreach (var item in src.ExistingISet)
             {
                 target.ExistingISet.Add(ParseableInt(item));
@@ -170,8 +194,12 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             MapExistingList(src.ExistingList, target.ExistingList);
             target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(src.ISet, x => ParseableInt(x)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(src.HashSet, x => ParseableInt(x)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(global::System.Linq.Enumerable.Select(src.SortedSet, x => ParseableInt(x)));
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(src.HashSet, x => ParseableInt(x))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
+                global::System.Linq.Enumerable.Select(src.SortedSet, x => ParseableInt(x))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)src.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestFlagsEnumDto)src.FlagsEnumValue;
             target.EnumName = MapToEnumDtoByName(src.EnumName);
@@ -194,7 +222,10 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private static partial global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto MapToDtoInternal(global::Riok.Mapperly.IntegrationTests.Models.TestObject testObject)
         {
-            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto(DirectInt(testObject.CtorValue), ctorValue2: DirectInt(testObject.CtorValue2))
+            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto(
+                DirectInt(testObject.CtorValue),
+                ctorValue2: DirectInt(testObject.CtorValue2)
+            )
             {
                 IntInitOnlyValue = DirectInt(testObject.IntInitOnlyValue),
                 RequiredValue = DirectInt(testObject.RequiredValue),
@@ -261,16 +292,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array1(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array2(testObject.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(testObject.ImmutableListValue, x => ParseableInt(x)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(testObject.ImmutableHashSetValue, x => ParseableInt(x)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x => ParseableInt(x)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x => ParseableInt(x)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x => ParseableInt(x)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(testObject.ImmutableDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(testObject.ImmutableSortedDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
+            target.StackValue = new global::System.Collections.Generic.Stack<int>(
+                global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
+                global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableListValue, x => ParseableInt(x))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableHashSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x => ParseableInt(x))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                testObject.ImmutableDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                testObject.ImmutableSortedDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
             foreach (var item in testObject.ExistingISet)
             {
                 target.ExistingISet.Add(ParseableInt(item));
@@ -284,9 +339,15 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.ExistingSortedSet.Add(ParseableInt(item2));
             }
             MapExistingList(testObject.ExistingList, target.ExistingList);
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x)));
+            target.ISet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x))
+            );
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
+                global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)testObject.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestFlagsEnumDto)testObject.FlagsEnumValue;
             target.EnumName = MapToEnumDtoByName(testObject.EnumName);
@@ -361,16 +422,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.NullableReadOnlyObjectCollection = null;
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<string>(global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString()));
-            target.QueueValue = new global::System.Collections.Generic.Queue<string>(global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString()));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString()));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(dto.ImmutableListValue, x => x.ToString()));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(dto.ImmutableHashSetValue, x => x.ToString()));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x => x.ToString()));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x => x.ToString()));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x => x.ToString()));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(dto.ImmutableDictionaryValue, x => x.Key.ToString(), x => x.Value.ToString());
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(dto.ImmutableSortedDictionaryValue, x => x.Key.ToString(), x => x.Value.ToString());
+            target.StackValue = new global::System.Collections.Generic.Stack<string>(
+                global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString())
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<string>(
+                global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString())
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString())
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(dto.ImmutableListValue, x => x.ToString())
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(dto.ImmutableHashSetValue, x => x.ToString())
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x => x.ToString())
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x => x.ToString())
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x => x.ToString())
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                dto.ImmutableDictionaryValue,
+                x => x.Key.ToString(),
+                x => x.Value.ToString()
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                dto.ImmutableSortedDictionaryValue,
+                x => x.Key.ToString(),
+                x => x.Value.ToString()
+            );
             foreach (var item in dto.ExistingISet)
             {
                 target.ExistingISet.Add(item.ToString());
@@ -389,7 +474,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.ISet, x => x.ToString()));
             target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.HashSet, x => x.ToString()));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString()));
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(
+                global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString())
+            );
             target.EnumValue = MapToEnumByValueCheckDefined(dto.EnumValue);
             target.FlagsEnumValue = MapToFlagsEnumByValueCheckDefined(dto.FlagsEnumValue);
             target.EnumName = MapToEnumByNameWithFallback(dto.EnumName);
@@ -467,16 +554,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array1(source.SpanValue);
             target.MemoryValue = MapToInt32Array2(source.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(source.ImmutableListValue, x => ParseableInt(x)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(source.ImmutableHashSetValue, x => ParseableInt(x)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x => ParseableInt(x)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x => ParseableInt(x)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x => ParseableInt(x)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(source.ImmutableDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(source.ImmutableSortedDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
+            target.StackValue = new global::System.Collections.Generic.Stack<int>(
+                global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
+                global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(source.ImmutableListValue, x => ParseableInt(x))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(source.ImmutableHashSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x => ParseableInt(x))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                source.ImmutableDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                source.ImmutableSortedDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
             foreach (var item in source.ExistingISet)
             {
                 target.ExistingISet.Add(ParseableInt(item));
@@ -490,9 +601,15 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.ExistingSortedSet.Add(ParseableInt(item2));
             }
             MapExistingList(source.ExistingList, target.ExistingList);
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x)));
+            target.ISet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x))
+            );
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
+                global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)source.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestFlagsEnumDto)source.FlagsEnumValue;
             target.EnumName = MapToEnumDtoByName(source.EnumName);
@@ -819,7 +936,11 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 nameof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue.DtoValue1) => global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue.DtoValue1,
                 nameof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue.DtoValue2) => global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue.DtoValue2,
                 nameof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue.DtoValue3) => global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue.DtoValue3,
-                _ => (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)System.Enum.Parse(typeof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue), source, false),
+                _ => (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)System.Enum.Parse(
+                typeof(global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue),
+                source,
+                false
+            ),
             };
         }
 
@@ -877,7 +998,11 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 nameof(global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value10) => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value10,
                 nameof(global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value20) => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value20,
                 nameof(global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30) => global::Riok.Mapperly.IntegrationTests.Models.TestEnum.Value30,
-                _ => (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)System.Enum.Parse(typeof(global::Riok.Mapperly.IntegrationTests.Models.TestEnum), source, false),
+                _ => (global::Riok.Mapperly.IntegrationTests.Models.TestEnum)System.Enum.Parse(
+                typeof(global::Riok.Mapperly.IntegrationTests.Models.TestEnum),
+                source,
+                false
+            ),
             };
         }
 

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET6_0.verified.cs
@@ -146,16 +146,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array1(src.SpanValue);
             target.MemoryValue = MapToInt32Array2(src.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(global::System.Linq.Enumerable.Select(src.StackValue, x => ParseableInt(x)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(global::System.Linq.Enumerable.Select(src.QueueValue, x => ParseableInt(x)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(src.ImmutableArrayValue, x => ParseableInt(x)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(src.ImmutableListValue, x => ParseableInt(x)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(src.ImmutableHashSetValue, x => ParseableInt(x)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(src.ImmutableQueueValue, x => ParseableInt(x)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(src.ImmutableStackValue, x => ParseableInt(x)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(src.ImmutableSortedSetValue, x => ParseableInt(x)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(src.ImmutableDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(src.ImmutableSortedDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
+            target.StackValue = new global::System.Collections.Generic.Stack<int>(
+                global::System.Linq.Enumerable.Select(src.StackValue, x => ParseableInt(x))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
+                global::System.Linq.Enumerable.Select(src.QueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(src.ImmutableArrayValue, x => ParseableInt(x))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(src.ImmutableListValue, x => ParseableInt(x))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(src.ImmutableHashSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(src.ImmutableQueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(src.ImmutableStackValue, x => ParseableInt(x))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(src.ImmutableSortedSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                src.ImmutableDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                src.ImmutableSortedDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
             foreach (var item in src.ExistingISet)
             {
                 target.ExistingISet.Add(ParseableInt(item));
@@ -171,9 +195,15 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             MapExistingList(src.ExistingList, target.ExistingList);
             target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(src.ISet, x => ParseableInt(x)));
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(src.IReadOnlySet, x => ParseableInt(x)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(src.HashSet, x => ParseableInt(x)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(global::System.Linq.Enumerable.Select(src.SortedSet, x => ParseableInt(x)));
+            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(src.IReadOnlySet, x => ParseableInt(x))
+            );
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(src.HashSet, x => ParseableInt(x))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
+                global::System.Linq.Enumerable.Select(src.SortedSet, x => ParseableInt(x))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)src.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestFlagsEnumDto)src.FlagsEnumValue;
             target.EnumName = MapToEnumDtoByName(src.EnumName);
@@ -196,7 +226,10 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private static partial global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto MapToDtoInternal(global::Riok.Mapperly.IntegrationTests.Models.TestObject testObject)
         {
-            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto(DirectInt(testObject.CtorValue), ctorValue2: DirectInt(testObject.CtorValue2))
+            var target = new global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto(
+                DirectInt(testObject.CtorValue),
+                ctorValue2: DirectInt(testObject.CtorValue2)
+            )
             {
                 IntInitOnlyValue = DirectInt(testObject.IntInitOnlyValue),
                 RequiredValue = DirectInt(testObject.RequiredValue),
@@ -263,16 +296,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array1(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array2(testObject.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(testObject.ImmutableListValue, x => ParseableInt(x)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(testObject.ImmutableHashSetValue, x => ParseableInt(x)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x => ParseableInt(x)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x => ParseableInt(x)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x => ParseableInt(x)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(testObject.ImmutableDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(testObject.ImmutableSortedDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
+            target.StackValue = new global::System.Collections.Generic.Stack<int>(
+                global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
+                global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableListValue, x => ParseableInt(x))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableHashSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableQueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableStackValue, x => ParseableInt(x))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(testObject.ImmutableSortedSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                testObject.ImmutableDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                testObject.ImmutableSortedDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
             foreach (var item in testObject.ExistingISet)
             {
                 target.ExistingISet.Add(ParseableInt(item));
@@ -287,10 +344,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.ExistingSortedSet.Add(ParseableInt(item2));
             }
             MapExistingList(testObject.ExistingList, target.ExistingList);
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x)));
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(testObject.IReadOnlySet, x => ParseableInt(x)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x)));
+            target.ISet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x))
+            );
+            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(testObject.IReadOnlySet, x => ParseableInt(x))
+            );
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
+                global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)testObject.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestFlagsEnumDto)testObject.FlagsEnumValue;
             target.EnumName = MapToEnumDtoByName(testObject.EnumName);
@@ -365,16 +430,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.NullableReadOnlyObjectCollection = null;
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<string>(global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString()));
-            target.QueueValue = new global::System.Collections.Generic.Queue<string>(global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString()));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString()));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(dto.ImmutableListValue, x => x.ToString()));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(dto.ImmutableHashSetValue, x => x.ToString()));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x => x.ToString()));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x => x.ToString()));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x => x.ToString()));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(dto.ImmutableDictionaryValue, x => x.Key.ToString(), x => x.Value.ToString());
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(dto.ImmutableSortedDictionaryValue, x => x.Key.ToString(), x => x.Value.ToString());
+            target.StackValue = new global::System.Collections.Generic.Stack<string>(
+                global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString())
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<string>(
+                global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString())
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString())
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(dto.ImmutableListValue, x => x.ToString())
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(dto.ImmutableHashSetValue, x => x.ToString())
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(dto.ImmutableQueueValue, x => x.ToString())
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(dto.ImmutableStackValue, x => x.ToString())
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(dto.ImmutableSortedSetValue, x => x.ToString())
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                dto.ImmutableDictionaryValue,
+                x => x.Key.ToString(),
+                x => x.Value.ToString()
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                dto.ImmutableSortedDictionaryValue,
+                x => x.Key.ToString(),
+                x => x.Value.ToString()
+            );
             foreach (var item in dto.ExistingISet)
             {
                 target.ExistingISet.Add(item.ToString());
@@ -394,9 +483,13 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.ExistingList.Add(item3.ToString());
             }
             target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.ISet, x => x.ToString()));
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.IReadOnlySet, x => x.ToString()));
+            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(dto.IReadOnlySet, x => x.ToString())
+            );
             target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.HashSet, x => x.ToString()));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString()));
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(
+                global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString())
+            );
             target.EnumValue = MapToEnumByValueCheckDefined(dto.EnumValue);
             target.FlagsEnumValue = MapToFlagsEnumByValueCheckDefined(dto.FlagsEnumValue);
             target.EnumName = MapToEnumByNameWithFallback(dto.EnumName);
@@ -474,16 +567,40 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array1(source.SpanValue);
             target.MemoryValue = MapToInt32Array2(source.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x)));
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x)));
-            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x)));
-            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(global::System.Linq.Enumerable.Select(source.ImmutableListValue, x => ParseableInt(x)));
-            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(global::System.Linq.Enumerable.Select(source.ImmutableHashSetValue, x => ParseableInt(x)));
-            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x => ParseableInt(x)));
-            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x => ParseableInt(x)));
-            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x => ParseableInt(x)));
-            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(source.ImmutableDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
-            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(source.ImmutableSortedDictionaryValue, x => ParseableInt(x.Key), x => ParseableInt(x.Value));
+            target.StackValue = new global::System.Collections.Generic.Stack<int>(
+                global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x))
+            );
+            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
+                global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
+                global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x))
+            );
+            target.ImmutableListValue = global::System.Collections.Immutable.ImmutableList.ToImmutableList(
+                global::System.Linq.Enumerable.Select(source.ImmutableListValue, x => ParseableInt(x))
+            );
+            target.ImmutableHashSetValue = global::System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet(
+                global::System.Linq.Enumerable.Select(source.ImmutableHashSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableQueueValue = global::System.Collections.Immutable.ImmutableQueue.CreateRange(
+                global::System.Linq.Enumerable.Select(source.ImmutableQueueValue, x => ParseableInt(x))
+            );
+            target.ImmutableStackValue = global::System.Collections.Immutable.ImmutableStack.CreateRange(
+                global::System.Linq.Enumerable.Select(source.ImmutableStackValue, x => ParseableInt(x))
+            );
+            target.ImmutableSortedSetValue = global::System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet(
+                global::System.Linq.Enumerable.Select(source.ImmutableSortedSetValue, x => ParseableInt(x))
+            );
+            target.ImmutableDictionaryValue = global::System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(
+                source.ImmutableDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
+            target.ImmutableSortedDictionaryValue = global::System.Collections.Immutable.ImmutableSortedDictionary.ToImmutableSortedDictionary(
+                source.ImmutableSortedDictionaryValue,
+                x => ParseableInt(x.Key),
+                x => ParseableInt(x.Value)
+            );
             foreach (var item in source.ExistingISet)
             {
                 target.ExistingISet.Add(ParseableInt(item));
@@ -498,10 +615,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.ExistingSortedSet.Add(ParseableInt(item2));
             }
             MapExistingList(source.ExistingList, target.ExistingList);
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x)));
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(source.IReadOnlySet, x => ParseableInt(x)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x)));
-            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x)));
+            target.ISet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x))
+            );
+            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(source.IReadOnlySet, x => ParseableInt(x))
+            );
+            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
+                global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x))
+            );
+            target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
+                global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x))
+            );
             target.EnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestEnumDtoByValue)source.EnumValue;
             target.FlagsEnumValue = (global::Riok.Mapperly.IntegrationTests.Dto.TestFlagsEnumDto)source.FlagsEnumValue;
             target.EnumName = MapToEnumDtoByName(source.EnumName);

--- a/test/Riok.Mapperly.Tests/Mapping/DictionaryTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/DictionaryTest.cs
@@ -408,7 +408,11 @@ public class DictionaryTest
             .Should()
             .HaveAssertedAllDiagnostics()
             .HaveMapMethodBody(
-                "return new global::System.Collections.Generic.Dictionary<int, int>(global::System.Linq.Enumerable.Select(source, x => MapToKeyValuePairOfInt32AndInt32(x)));"
+                """
+                return new global::System.Collections.Generic.Dictionary<int, int>(
+                    global::System.Linq.Enumerable.Select(source, x => MapToKeyValuePairOfInt32AndInt32(x))
+                );
+                """
             );
     }
 

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyConstructorResolverTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyConstructorResolverTest.cs
@@ -349,7 +349,9 @@ public class ObjectPropertyConstructorResolverTest
             .Should()
             .HaveSingleMethodBody(
                 """
-                var target = new global::B(source.Nested?.Value ?? throw new System.ArgumentNullException(nameof(source.Nested.Value)));
+                var target = new global::B(
+                    source.Nested?.Value ?? throw new System.ArgumentNullException(nameof(source.Nested.Value))
+                );
                 return target;
                 """
             );
@@ -428,7 +430,9 @@ public class ObjectPropertyConstructorResolverTest
             .Should()
             .HaveSingleMethodBody(
                 """
-                var target = new global::B(source.Value ?? throw new System.ArgumentNullException(nameof(source.Value)));
+                var target = new global::B(
+                    source.Value ?? throw new System.ArgumentNullException(nameof(source.Value))
+                );
                 return target;
                 """
             );
@@ -444,7 +448,9 @@ public class ObjectPropertyConstructorResolverTest
             .Should()
             .HaveSingleMethodBody(
                 """
-                var target = new global::B(source.Value != null ? (double)source.Value.Value : throw new System.ArgumentNullException(nameof(source.Value.Value)));
+                var target = new global::B(
+                    source.Value != null ? (double)source.Value.Value : throw new System.ArgumentNullException(nameof(source.Value.Value))
+                );
                 return target;
                 """
             );
@@ -460,7 +466,9 @@ public class ObjectPropertyConstructorResolverTest
             .Should()
             .HaveSingleMethodBody(
                 """
-                var target = new global::B(source.Nested != null ? (double)source.Nested.Value : throw new System.ArgumentNullException(nameof(source.Nested.Value)));
+                var target = new global::B(
+                    source.Nested != null ? (double)source.Nested.Value : throw new System.ArgumentNullException(nameof(source.Nested.Value))
+                );
                 return target;
                 """
             );
@@ -544,7 +552,9 @@ public class ObjectPropertyConstructorResolverTest
             .Should()
             .HaveMapMethodBody(
                 """
-                var target = new global::B(source.EnumValue != null ? (global::D)source.EnumValue.Value : default(global::D?));
+                var target = new global::B(
+                    source.EnumValue != null ? (global::D)source.EnumValue.Value : default(global::D?)
+                );
                 return target;
                 """
             );
@@ -567,7 +577,9 @@ public class ObjectPropertyConstructorResolverTest
             .Should()
             .HaveMapMethodBody(
                 """
-                var target = new global::B(source.StructValue != null ? MapToD(source.StructValue.Value) : default(global::D?));
+                var target = new global::B(
+                    source.StructValue != null ? MapToD(source.StructValue.Value) : default(global::D?)
+                );
                 return target;
                 """
             );

--- a/test/Riok.Mapperly.Tests/Mapping/ToStringFormattedTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ToStringFormattedTest.cs
@@ -47,7 +47,11 @@ public class ToStringFormattedTest
             .Should()
             .HaveSingleMethodBody(
                 """
-                var target = new global::B(source.Value.ToString(), source.Value1.ToString("dd.MM.yyyy"), source.Value2.ToString("yyyy-MM-dd"));
+                var target = new global::B(
+                    source.Value.ToString(),
+                    source.Value1.ToString("dd.MM.yyyy"),
+                    source.Value2.ToString("yyyy-MM-dd")
+                );
                 return target;
                 """
             );

--- a/test/Riok.Mapperly.Tests/Mapping/UseStaticMapperTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/UseStaticMapperTest.cs
@@ -433,10 +433,13 @@ public class UseStaticMapperTest
             "ProjectToTarget",
             """
             #nullable disable
-                    return System.Linq.Queryable.Select(source, x => new global::Mapper.Target()
-                    {
-                        DateTime = new global::System.DateTimeOffset(x.DateTime, global::System.TimeSpan.Zero),
-                    });
+                    return System.Linq.Queryable.Select(
+                        source,
+                        x => new global::Mapper.Target()
+                        {
+                            DateTime = new global::System.DateTimeOffset(x.DateTime, global::System.TimeSpan.Zero),
+                        }
+                    );
             #nullable enable
             """
         );
@@ -456,10 +459,13 @@ public class UseStaticMapperTest
                 "ProjectToTarget",
                 """
                 #nullable disable
-                        return System.Linq.Queryable.Select(source, x => new global::Mapper.Target()
-                        {
-                            DateTime = global::Riok.Mapperly.TestDependency.Mapper.DateTimeMapper.MapToDateTimeOffset(x.DateTime),
-                        });
+                        return System.Linq.Queryable.Select(
+                            source,
+                            x => new global::Mapper.Target()
+                            {
+                                DateTime = global::Riok.Mapperly.TestDependency.Mapper.DateTimeMapper.MapToDateTimeOffset(x.DateTime),
+                            }
+                        );
                 #nullable enable
                 """
             );

--- a/test/Riok.Mapperly.Tests/_snapshots/GenericTest.WithGenericSourceAndTargetAndEnabledReferenceHandling#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/GenericTest.WithGenericSourceAndTargetAndEnabledReferenceHandling#Mapper.g.verified.cs
@@ -19,13 +19,19 @@ public partial class Mapper
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::B MapToB(global::A source)
     {
-        return MapToB1(source, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToB1(
+            source,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::D MapToD(global::C source)
     {
-        return MapToD1(source, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToD1(
+            source,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyUseNamedMappingTest.ShouldUseReferencedMappingOnSelectedPropertiesWithRecordConstructors#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyUseNamedMappingTest.ShouldUseReferencedMappingOnSelectedPropertiesWithRecordConstructors#Mapper.g.verified.cs
@@ -6,7 +6,11 @@ public partial class Mapper
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     public partial global::B Map(global::A source)
     {
-        var target = new global::B(DefaultStringMapping(source.StringValue), ModifyString(source.StringValue1), ModifyString2(source.StringValue2));
+        var target = new global::B(
+            DefaultStringMapping(source.StringValue),
+            ModifyString(source.StringValue1),
+            ModifyString2(source.StringValue2)
+        );
         return target;
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyUseNamedMappingTest.UserMethodReturnsNullableShouldThrow#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ObjectPropertyUseNamedMappingTest.UserMethodReturnsNullableShouldThrow#Mapper.g.verified.cs
@@ -7,7 +7,9 @@ public partial class Mapper
     public partial global::B Map(global::A source)
     {
         var target = new global::B();
-        target.Value = ToC(source.Name ?? throw new System.ArgumentNullException(nameof(source.Name))) ?? throw new System.NullReferenceException("ToC returned null");
+        target.Value = ToC(
+            source.Name ?? throw new System.ArgumentNullException(nameof(source.Name))
+        ) ?? throw new System.NullReferenceException("ToC returned null");
         return target;
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionDerivedTypeTest.AbstractBaseClassDerivedTypesShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionDerivedTypeTest.AbstractBaseClassDerivedTypesShouldWork#Mapper.g.verified.cs
@@ -7,17 +7,20 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => (global::B)(x is global::ASubType1 ? new global::BSubType1()
-        {
-            Value1 = ((global::ASubType1)x).Value1,
-            BaseValueB = ((global::ASubType1)x).BaseValueA,
-            StringValue = ((global::ASubType1)x).StringValue,
-        } : x is global::ASubType2 ? new global::BSubType2()
-        {
-            Value2 = ((global::ASubType2)x).Value2,
-            BaseValueB = ((global::ASubType2)x).BaseValueA,
-            StringValue = ((global::ASubType2)x).StringValue,
-        } : default));
+        return System.Linq.Queryable.Select(
+            source,
+            x => (global::B)(x is global::ASubType1 ? new global::BSubType1()
+            {
+                Value1 = ((global::ASubType1)x).Value1,
+                BaseValueB = ((global::ASubType1)x).BaseValueA,
+                StringValue = ((global::ASubType1)x).StringValue,
+            } : x is global::ASubType2 ? new global::BSubType2()
+            {
+                Value2 = ((global::ASubType2)x).Value2,
+                BaseValueB = ((global::ASubType2)x).BaseValueA,
+                StringValue = ((global::ASubType2)x).StringValue,
+            } : default)
+        );
 #nullable enable
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionEnumTest.EnumFromString#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionEnumTest.EnumFromString#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            Value = System.Enum.Parse<global::C>(x.Value, false),
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                Value = System.Enum.Parse<global::C>(x.Value, false),
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionEnumTest.EnumToAnotherEnum#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionEnumTest.EnumToAnotherEnum#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            Value = (global::D)x.Value,
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                Value = (global::D)x.Value,
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionEnumTest.EnumToString#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionEnumTest.EnumToString#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            Value = (string)x.Value.ToString(),
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                Value = (string)x.Value.ToString(),
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionEnumerableTest.ArrayToArrayExplicitCast#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionEnumerableTest.ArrayToArrayExplicitCast#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            Values = global::System.Linq.Enumerable.ToArray(global::System.Linq.Enumerable.Select(x.Values, x1 => (int)x1)),
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                Values = global::System.Linq.Enumerable.ToArray(global::System.Linq.Enumerable.Select(x.Values, x1 => (int)x1)),
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionEnumerableTest.ExplicitCast#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionEnumerableTest.ExplicitCast#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            Values = global::System.Linq.Enumerable.Select(x.Values, x1 => (int)x1),
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                Values = global::System.Linq.Enumerable.Select(x.Values, x1 => (int)x1),
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourceAndTargetProperty#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourceAndTargetProperty#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                StringValue = x.StringValue,
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourceAndTargetPropertyWithNoNullAssignmentAndThrowShouldBeIgnored#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourceAndTargetPropertyWithNoNullAssignmentAndThrowShouldBeIgnored#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                StringValue = x.StringValue,
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourceAndTargetValueTypeProperty#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourceAndTargetValueTypeProperty#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            IntValue = x.IntValue,
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                IntValue = x.IntValue,
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourcePathAutoFlatten#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourcePathAutoFlatten#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            NestedValue = x.Nested != null ? x.Nested.Value : default,
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                NestedValue = x.Nested != null ? x.Nested.Value : default,
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourcePathAutoFlattenString#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourcePathAutoFlattenString#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            NestedValue = x.Nested != null ? x.Nested.Value : "",
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                NestedValue = x.Nested != null ? x.Nested.Value : "",
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourcePathManuallyFlatten#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourcePathManuallyFlatten#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     public partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> q)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(q, x => new global::B()
-        {
-            NestedValue4 = x.Nested != null && x.Nested.Nested2 != null ? x.Nested.Nested2.Value3 : default,
-        });
+        return System.Linq.Queryable.Select(
+            q,
+            x => new global::B()
+            {
+                NestedValue4 = x.Nested != null && x.Nested.Nested2 != null ? x.Nested.Nested2.Value3 : default,
+            }
+        );
 #nullable enable
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourceProperty#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourceProperty#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue ?? "",
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                StringValue = x.StringValue ?? "",
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourceValueTypeProperty#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableSourceValueTypeProperty#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            IntValue = x.IntValue ?? default,
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                IntValue = x.IntValue ?? default,
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableTargetProperty#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableTargetProperty#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                StringValue = x.StringValue,
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableTargetValueTypeProperty#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.ClassToClassNullableTargetValueTypeProperty#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            IntValue = x.IntValue,
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                IntValue = x.IntValue,
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.ClassToClass#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.ClassToClass#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                StringValue = x.StringValue,
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.ClassToClassMultipleProperties#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.ClassToClassMultipleProperties#Mapper.g.verified.cs
@@ -7,12 +7,15 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-            IntValue = x.IntValue,
-            CharValue = x.CharValue,
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                StringValue = x.StringValue,
+                IntValue = x.IntValue,
+                CharValue = x.CharValue,
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.ClassToClassNested#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.ClassToClassNested#Mapper.g.verified.cs
@@ -7,14 +7,17 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-            OtherValue = new global::D()
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
             {
-                IntValue = x.OtherValue.IntValue,
-            },
-        });
+                StringValue = x.StringValue,
+                OtherValue = new global::D()
+                {
+                    IntValue = x.OtherValue.IntValue,
+                },
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.ClassToClassNestedMemberAttribute#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.ClassToClassNestedMemberAttribute#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            Id = x.Value.Id,
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                Id = x.Value.Id,
+            }
+        );
 #nullable enable
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.ClassToClassWithConfigs#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.ClassToClassWithConfigs#Mapper.g.verified.cs
@@ -7,18 +7,21 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue2 = x.StringValue,
-            NestedValue = new global::D()
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
             {
-                IntValue = (int)x.NestedValue.LongValue,
-                NestedValue = new global::F()
+                StringValue2 = x.StringValue,
+                NestedValue = new global::D()
                 {
-                    ShortValue = x.NestedValue.NestedValue.ShortValue,
+                    IntValue = (int)x.NestedValue.LongValue,
+                    NestedValue = new global::F()
+                    {
+                        ShortValue = x.NestedValue.NestedValue.ShortValue,
+                    },
                 },
-            },
-        });
+            }
+        );
 #nullable enable
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.CtorShouldSkipUnmatchedOptionalParameters#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.CtorShouldSkipUnmatchedOptionalParameters#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B(x.StringValue)
-        {
-            IntValue = x.IntValue,
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B(x.StringValue)
+            {
+                IntValue = x.IntValue,
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.QueryablePropertyWithStringFormat#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.QueryablePropertyWithStringFormat#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            Value = x.Value.ToString("C"),
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                Value = x.Value.ToString("C"),
+            }
+        );
 #nullable enable
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.RecordToRecordManualFlatteningInsideList#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.RecordToRecordManualFlatteningInsideList#Mapper.g.verified.cs
@@ -7,7 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B(x.Id.ToString(), global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.Select(x.Values, x1 => x1.Value))));
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B(
+                x.Id.ToString(),
+                global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.Select(x.Values, x1 => x1.Value))
+            )
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.RecordToRecordManualListMapping#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.RecordToRecordManualListMapping#Mapper.g.verified.cs
@@ -7,7 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B(x.Id.ToString(), global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.OrderBy(global::System.Linq.Enumerable.Select(x.Values, x => x.Value), x => x))));
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B(
+                x.Id.ToString(),
+                global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.OrderBy(global::System.Linq.Enumerable.Select(x.Values, x => x.Value), x => x))
+            )
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.ReferenceLoopCtor#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.ReferenceLoopCtor#Mapper.g.verified.cs
@@ -7,13 +7,18 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B(x.Parent != null ? new global::B()
-        {
-            IntValue = x.Parent.IntValue,
-        } : default)
-        {
-            IntValue = x.IntValue,
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B(
+                x.Parent != null ? new global::B()
+                {
+                    IntValue = x.Parent.IntValue,
+                } : default
+            )
+            {
+                IntValue = x.IntValue,
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.ReferenceLoopInitProperty#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionTest.ReferenceLoopInitProperty#Mapper.g.verified.cs
@@ -7,14 +7,17 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            Parent = x.Parent != null ? new global::B()
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
             {
-                IntValue = x.Parent.IntValue,
-            } : default,
-            IntValue = x.IntValue,
-        });
+                Parent = x.Parent != null ? new global::B()
+                {
+                    IntValue = x.Parent.IntValue,
+                } : default,
+                IntValue = x.IntValue,
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUseNamedMappingTest.ShouldUseReferencedMappingOnSelectedProperties#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUseNamedMappingTest.ShouldUseReferencedMappingOnSelectedProperties#Mapper.g.verified.cs
@@ -7,12 +7,15 @@ public partial class Mapper
     public partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-            StringValue1 = x.StringValue1 + "-modified",
-            StringValue2 = x.StringValue2 + "-modified2",
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                StringValue = x.StringValue,
+                StringValue1 = x.StringValue1 + "-modified",
+                StringValue2 = x.StringValue2 + "-modified2",
+            }
+        );
 #nullable enable
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUseNamedMappingTest.ShouldUseReferencedMappingOnSelectedPropertiesWithDisabledAutoUserMappings#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUseNamedMappingTest.ShouldUseReferencedMappingOnSelectedPropertiesWithDisabledAutoUserMappings#Mapper.g.verified.cs
@@ -7,12 +7,15 @@ public partial class Mapper
     public partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-            StringValue1 = x.StringValue1 + "-modified",
-            StringValue2 = x.StringValue2 + "-modified2",
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                StringValue = x.StringValue,
+                StringValue1 = x.StringValue1 + "-modified",
+                StringValue2 = x.StringValue2 + "-modified2",
+            }
+        );
 #nullable enable
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUseNamedMappingTest.ShouldUseReferencedUserDefinedMappingOnSelectedProperties#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUseNamedMappingTest.ShouldUseReferencedUserDefinedMappingOnSelectedProperties#Mapper.g.verified.cs
@@ -7,12 +7,15 @@ public partial class Mapper
     public partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            Value = new global::D(x.Value.Value.ToString("P")),
-            Value2 = new global::D(x.Value2.Value.ToString("C")),
-            ValueDefault = new global::D(x.ValueDefault.Value.ToString("N")),
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                Value = new global::D(x.Value.Value.ToString("P")),
+                Value2 = new global::D(x.Value2.Value.ToString("C")),
+                ValueDefault = new global::D(x.ValueDefault.Value.ToString("N")),
+            }
+        );
 #nullable enable
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUseNamedMappingTest.ShouldUseReferencedUserDefinedMappingOnSelectedPropertiesWithDisabledAutoUserMappings#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUseNamedMappingTest.ShouldUseReferencedUserDefinedMappingOnSelectedPropertiesWithDisabledAutoUserMappings#Mapper.g.verified.cs
@@ -7,12 +7,15 @@ public partial class Mapper
     public partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            Value = new global::D(x.Value.Value.ToString("P")),
-            Value2 = new global::D(x.Value2.Value.ToString("C")),
-            ValueDefault = new global::D(x.ValueDefault.Value.ToString("N")),
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                Value = new global::D(x.Value.Value.ToString("P")),
+                Value2 = new global::D(x.Value2.Value.ToString("C")),
+                ValueDefault = new global::D(x.ValueDefault.Value.ToString("N")),
+            }
+        );
 #nullable enable
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUseNamedMappingTest.TwoQueryableMappingsWithNamedUsedMappingsAndAmbiguousName#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUseNamedMappingTest.TwoQueryableMappingsWithNamedUsedMappingsAndAmbiguousName#Mapper.g.verified.cs
@@ -7,7 +7,14 @@ public partial class Mapper
     public partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B(x.StringValue, x.StringValue1 + "-modified", x.StringValue2 + "-modified2"));
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B(
+                x.StringValue,
+                x.StringValue1 + "-modified",
+                x.StringValue2 + "-modified2"
+            )
+        );
 #nullable enable
     }
 
@@ -15,21 +22,36 @@ public partial class Mapper
     public partial global::System.Linq.IQueryable<global::D> Map(global::System.Linq.IQueryable<global::C> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::D(x.StringValue, x.StringValue1 + "-modified", x.StringValue2 + "-modified2"));
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::D(
+                x.StringValue,
+                x.StringValue1 + "-modified",
+                x.StringValue2 + "-modified2"
+            )
+        );
 #nullable enable
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::B Map(global::A source)
     {
-        var target = new global::B(DefaultStringMapping(source.StringValue), ModifyString(source.StringValue1), ModifyString2(source.StringValue2));
+        var target = new global::B(
+            DefaultStringMapping(source.StringValue),
+            ModifyString(source.StringValue1),
+            ModifyString2(source.StringValue2)
+        );
         return target;
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::D Map(global::C source)
     {
-        var target = new global::D(DefaultStringMapping(source.StringValue), ModifyString(source.StringValue1), ModifyString2(source.StringValue2));
+        var target = new global::D(
+            DefaultStringMapping(source.StringValue),
+            ModifyString(source.StringValue1),
+            ModifyString2(source.StringValue2)
+        );
         return target;
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassInlinedExpression#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassInlinedExpression#Mapper.g.verified.cs
@@ -7,11 +7,14 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-            NestedValue = new global::D { Value = x.NestedValue.Value + "-mapped" },
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                StringValue = x.StringValue,
+                NestedValue = new global::D { Value = x.NestedValue.Value + "-mapped" },
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassInlinedSingleDeclaration#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassInlinedSingleDeclaration#Mapper.g.verified.cs
@@ -7,11 +7,14 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-            NestedValue = new global::D { Value = x.NestedValue.Value + "-mapped" },
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                StringValue = x.StringValue,
+                NestedValue = new global::D { Value = x.NestedValue.Value + "-mapped" },
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassInlinedSingleStatement#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassInlinedSingleStatement#Mapper.g.verified.cs
@@ -7,11 +7,14 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-            NestedValue = new global::D { Value = x.NestedValue.Value + "-mapped" },
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                StringValue = x.StringValue,
+                NestedValue = new global::D { Value = x.NestedValue.Value + "-mapped" },
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassNonInlinedMethod#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassNonInlinedMethod#Mapper.g.verified.cs
@@ -7,11 +7,14 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-            NestedValue = MapToD(x.NestedValue),
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                StringValue = x.StringValue,
+                NestedValue = MapToD(x.NestedValue),
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassUserImplementedOrdering#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassUserImplementedOrdering#Mapper.g.verified.cs
@@ -7,11 +7,14 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-            NestedValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.OrderBy(x.NestedValues, x => x.Value)),
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                StringValue = x.StringValue,
+                NestedValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.OrderBy(x.NestedValues, x => x.Value)),
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassUserImplementedOrderingWithMappingAndParameterHiding#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassUserImplementedOrderingWithMappingAndParameterHiding#Mapper.g.verified.cs
@@ -7,14 +7,17 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-            NestedValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.Select(global::System.Linq.Enumerable.OrderBy(x.NestedValues, x => x.Value), v => new global::D()
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
             {
-                Value = v.Value,
-            })),
-        });
+                StringValue = x.StringValue,
+                NestedValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.Select(global::System.Linq.Enumerable.OrderBy(x.NestedValues, x => x.Value), v => new global::D()
+                {
+                    Value = v.Value,
+                })),
+            }
+        );
 #nullable enable
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassUserImplementedOrderingWithTwoNestedMappings#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassUserImplementedOrderingWithTwoNestedMappings#Mapper.g.verified.cs
@@ -7,14 +7,17 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue + "-mod",
-            NestedValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.Select(global::System.Linq.Enumerable.OrderBy(x.NestedValues, x => x.Value), x => new global::D()
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
             {
-                Value = x.Value + "-mod",
-            })),
-        });
+                StringValue = x.StringValue + "-mod",
+                NestedValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.Select(global::System.Linq.Enumerable.OrderBy(x.NestedValues, x => x.Value), x => new global::D()
+                {
+                    Value = x.Value + "-mod",
+                })),
+            }
+        );
 #nullable enable
     }
 

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassUserImplementedParenthesizedLambdaOrdering#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassUserImplementedParenthesizedLambdaOrdering#Mapper.g.verified.cs
@@ -7,11 +7,14 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            StringValue = x.StringValue,
-            NestedValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.OrderBy(x.NestedValues, (x) => x.Value)),
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                StringValue = x.StringValue,
+                NestedValues = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.OrderBy(x.NestedValues, (x) => x.Value)),
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassUserImplementedWithTargetTypeNew#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassUserImplementedWithTargetTypeNew#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            Value = new global::System.DateTimeOffset(x.Value, global::System.TimeSpan.Zero),
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                Value = new global::System.DateTimeOffset(x.Value, global::System.TimeSpan.Zero),
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassUserImplementedWithTargetTypeNewInitializer#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassUserImplementedWithTargetTypeNewInitializer#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            Value = new global::C(1) { Value2 = 10 },
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                Value = new global::C(1) { Value2 = 10 },
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassUserImplementedWithUsingMappings#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassUserImplementedWithUsingMappings#Mapper.g.verified.cs
@@ -7,10 +7,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> Map(global::System.Linq.IQueryable<global::A> source)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(source, x => new global::B()
-        {
-            Value = new global::System.DateTimeOffset(x.Value, global::System.TimeSpan.Zero),
-        });
+        return System.Linq.Queryable.Select(
+            source,
+            x => new global::B()
+            {
+                Value = new global::System.DateTimeOffset(x.Value, global::System.TimeSpan.Zero),
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ArrayShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ArrayShouldWork#Mapper.g.verified.cs
@@ -6,7 +6,10 @@ public partial class Mapper
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::B Map(global::A source)
     {
-        return MapToB(source, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToB(
+            source,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.EnumerableShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.EnumerableShouldWork#Mapper.g.verified.cs
@@ -6,7 +6,10 @@ public partial class Mapper
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::B Map(global::A source)
     {
-        return MapToB(source, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToB(
+            source,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ManuallyMappedPropertiesShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ManuallyMappedPropertiesShouldWork#Mapper.g.verified.cs
@@ -6,13 +6,19 @@ public partial class Mapper
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::B MapToB(global::A source)
     {
-        return MapToB2(source, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToB2(
+            source,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::B MapToB1(global::A source)
     {
-        return MapToB3(source, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToB3(
+            source,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.MultipleUserDefinedWithSpecifiedDefault#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.MultipleUserDefinedWithSpecifiedDefault#Mapper.g.verified.cs
@@ -6,19 +6,28 @@ public partial class Mapper
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     public partial global::B Map(global::A a)
     {
-        return MapToB(a, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToB(
+            a,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::D MapD(global::C source)
     {
-        return MapToD(source, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToD(
+            source,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::D MapDIgnore(global::C source)
     {
-        return MapToD1(source, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToD1(
+            source,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ObjectFactoryShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ObjectFactoryShouldWork#Mapper.g.verified.cs
@@ -6,7 +6,10 @@ public partial class Mapper
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::B Map(global::A a)
     {
-        return MapToB(a, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToB(
+            a,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.ShouldWork#Mapper.g.verified.cs
@@ -6,7 +6,10 @@ public partial class Mapper
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::B Map(global::A source)
     {
-        return MapToB(source, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToB(
+            source,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.UserImplementedWithReferenceHandlerShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.UserImplementedWithReferenceHandlerShouldWork#Mapper.g.verified.cs
@@ -6,7 +6,10 @@ public partial class Mapper
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::B Map(global::A a)
     {
-        return MapToB(a, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToB(
+            a,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.UserImplementedWithoutReferenceHandlerShouldWork#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/ReferenceHandlingTest.UserImplementedWithoutReferenceHandlerShouldWork#Mapper.g.verified.cs
@@ -6,7 +6,10 @@ public partial class Mapper
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::B Map(global::A a)
     {
-        return MapToB(a, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToB(
+            a,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.Tests/_snapshots/RuntimeTargetTypeMappingTest.WithGenericSourceAndTarget#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/RuntimeTargetTypeMappingTest.WithGenericSourceAndTarget#Mapper.g.verified.cs
@@ -18,10 +18,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::B> ProjectToB(global::System.Linq.IQueryable<global::A> q)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(q, x => new global::B()
-        {
-            Value = x.Value,
-        });
+        return System.Linq.Queryable.Select(
+            q,
+            x => new global::B()
+            {
+                Value = x.Value,
+            }
+        );
 #nullable enable
     }
 
@@ -29,10 +32,13 @@ public partial class Mapper
     private partial global::System.Linq.IQueryable<global::D> ProjectToD(global::System.Linq.IQueryable<global::C> q)
     {
 #nullable disable
-        return System.Linq.Queryable.Select(q, x => new global::D()
-        {
-            Value2 = x.Value2,
-        });
+        return System.Linq.Queryable.Select(
+            q,
+            x => new global::D()
+            {
+                Value2 = x.Value2,
+            }
+        );
 #nullable enable
     }
 }

--- a/test/Riok.Mapperly.Tests/_snapshots/RuntimeTargetTypeMappingTest.WithReferenceHandlingEnabled#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/RuntimeTargetTypeMappingTest.WithReferenceHandlingEnabled#Mapper.g.verified.cs
@@ -18,13 +18,19 @@ public partial class Mapper
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::B MapToB(global::A source)
     {
-        return MapToB1(source, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToB1(
+            source,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
     private partial global::D MapToD(global::C source)
     {
-        return MapToD1(source, new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler());
+        return MapToD1(
+            source,
+            new global::Riok.Mapperly.Abstractions.ReferenceHandling.PreserveReferenceHandler()
+        );
     }
 
     [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]


### PR DESCRIPTION
Improves the constructor readability by separating long arguments by line feeds.

Replaces #1337
Fixes #1322 