### PR TITLE
Support inlining of method with generic type arguments

### DIFF
--- a/src/Riok.Mapperly/Descriptors/InlineExpressionRewriter.cs
+++ b/src/Riok.Mapperly/Descriptors/InlineExpressionRewriter.cs
@@ -229,7 +229,11 @@ public class InlineExpressionRewriter(SemanticModel semanticModel, Func<IMethodS
     private static InvocationExpressionSyntax VisitStaticMethodInvocation(InvocationExpressionSyntax node, IMethodSymbol methodSymbol)
     {
         var receiverType = FullyQualifiedIdentifier(methodSymbol.ReceiverType!);
-        var expression = MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, receiverType, IdentifierName(methodSymbol.Name));
+        SimpleNameSyntax method = methodSymbol.TypeArguments is { Length: > 0 } typeArguments
+            ? GenericName(methodSymbol.Name)
+                .WithTypeArgumentList(TypeArgumentList(SeparatedList<TypeSyntax>(typeArguments.Select(FullyQualifiedIdentifier))))
+            : IdentifierName(methodSymbol.Name);
+        var expression = MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, receiverType, method);
         return node.WithExpression(expression);
     }
 

--- a/test/Riok.Mapperly.Tests/Helpers/InlineExpressionRewriterTest.cs
+++ b/test/Riok.Mapperly.Tests/Helpers/InlineExpressionRewriterTest.cs
@@ -161,6 +161,29 @@ public class InlineExpressionRewriterTest
         result.Should().Be("(string)(object)(value as global::AnotherAssembly.B).Value");
     }
 
+    [Fact]
+    public void RewriteExpressionContainingMethodCallWithGenericArgument()
+    {
+        var (result, inlineOk) = Rewrite(
+            """
+            using AnotherAssembly;
+            using System;
+
+            public class Test
+            {
+                public IReadOnlyCollection<A> MapExpression(A value) => Array.Empty<A>();
+            }
+
+            namespace AnotherAssembly {
+                record A;
+            }
+            """
+        );
+
+        inlineOk.Should().BeTrue();
+        result.Should().Be("global::System.Array.Empty<global::AnotherAssembly.A>()");
+    }
+
     private (string Result, bool CanBeInlined) Rewrite([StringSyntax(StringSyntax.CSharp)] string source)
     {
         var compilation = TestHelper.BuildCompilation(source);


### PR DESCRIPTION
# Support inlining of method with generic type arguments

## Description

Inlining of
```cs
public class Test
{
    public IReadOnlyCollection<A> MapExpression(A value) => Array.Empty<A>();
}
```

Produces:
`global::System.Array.Empty()`

instead of
`global::System.Array.Empty<global::A>()`

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
