### PR TITLE
docs: add security headers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -189,6 +189,7 @@ indent_size = 2
 # Shell scripts
 [*.sh]
 end_of_line = lf
+
 [*.{cmd,bat}]
 end_of_line = crlf
 
@@ -225,3 +226,6 @@ indent_style = unset
 insert_final_newline = false
 tab_width = unset
 trim_trailing_whitespace = false
+
+[docs/static/_headers]
+indent_size = 2

--- a/docs/static/_headers
+++ b/docs/static/_headers
@@ -1,0 +1,12 @@
+/*
+  ! Access-Control-Allow-Origin
+  X-Content-Type-Options: nosniff
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  X-Frame-Options: Deny
+  Referrer-Policy: no-referrer
+  Content-Security-Policy: upgrade-insecure-requests; block-all-mixed-content; report-uri https://riok.report-uri.com/r/d/csp/enforce; default-src 'self'; script-src 'self' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'sha256-pBkmluod9Ko4GzDfbWgKM/wxzujFXUdGVOePkwOQT+c='; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://img.shields.io/; object-src 'none'; frame-ancestors 'none'
+  Cross-Origin-Opener-Policy: same-origin
+  Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()
+
+https://:project.pages.dev/*
+  X-Robots-Tag: noindex


### PR DESCRIPTION
Adds security relevant headers to the documentation webpage using the cloudflare pages _headers file.
Disables the access-control-allow-origin header, added by CF pages by default.
Use hashes for docusaurus inlined scripts