### PR TITLE
fix issue

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
@@ -18,7 +18,7 @@ public static class ObjectMemberMappingBodyBuilder
         BuildMappingBody(mappingCtx);
 
         // init only members should not result in unmapped diagnostics for existing target mappings
-        foreach (var initOnlyTargetMember in mappingCtx.EnumerateUnmappedTargetMembers().Where(x => x.IsInitOnly))
+        foreach (var initOnlyTargetMember in mappingCtx.EnumerateUnmappedTargetMembers().Where(x => x.IsInitOnly).ToArray())
         {
             mappingCtx.SetTargetMemberMapped(initOnlyTargetMember);
         }


### PR DESCRIPTION
# Fix "Building Riok.Mapperly.IntegrationTests fails with "Generator 'MapperGenerator' failed to generate source..." in VS 2022.17.11.4"

## Description

Fixes #1516 

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)