### PR TITLE
Removes the obsolete attribute from `MapProperty.ctor(string[], string[]`)

### DIFF
--- a/docs/docs/breaking-changes/4-0.md
+++ b/docs/docs/breaking-changes/4-0.md
@@ -11,7 +11,6 @@ description: How to upgrade to Mapperly v4.0 and a list of all its breaking chan
 
 ## Migration guide from v3.6.0
 
-- `MapPropertyAttribute.ctor(string[], string[])` is marked as obsolete, replace either with `MapPropertyAttribute.ctor(string[], string)` or `MapPropertyAttribute.ctor(string, string[])`.
 - Strict mappings are enabled by default, either use `MapperAttribute.RequiredMappingStrategy`/`MapperRequiredMappingAttribute` or revert to non-strict mappings (see [strict mappings by default](#strict-mappings-by-default)).
 - If the `ExplicitCast` conversion is disabled, disable the new `EnumUnderlyingType` conversion too.
 - Members of foreach mappings are now mapped, which may result in additional members being mapped or new diagnostics being reported.
@@ -19,13 +18,6 @@ description: How to upgrade to Mapperly v4.0 and a list of all its breaking chan
 - The ordering of the member assignments in mappings may change, if you rely on the order of members being mapped, you may need to diff and verify the generated source code.
 - Well-known .NET immutable types are not copied, even if `UseDeepCloning` is enabled.
 - For long property names, auto-flattening may not work anymore and may need to be configured manually by applying the `MapPropertyAttribute`.
-
-## MapPropertyAttribute constructors
-
-Since Mapperly does not support source nested member to target nested member mappings,
-the constructor `MapPropertyAttribute.ctor(string[], string[])` is marked as obsolete
-and will be removed in a future release.
-Use `MapPropertyAttribute.ctor(string[], string)` or `MapPropertyAttribute.ctor(string, string[])` instead.
 
 ## Strict mappings by default
 
@@ -53,7 +45,7 @@ New diagnostics can also be reported for existing mappings
 ## Limited auto-flattening
 
 Mapperly tries to flatten properties automatically.
-For this Mapperly tries to access object members based on the pascal case member name notation of C#.
+For this Mapperly tries to access object members based on the PascalCase member name notation of C#.
 Starting with 4.0 Mapperly will only try up to 256 member path permutations.
 Before all possible permutations were tried.
 Auto-flattening can always be overwritten by applying the `MapPropertyAttribute`.

--- a/src/Riok.Mapperly.Abstractions/MapPropertyAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapPropertyAttribute.cs
@@ -50,7 +50,6 @@ public sealed class MapPropertyAttribute : Attribute
     /// </summary>
     /// <param name="source">The path of the source property. The use of `nameof()` is encouraged.</param>
     /// <param name="target">The path of the target property. The use of `nameof()` is encouraged.</param>
-    [Obsolete("Use MapPropertyAttribute(string[], string) or MapPropertyAttribute(string, string[]) instead.")]
     public MapPropertyAttribute(string[] source, string[] target)
     {
         Source = source;

--- a/test/Riok.Mapperly.Abstractions.Tests/_snapshots/PublicApiTest.PublicApiHasNotChanged.verified.cs
+++ b/test/Riok.Mapperly.Abstractions.Tests/_snapshots/PublicApiTest.PublicApiHasNotChanged.verified.cs
@@ -82,8 +82,6 @@ namespace Riok.Mapperly.Abstractions
         public MapPropertyAttribute(string source, string target) { }
         public MapPropertyAttribute(string[] source, string target) { }
         public MapPropertyAttribute(string source, string[] target) { }
-        [System.Obsolete("Use MapPropertyAttribute(string[], string) or MapPropertyAttribute(string, string" +
-            "[]) instead.")]
         public MapPropertyAttribute(string[] source, string[] target) { }
         public string? FormatProvider { get; set; }
         public System.Collections.Generic.IReadOnlyCollection<string> Source { get; }

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNestedTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNestedTest.cs
@@ -1,0 +1,94 @@
+using Riok.Mapperly.Diagnostics;
+
+namespace Riok.Mapperly.Tests.Mapping;
+
+public class ObjectPropertyNestedTest
+{
+    [Fact]
+    public void ManualNestedToNestedProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapProperty(new [] {"Value", "IntValue"}, new [] {"Value", "StringValue"})]
+            public partial B Map(A source);
+            """,
+            "class A { public C Value { get; set; } }",
+            "class B { public D Value { get; set; } }",
+            "class C { public int IntValue { get; set; } }",
+            "class D { public string StringValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value.StringValue = source.Value.IntValue.ToString();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ManualNullableNestedToNullableNestedProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapProperty(new [] {"Value", "IntValue"}, new [] {"Value", "StringValue"})]
+            public partial B Map(A source);
+            """,
+            "class A { public C? Value { get; set; } }",
+            "class B { public D? Value { get; set; } }",
+            "class C { public int IntValue { get; set; } }",
+            "class D { public string StringValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                if (source.Value != null)
+                {
+                    target.Value ??= new global::D();
+                    target.Value.StringValue = source.Value.IntValue.ToString();
+                }
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ManualNestedToInitOnlyNestedPropertyShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapProperty(new [] {"Value", "IntValue"}, new [] {"Value", "StringValue"})]
+            public partial B Map(A source);
+            """,
+            "class A { public C Value { get; set; } }",
+            "class B { public D Value { get; set; } }",
+            "class C { public int IntValue { get; init; } }",
+            "class D { public string StringValue { get; init; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.SourceMemberNotMapped,
+                "The member Value on the mapping source type A is not mapped to any member on the mapping target type B"
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.SourceMemberNotFound,
+                "The member Value on the mapping target type B was not found on the mapping source type A"
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.CannotMapToInitOnlyMemberPath,
+                "Cannot map from A.Value.IntValue to init only member path B.Value.StringValue"
+            )
+            .HaveAssertedAllDiagnostics();
+    }
+}


### PR DESCRIPTION
Removes the obsolete attribute from `MapProperty.ctor(string[], string[]`) and adds tests to ensure nested to nested mappings work correct.
See https://github.com/riok/mapperly/pull/1354#issuecomment-2411370018.