### PR TITLE
fix: initialize nullable members for nested containers

### DIFF
--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
@@ -589,6 +589,45 @@ public class ObjectPropertyNullableTest
     }
 
     [Fact]
+    public void NullableNestedMembersShouldInitializeWithNoNullAssignment()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapProperty("NullableValue1", "V.NullableValue1")]
+            [MapProperty("NullableValue2", "V.NullableValue2")]
+            public partial B Map(A a)
+            """,
+            TestSourceBuilderOptions.Default with
+            {
+                AllowNullPropertyAssignment = false,
+            },
+            "class A { public int? NullableValue1 { get; set; } public int? NullableValue2 { get; set; } }",
+            "class B { public C? V { get; set; } }",
+            "class C { public int? NullableValue1 { get; set; } public int? NullableValue2 { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                if (a.NullableValue1 != null)
+                {
+                    target.V ??= new global::C();
+                    target.V.NullableValue1 = a.NullableValue1.Value;
+                }
+                if (a.NullableValue2 != null)
+                {
+                    target.V ??= new global::C();
+                    target.V.NullableValue2 = a.NullableValue2.Value;
+                }
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public void NullableClassToNullableClassPropertyThrowShouldSetNull()
     {
         var source = TestSourceBuilder.Mapping(


### PR DESCRIPTION
# fix: initialize nullable members for nested containers

## Description

Made changes to store `IMemberAssignmentMappingContainer` along with the `MemberPath` to keep track of nullable member initializations.

Fixes #1650 

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [ ] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [ ] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
