### PR TITLE
feat: do not apply deep cloning to queryable projection mappings

### DIFF
--- a/docs/docs/configuration/mapper.mdx
+++ b/docs/docs/configuration/mapper.mdx
@@ -35,6 +35,10 @@ public partial class CarMapper
 }
 ```
 
+:::note
+Deep cloning is not applied to `IQueryable` projection mappings.
+:::
+
 ## Properties / fields
 
 On each mapping method declaration, property and field mappings can be customized.

--- a/docs/docs/configuration/queryable-projections.mdx
+++ b/docs/docs/configuration/queryable-projections.mdx
@@ -53,6 +53,7 @@ such mappings have several limitations:
 - Enum mappings do not support the `ByName` strategy
 - Reference handling is not supported
 - Nullable reference types are disabled
+- Deep cloning is not applied
   :::
 
 ## Property configurations

--- a/src/Riok.Mapperly/Configuration/MapperConfigurationReader.cs
+++ b/src/Riok.Mapperly/Configuration/MapperConfigurationReader.cs
@@ -37,21 +37,32 @@ public class MapperConfigurationReader
                 mapper.EnumNamingStrategy
             ),
             new MembersMappingConfiguration([], [], [], [], [], mapper.IgnoreObsoleteMembersStrategy, mapper.RequiredMappingStrategy),
-            []
+            [],
+            mapper.UseDeepCloning
         );
     }
 
     public MappingConfiguration MapperConfiguration { get; }
 
-    public MappingConfiguration BuildFor(MappingConfigurationReference reference, DiagnosticCollection diagnostics)
+    public MappingConfiguration BuildFor(
+        MappingConfigurationReference reference,
+        bool supportsDeepCloning,
+        DiagnosticCollection diagnostics
+    )
     {
         if (reference.Method == null)
-            return MapperConfiguration;
+            return supportsDeepCloning ? MapperConfiguration : MapperConfiguration with { UseDeepCloning = false };
 
         var enumConfig = BuildEnumConfig(reference, diagnostics);
         var membersConfig = BuildMembersConfig(reference, diagnostics);
         var derivedTypesConfig = BuildDerivedTypeConfigs(reference.Method);
-        return new MappingConfiguration(MapperConfiguration.Mapper, enumConfig, membersConfig, derivedTypesConfig);
+        return new MappingConfiguration(
+            MapperConfiguration.Mapper,
+            enumConfig,
+            membersConfig,
+            derivedTypesConfig,
+            supportsDeepCloning && MapperConfiguration.Mapper.UseDeepCloning
+        );
     }
 
     private IReadOnlyCollection<DerivedTypeMappingConfiguration> BuildDerivedTypeConfigs(IMethodSymbol method)

--- a/src/Riok.Mapperly/Configuration/MappingConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/MappingConfiguration.cs
@@ -6,5 +6,6 @@ public record MappingConfiguration(
     MapperAttribute Mapper,
     EnumMappingConfiguration Enum,
     MembersMappingConfiguration Members,
-    IReadOnlyCollection<DerivedTypeMappingConfiguration> DerivedTypes
+    IReadOnlyCollection<DerivedTypeMappingConfiguration> DerivedTypes,
+    bool UseDeepCloning
 );

--- a/src/Riok.Mapperly/Descriptors/InlineExpressionMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/InlineExpressionMappingBuilderContext.cs
@@ -16,7 +16,7 @@ namespace Riok.Mapperly.Descriptors;
 public class InlineExpressionMappingBuilderContext : MappingBuilderContext
 {
     public InlineExpressionMappingBuilderContext(MappingBuilderContext ctx, IUserMapping? userMapping, TypeMappingKey mappingKey)
-        : base(ctx, userMapping, null, mappingKey, false) { }
+        : base(ctx, userMapping, null, mappingKey, ignoreDerivedTypes: false, supportsDeepCloning: false) { }
 
     private InlineExpressionMappingBuilderContext(
         InlineExpressionMappingBuilderContext ctx,
@@ -25,7 +25,7 @@ public class InlineExpressionMappingBuilderContext : MappingBuilderContext
         TypeMappingKey mappingKey,
         bool ignoreDerivedTypes
     )
-        : base(ctx, userMapping, diagnosticLocation, mappingKey, ignoreDerivedTypes) { }
+        : base(ctx, userMapping, diagnosticLocation, mappingKey, ignoreDerivedTypes, supportsDeepCloning: false) { }
 
     public override bool IsExpression => true;
 

--- a/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
@@ -23,7 +23,8 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
         FormatProviderCollection formatProviders,
         IUserMapping? userMapping,
         TypeMappingKey mappingKey,
-        Location? diagnosticLocation = null
+        Location? diagnosticLocation = null,
+        bool supportsDeepCloning = true
     )
         : base(parentCtx, diagnosticLocation ?? userMapping?.Method.GetSyntaxLocation())
     {
@@ -31,7 +32,10 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
         _formatProviders = formatProviders;
         UserMapping = userMapping;
         MappingKey = mappingKey;
-        Configuration = ReadConfiguration(new MappingConfigurationReference(UserSymbol, mappingKey.Source, mappingKey.Target));
+        Configuration = ReadConfiguration(
+            new MappingConfigurationReference(UserSymbol, mappingKey.Source, mappingKey.Target),
+            supportsDeepCloning
+        );
     }
 
     protected MappingBuilderContext(
@@ -39,9 +43,18 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
         IUserMapping? userMapping,
         Location? diagnosticLocation,
         TypeMappingKey mappingKey,
-        bool ignoreDerivedTypes
+        bool ignoreDerivedTypes,
+        bool supportsDeepCloning = true
     )
-        : this(ctx, ctx.InstanceConstructors, ctx._formatProviders, userMapping, mappingKey, diagnosticLocation)
+        : this(
+            ctx,
+            ctx.InstanceConstructors,
+            ctx._formatProviders,
+            userMapping,
+            mappingKey,
+            diagnosticLocation,
+            supportsDeepCloning: supportsDeepCloning
+        )
     {
         if (ignoreDerivedTypes)
         {

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/DirectAssignmentMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/DirectAssignmentMappingBuilder.cs
@@ -10,7 +10,7 @@ public static class DirectAssignmentMappingBuilder
     {
         return
             SymbolEqualityComparer.IncludeNullability.Equals(ctx.Source, ctx.Target)
-            && (!ctx.Configuration.Mapper.UseDeepCloning || ctx.Source.IsImmutable())
+            && (!ctx.Configuration.UseDeepCloning || ctx.Source.IsImmutable())
             ? new DirectAssignmentMapping(ctx.Source)
             : null;
     }

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
@@ -98,7 +98,7 @@ public static class EnumerableMappingBuilder
         // cannot cast if the method mapping is synthetic, deep clone is enabled or target is an unknown collection
         if (
             !elementMapping.IsSynthetic
-            || ctx.Configuration.Mapper.UseDeepCloning
+            || ctx.Configuration.UseDeepCloning
             || ctx.CollectionInfos!.Target.CollectionType == CollectionType.None
         )
         {
@@ -202,7 +202,7 @@ public static class EnumerableMappingBuilder
         // use a for loop mapping otherwise.
         if (elementMapping.IsSynthetic)
         {
-            return ctx.Configuration.Mapper.UseDeepCloning
+            return ctx.Configuration.UseDeepCloning
                 ? new ArrayCloneMapping(ctx.Source, ctx.Target)
                 : new CastMapping(ctx.Source, ctx.Target);
         }
@@ -320,7 +320,7 @@ public static class EnumerableMappingBuilder
         // if the target is an IEnumerable<T> don't collect at all
         // except deep cloning is enabled.
         var targetIsIEnumerable = ctx.CollectionInfos!.Target.CollectionType == CollectionType.IEnumerable;
-        if (targetIsIEnumerable && !ctx.Configuration.Mapper.UseDeepCloning)
+        if (targetIsIEnumerable && !ctx.Configuration.UseDeepCloning)
             return (true, null);
 
         // if the target is IReadOnlyCollection<T> or IEnumerable<T>

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/ExplicitCastMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/ExplicitCastMappingBuilder.cs
@@ -13,7 +13,7 @@ public static class ExplicitCastMappingBuilder
         if (!ctx.IsConversionEnabled(MappingConversionType.ExplicitCast))
             return null;
 
-        if (ctx.Configuration.Mapper.UseDeepCloning && !ctx.Source.IsImmutable() && !ctx.Target.IsImmutable())
+        if (ctx.Configuration.UseDeepCloning && !ctx.Source.IsImmutable() && !ctx.Target.IsImmutable())
             return null;
 
         // ClassifyConversion does not check if tuple field member names are the same

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/ImplicitCastMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/ImplicitCastMappingBuilder.cs
@@ -11,7 +11,7 @@ public static class ImplicitCastMappingBuilder
         if (!ctx.IsConversionEnabled(MappingConversionType.ImplicitCast))
             return null;
 
-        if (ctx.Configuration.Mapper.UseDeepCloning && !ctx.Source.IsImmutable() && !ctx.Target.IsImmutable())
+        if (ctx.Configuration.UseDeepCloning && !ctx.Source.IsImmutable() && !ctx.Target.IsImmutable())
             return null;
 
         // ClassifyConversion does not check if tuple field member names are the same

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/MemoryMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/MemoryMappingBuilder.cs
@@ -106,7 +106,7 @@ public static class MemoryMappingBuilder
 
     private static NewInstanceMapping? BuildSpanToMemoryMapping(MappingBuilderContext ctx, INewInstanceMapping elementMapping)
     {
-        if (elementMapping.IsSynthetic && !ctx.Configuration.Mapper.UseDeepCloning)
+        if (elementMapping.IsSynthetic && !ctx.Configuration.UseDeepCloning)
             return new SourceObjectMethodMapping(ctx.Source, ctx.Target, ToArrayMethodName);
 
         var targetArray = ctx.Types.GetArrayType(elementMapping.TargetType);
@@ -117,7 +117,7 @@ public static class MemoryMappingBuilder
 
     private static NewInstanceMapping? BuildMemoryToArrayMapping(MappingBuilderContext ctx, INewInstanceMapping elementMapping)
     {
-        if (!elementMapping.IsSynthetic || ctx.Configuration.Mapper.UseDeepCloning)
+        if (!elementMapping.IsSynthetic || ctx.Configuration.UseDeepCloning)
             return BuildSpanToArrayMethodMapping(ctx, elementMapping);
 
         return new SourceObjectMethodMapping(ctx.Source, ctx.Target, ToArrayMethodName);
@@ -125,7 +125,7 @@ public static class MemoryMappingBuilder
 
     private static NewInstanceMapping? BuildMemoryToSpanMapping(MappingBuilderContext ctx, INewInstanceMapping elementMapping)
     {
-        if (!elementMapping.IsSynthetic || ctx.Configuration.Mapper.UseDeepCloning)
+        if (!elementMapping.IsSynthetic || ctx.Configuration.UseDeepCloning)
             return BuildMemoryToSpanMethod(ctx, elementMapping);
 
         return new SourceObjectMemberMapping(ctx.Source, ctx.Target, SpanMemberName);
@@ -133,7 +133,7 @@ public static class MemoryMappingBuilder
 
     private static INewInstanceMapping BuildArrayToMemoryMapping(MappingBuilderContext ctx, INewInstanceMapping elementMapping)
     {
-        if (!elementMapping.IsSynthetic || ctx.Configuration.Mapper.UseDeepCloning)
+        if (!elementMapping.IsSynthetic || ctx.Configuration.UseDeepCloning)
             return new ArrayForMapping(
                 ctx.Source,
                 ctx.Types.GetArrayType(elementMapping.TargetType),
@@ -155,7 +155,7 @@ public static class MemoryMappingBuilder
 
     private static NewInstanceMapping? BuildMemoryToMemoryMapping(MappingBuilderContext ctx, INewInstanceMapping elementMapping)
     {
-        if (!elementMapping.IsSynthetic || ctx.Configuration.Mapper.UseDeepCloning)
+        if (!elementMapping.IsSynthetic || ctx.Configuration.UseDeepCloning)
             return BuildSpanToArrayMethodMapping(ctx, elementMapping);
 
         return new CastMapping(ctx.Source, ctx.Target);

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/SpanMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/SpanMappingBuilder.cs
@@ -44,7 +44,7 @@ public static class SpanMappingBuilder
             // if the source is Span/ReadOnlySpan or Array and target is Span/ReadOnlySpan
             // and element type is the same, then direct cast
             (CollectionType.Span or CollectionType.ReadOnlySpan or CollectionType.Array, CollectionType.Span or CollectionType.ReadOnlySpan)
-                when elementMapping.IsSynthetic && !ctx.Configuration.Mapper.UseDeepCloning => new CastMapping(ctx.Source, ctx.Target),
+                when elementMapping.IsSynthetic && !ctx.Configuration.UseDeepCloning => new CastMapping(ctx.Source, ctx.Target),
 
             // otherwise map each value into an Array
             _ => BuildToArrayOrMap(ctx, elementMapping),

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/ToObjectMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/ToObjectMappingBuilder.cs
@@ -15,7 +15,7 @@ public static class ToObjectMappingBuilder
         if (ctx.Target.SpecialType != SpecialType.System_Object)
             return null;
 
-        if (!ctx.Configuration.Mapper.UseDeepCloning)
+        if (!ctx.Configuration.UseDeepCloning)
             return new CastMapping(ctx.Source, ctx.Target);
 
         if (ctx.Source.SpecialType == SpecialType.System_Object)

--- a/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
@@ -83,6 +83,6 @@ public class SimpleMappingBuilderContext(
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, ISymbol? symbolLocation, params object[] messageArgs) =>
         _diagnostics.ReportDiagnostic(descriptor, symbolLocation?.GetSyntaxLocation() ?? _diagnosticLocation, messageArgs);
 
-    protected MappingConfiguration ReadConfiguration(MappingConfigurationReference configRef) =>
-        _configurationReader.BuildFor(configRef, _diagnostics);
+    protected MappingConfiguration ReadConfiguration(MappingConfigurationReference configRef, bool supportsDeepCloning) =>
+        _configurationReader.BuildFor(configRef, supportsDeepCloning, _diagnostics);
 }

--- a/test/Riok.Mapperly.Tests/Mapping/QueryableProjectionNullableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/QueryableProjectionNullableTest.cs
@@ -115,6 +115,7 @@ public class QueryableProjectionNullableTest
     [Fact]
     public Task NestedPropertyWithDeepCloneable()
     {
+        // deep cloneable should be ignored.
         // see https://github.com/riok/mapperly/issues/1710
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             """

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.NestedPropertyWithDeepCloneable#Mapper.g.verified.cs
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionNullableTest.NestedPropertyWithDeepCloneable#Mapper.g.verified.cs
@@ -13,9 +13,7 @@ public partial class Mapper
             source,
             x => new global::B()
             {
-                Value0 = x.Nested != null && x.Nested.Value0 != null ? global::System.Linq.Enumerable.ToArray(
-                    global::System.Linq.Enumerable.Select(x.Nested.Value0, x1 => x1 == null ? default : x1)
-                ) : default,
+                Value0 = x.Nested != null && x.Nested.Value0 != null ? x.Nested.Value0 : default,
                 Value = x.Nested != null && x.Nested.Value != null ? x.Nested.Value : default,
             }
         );


### PR DESCRIPTION
Never apply deep cloning to queryable projections, as these are projections and deep cloning doesn't have an effect on the projection.