### PR TITLE
chore: revert fluent assertions to v7 due to license concerns

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-    <PackageReference Include="FluentAssertions" Version="8.0.1"/>
+    <PackageReference Include="FluentAssertions" Version="7.1.0"/>
     <PackageReference Include="xunit" Version="2.9.3"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Riok.Mapperly.Abstractions.Tests/Helpers/ArchTestResultAssertions.cs
+++ b/test/Riok.Mapperly.Abstractions.Tests/Helpers/ArchTestResultAssertions.cs
@@ -1,11 +1,9 @@
-using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using NetArchTest.Rules;
 
 namespace Riok.Mapperly.Abstractions.Tests.Helpers;
 
-internal class ArchTestResultAssertions(TestResult value)
-    : ObjectAssertions<TestResult, ArchTestResultAssertions>(value, AssertionChain.GetOrCreate())
+internal class ArchTestResultAssertions(TestResult value) : ObjectAssertions<TestResult, ArchTestResultAssertions>(value)
 {
     public void BeSuccessful()
     {


### PR DESCRIPTION
See https://github.com/riok/mapperly/pull/1703#issuecomment-2660483137