### PR TITLE
fix(doc): In page "contributing", replace remaining occurence of "OpenThread"

### DIFF
--- a/docs/docs/contributing/index.md
+++ b/docs/docs/contributing/index.md
@@ -57,7 +57,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 
 4. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the riok/mapperly repository.
 
-5. In your forked repository, make your changes in a new git branch:
+5. In your forked repository, make your changes in a new Git branch:
 
    ```shell
    git checkout -b my-fix-branch main

--- a/docs/docs/contributing/index.md
+++ b/docs/docs/contributing/index.md
@@ -10,7 +10,7 @@ As a contributor, here are the guidelines we would like you to follow.
 
 ## Code of Conduct
 
-Help us keep OpenThread open and inclusive. Please read and follow our [code of conduct](https://github.com/riok/mapperly/blob/main/CODE_OF_CONDUCT.md).
+Help us keep Mapperly open and inclusive. Please read and follow our [code of conduct](https://github.com/riok/mapperly/blob/main/CODE_OF_CONDUCT.md).
 
 ## Got a question or problem?
 


### PR DESCRIPTION
# Replace remaining occurence of "OpenThread"

A little fix in the documentation.

## Description

I was confused when reading the contribution guide by the word "OpenThread". I assume you were inspired by OpenThread guidelines and that an occurrence was not replaced.

So I fix it to avoid futur misleading.

## Checklist

- [ ] The existing code style is followed
- [x] The commit message follows our guidelines
- [ ] Performed a self-review of my code
- [ ] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [ ] Unit tests are added/updated
- [ ] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
