### PR TITLE
fix typo: dontet -> dotnet

### DIFF
--- a/docs/docs/contributing/docs.md
+++ b/docs/docs/contributing/docs.md
@@ -25,7 +25,7 @@ npm i
 
 To build the generated parts of the documentation
 (eg. the API documentation (located in `docs/99-api`), the table of analyzer rules, the samples, ...)
-ensure the dotnet solution is built or run `dontet build` in the solutions root directory.
+ensure the dotnet solution is built or run `dotnet build` in the solutions root directory.
 Then run the prebuild script:
 
 ```bash

--- a/docs/docs/getting-started/installation.mdx
+++ b/docs/docs/getting-started/installation.mdx
@@ -19,7 +19,7 @@ All you need to do, to install Mapperly is to add a NuGet reference pointing to 
   <TabItem value="csproj" label="PackageReference" default>
       <CodeBlock language="xml">{`<PackageReference Include="Riok.Mapperly" Version="${useDocusaurusContext().siteConfig.customFields.mapperlyVersion}" ExcludeAssets="runtime" PrivateAssets="all" />`}</CodeBlock>
   </TabItem>
-<TabItem value="dontet-cli" label=".NET CLI">
+<TabItem value="dotnet-cli" label=".NET CLI">
 
 ```bash
 dotnet add package Riok.Mapperly


### PR DESCRIPTION
# Fix typos

## Description
While reading the docs I spotted a typo "dontet".

<!-- Please include a summary of the changes and the related issue. -->

Fixes # (issue)

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
