### PR TITLE
Add Default MappingTypeConversion

### DIFF
--- a/docs/docs/breaking-changes/5-0.md
+++ b/docs/docs/breaking-changes/5-0.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: -5
+description: How to upgrade to Mapperly v5.0 and a list of all its breaking changes
+---
+
+# v5.0
+
+[![Release notes v5.0.0](https://img.shields.io/badge/Release_notes-v5.0-green?style=flat-square)](https://github.com/riok/mapperly/releases/tag/v5.0.0)
+[![NuGet v5.0.0](https://img.shields.io/badge/NuGet-v5.0-blue?style=flat-square)](https://www.nuget.org/packages/Riok.Mapperly/5.0.0)
+[![API Diff v5.0.0 / v4.3.0](https://img.shields.io/badge/API--Diff-v5.0_%2F_v4.0-yellow?style=flat-square)](https://www.fuget.org/packages/Riok.Mapperly/5.0.0/lib/netstandard2.0/diff/4.0.0/)
+
+## Migration guide from v4.3.0
+
+- Default enabled conversions no longer include explicit casts. Use `MappingConversionType.All` to get the previous behavior, or enable explicit casts explicitly with `MappingConversionType.All | MappingConversionType.ExplicitCast`.
+
+## Default enabled conversions exclude explicit casts
+
+Starting with v5.0, Mapperly introduces a new `MappingConversionType.Default` value that excludes explicit casts.
+This value is now used as the default for `MapperAttribute.EnabledConversions`.
+
+Previously, the default was `MappingConversionType.All`, which included all conversions including explicit casts.
+The new default behavior excludes explicit casts to be safer by default, as explicit casts can potentially throw runtime exceptions.
+
+### Migration options:
+
+1. **Recommended**: Review your mappings and explicitly enable `ExplicitCast` where needed:
+   ```csharp
+   [Mapper(EnabledConversions = MappingConversionType.ExplicitCast)]
+   public partial class MyMapper
+   {
+       public partial Target Map(Source source);
+   }
+   ```
+
+2. **Quick fix**: Use `MappingConversionType.All` to restore the previous behavior:
+   ```csharp
+   [Mapper(EnabledConversions = MappingConversionType.All)]
+   public partial class MyMapper
+   {
+       // Your existing mappings
+   }
+   ```
+
+This change makes Mapperly safer by default while still allowing explicit casts when explicitly requested.

--- a/src/Riok.Mapperly.Abstractions/MapperAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperAttribute.cs
@@ -69,7 +69,7 @@ public class MapperAttribute : Attribute
 
     /// <summary>
     /// Enabled conversions which Mapperly automatically implements.
-    /// By default all supported type conversions are enabled.
+    /// By default all supported type conversions except explicit casts are enabled, ie <c>MappingConversionType.All &amp; ~MappingConversionType.ExplicitCast</c>.
     /// <example>
     /// Eg. to disable all automatically implemented conversions:<br />
     /// <c>EnabledConversions = MappingConversionType.None</c>
@@ -79,7 +79,7 @@ public class MapperAttribute : Attribute
     /// <c>EnabledConversions = MappingConversionType.All &amp; ~MappingConversionType.ToStringMethod</c>
     /// </example>
     /// </summary>
-    public MappingConversionType EnabledConversions { get; set; } = MappingConversionType.All;
+    public MappingConversionType EnabledConversions { get; set; } = MappingConversionType.Default;
 
     /// <summary>
     /// Enables the reference handling feature.

--- a/src/Riok.Mapperly.Abstractions/MappingConversionType.cs
+++ b/src/Riok.Mapperly.Abstractions/MappingConversionType.cs
@@ -142,4 +142,10 @@ public enum MappingConversionType
     /// Enables all supported conversions.
     /// </summary>
     All = ~None,
+
+    /// <summary>
+    /// Enables all supported conversions except explicit casts.
+    /// This is the default value for enabled conversions.
+    /// </summary>
+    Default = All & ~ExplicitCast,
 }

--- a/src/Riok.Mapperly/Configuration/MapperConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/MapperConfiguration.cs
@@ -67,7 +67,7 @@ public record MapperConfiguration
 
     /// <summary>
     /// Enabled conversions which Mapperly automatically implements.
-    /// By default all supported type conversions are enabled.
+    /// By default all supported type conversions except explicit casts are enabled.
     /// <example>
     /// Eg. to disable all automatically implemented conversions:<br />
     /// <c>EnabledConversions = MappingConversionType.None</c>

--- a/test/Riok.Mapperly.Abstractions.Tests/_snapshots/PublicApiTest.PublicApiHasNotChanged.verified.cs
+++ b/test/Riok.Mapperly.Abstractions.Tests/_snapshots/PublicApiTest.PublicApiHasNotChanged.verified.cs
@@ -231,6 +231,7 @@ namespace Riok.Mapperly.Abstractions
         ToTargetMethod = 131072,
         StaticConvertMethods = 262144,
         All = -1,
+        Default = -5,
     }
     [System.AttributeUsage(System.AttributeTargets.Parameter)]
     [System.Diagnostics.Conditional("MAPPERLY_ABSTRACTIONS_SCOPE_RUNTIME")]

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/DerivedMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/DerivedMapper.cs
@@ -2,7 +2,7 @@ using Riok.Mapperly.Abstractions;
 
 namespace Riok.Mapperly.IntegrationTests.Mapper
 {
-    [Mapper]
+    [Mapper(EnabledConversions = MappingConversionType.ExplicitCast | MappingConversionType.ImplicitCast)]
     public partial class BaseMapper
     {
         public virtual partial long IntToLong(int value);
@@ -10,13 +10,13 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         public partial short IntToShort(int value);
     }
 
-    [Mapper]
+    [Mapper(EnabledConversions = MappingConversionType.ImplicitCast)]
     public partial class DerivedMapper : BaseMapper
     {
         public override partial long IntToLong(int value);
     }
 
-    [Mapper]
+    [Mapper(EnabledConversions = MappingConversionType.ExplicitCast | MappingConversionType.ImplicitCast)]
     public partial class DerivedMapper2 : BaseMapper
     {
         public sealed override partial long IntToLong(int value);

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/INestedTestMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/INestedTestMapper.cs
@@ -4,7 +4,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
 {
     public partial interface INestedTestMapper
     {
-        [Mapper]
+        [Mapper(EnabledConversions = MappingConversionType.ExplicitCast)]
         public static partial class NestedMapper
         {
             public static partial int ToInt(decimal value);

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/NestedMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/NestedMapper.cs
@@ -6,7 +6,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
     {
         public static partial class TestNesting
         {
-            [Mapper]
+            [Mapper(EnabledConversions = MappingConversionType.ExplicitCast)]
             public static partial class NestedMapper
             {
                 public static partial int ToInt(decimal value);

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/NestedTestMapperPrimaryConstructor.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/NestedTestMapperPrimaryConstructor.cs
@@ -9,7 +9,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
 
         public partial class TestNesting
         {
-            [Mapper]
+            [Mapper(EnabledConversions = MappingConversionType.ExplicitCast)]
             public static partial class NestedMapper
             {
                 public static partial int ToInt(decimal value);

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/NestedTestMapperRecord.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/NestedTestMapperRecord.cs
@@ -6,7 +6,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
     {
         public partial record TestNesting
         {
-            [Mapper]
+            [Mapper(EnabledConversions = MappingConversionType.ExplicitCast)]
             public static partial class NestedMapper
             {
                 public static partial int ToInt(decimal value);

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/StaticTestMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/StaticTestMapper.cs
@@ -6,7 +6,7 @@ using Riok.Mapperly.IntegrationTests.Models;
 
 namespace Riok.Mapperly.IntegrationTests.Mapper
 {
-    [Mapper(EnumMappingStrategy = EnumMappingStrategy.ByValue)]
+    [Mapper(EnumMappingStrategy = EnumMappingStrategy.ByValue, EnabledConversions = MappingConversionType.All)]
     public static partial class StaticTestMapper
     {
         [UserMapping(Default = true)]

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/TestMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/TestMapper.cs
@@ -15,10 +15,11 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
     [Mapper(
         IncludedMembers = MemberVisibility.All,
         IncludedConstructors = MemberVisibility.All,
-        EnumMappingStrategy = EnumMappingStrategy.ByValue
+        EnumMappingStrategy = EnumMappingStrategy.ByValue,
+        EnabledConversions = MappingConversionType.All
     )]
 #else
-    [Mapper(EnumMappingStrategy = EnumMappingStrategy.ByValue)]
+    [Mapper(EnumMappingStrategy = EnumMappingStrategy.ByValue, EnabledConversions = MappingConversionType.All)]
 #endif
     public partial class TestMapper
     {

--- a/test/Riok.Mapperly.Tests/Mapping/CastTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/CastTest.cs
@@ -11,7 +11,7 @@ public class CastTest
     [InlineData("long", "int")]
     public void NumericExplicitCast(string from, string to)
     {
-        var source = TestSourceBuilder.Mapping(from, to, TestSourceBuilderOptions.WithDeepCloning);
+        var source = TestSourceBuilder.Mapping(from, to, TestSourceBuilderOptions.WithDeepCloningAndExplicitCast);
         TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody($"return ({to})source;");
     }
 
@@ -35,7 +35,12 @@ public class CastTest
     [Fact]
     public void OperatorExplicitClassWithImmutableTarget()
     {
-        var source = TestSourceBuilder.Mapping("A", "string", "class A { public static explicit operator string(A a) => \"A\"; }");
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "string",
+            TestSourceBuilderOptions.WithExplicitCast,
+            "class A { public static explicit operator string(A a) => \"A\"; }"
+        );
         TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (string)source;");
     }
 
@@ -45,7 +50,7 @@ public class CastTest
         var source = TestSourceBuilder.Mapping(
             "A",
             "string",
-            TestSourceBuilderOptions.WithDeepCloning,
+            TestSourceBuilderOptions.WithDeepCloningAndExplicitCast,
             "class A { public static explicit operator string(A a) => \"A\"; }"
         );
         TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (string)source;");
@@ -54,7 +59,12 @@ public class CastTest
     [Fact]
     public void OperatorExplicitStructWithImmutableTarget()
     {
-        var source = TestSourceBuilder.Mapping("A", "string", "struct A { public static explicit operator string(A a) => \"A\"; }");
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "string",
+            TestSourceBuilderOptions.WithExplicitCast,
+            "struct A { public static explicit operator string(A a) => \"A\"; }"
+        );
         TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (string)source;");
     }
 
@@ -64,7 +74,7 @@ public class CastTest
         var source = TestSourceBuilder.Mapping(
             "A",
             "string",
-            TestSourceBuilderOptions.WithDeepCloning,
+            TestSourceBuilderOptions.WithDeepCloningAndExplicitCast,
             "struct A { public static explicit operator string(A a) => \"A\"; }"
         );
         TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (string)source;");
@@ -73,7 +83,12 @@ public class CastTest
     [Fact]
     public void OperatorExplicitClassWithImmutableSource()
     {
-        var source = TestSourceBuilder.Mapping("string", "A", "class A { public static explicit operator A(string s) => new(); }");
+        var source = TestSourceBuilder.Mapping(
+            "string",
+            "A",
+            TestSourceBuilderOptions.WithExplicitCast,
+            "class A { public static explicit operator A(string s) => new(); }"
+        );
         TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::A)source;");
     }
 
@@ -83,7 +98,7 @@ public class CastTest
         var source = TestSourceBuilder.Mapping(
             "string",
             "A",
-            TestSourceBuilderOptions.WithDeepCloning,
+            TestSourceBuilderOptions.WithDeepCloningAndExplicitCast,
             "class A { public static explicit operator A(string s) => new(); }"
         );
         TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::A)source;");
@@ -92,7 +107,12 @@ public class CastTest
     [Fact]
     public void OperatorExplicitStructWithImmutableSource()
     {
-        var source = TestSourceBuilder.Mapping("string", "A", "struct A { public static explicit operator A(string s) => new(); }");
+        var source = TestSourceBuilder.Mapping(
+            "string",
+            "A",
+            TestSourceBuilderOptions.WithExplicitCast,
+            "struct A { public static explicit operator A(string s) => new(); }"
+        );
         TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::A)source;");
     }
 
@@ -102,7 +122,7 @@ public class CastTest
         var source = TestSourceBuilder.Mapping(
             "string",
             "A",
-            TestSourceBuilderOptions.WithDeepCloning,
+            TestSourceBuilderOptions.WithDeepCloningAndExplicitCast,
             "struct A { public static explicit operator A(string s) => new(); }"
         );
         TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::A)source;");
@@ -111,7 +131,13 @@ public class CastTest
     [Fact]
     public void OperatorExplicitClassWithClassTarget()
     {
-        var source = TestSourceBuilder.Mapping("A", "B", "class A { public static explicit operator B(A a) => new(); }", "class B {}");
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithExplicitCast,
+            "class A { public static explicit operator B(A a) => new(); }",
+            "class B {}"
+        );
         TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::B)source;");
     }
 
@@ -121,7 +147,7 @@ public class CastTest
         var source = TestSourceBuilder.Mapping(
             "A",
             "B",
-            TestSourceBuilderOptions.WithDeepCloning,
+            TestSourceBuilderOptions.WithDeepCloningAndExplicitCast,
             "class A { public static explicit operator B(A a) => new(); }",
             "class B {}"
         );
@@ -139,7 +165,13 @@ public class CastTest
     [Fact]
     public void OperatorExplicitStructWithMutableStructTarget()
     {
-        var source = TestSourceBuilder.Mapping("A", "B", "struct A { public static explicit operator B(A a) => new(); }", "struct B {}");
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithExplicitCast,
+            "struct A { public static explicit operator B(A a) => new(); }",
+            "struct B {}"
+        );
         TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return (global::B)source;");
     }
 
@@ -149,7 +181,7 @@ public class CastTest
         var source = TestSourceBuilder.Mapping(
             "A",
             "B",
-            TestSourceBuilderOptions.WithDeepCloning,
+            TestSourceBuilderOptions.WithDeepCloningAndExplicitCast,
             """
             struct A
             {
@@ -177,7 +209,7 @@ public class CastTest
         var source = TestSourceBuilder.Mapping(
             "A",
             "B",
-            TestSourceBuilderOptions.WithDeepCloning,
+            TestSourceBuilderOptions.WithDeepCloningAndExplicitCast,
             "struct A { public static explicit operator B(A a) => new(); }",
             "struct B {}"
         );
@@ -359,6 +391,17 @@ public class CastTest
             "byte",
             TestSourceBuilderOptions.WithDisabledMappingConversion(MappingConversionType.ExplicitCast)
         );
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.CouldNotCreateMapping)
+            .HaveAssertedAllDiagnostics();
+    }
+
+    [Fact]
+    public void ExplicitCastMappingDisabledByDefaultShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.Mapping("int", "byte");
         TestHelper
             .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()

--- a/test/Riok.Mapperly.Tests/Mapping/DictionaryImmutableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/DictionaryImmutableTest.cs
@@ -58,7 +58,11 @@ public class DictionaryImmutableTest
     [Fact]
     public void DictionaryToImmutableDictionaryExplicitCastedKeyValue()
     {
-        var source = TestSourceBuilder.Mapping("Dictionary<long, long>", "System.Collections.Immutable.ImmutableDictionary<int, int>");
+        var source = TestSourceBuilder.Mapping(
+            "Dictionary<long, long>",
+            "System.Collections.Immutable.ImmutableDictionary<int, int>",
+            TestSourceBuilderOptions.WithDictionaryAndExplicitCast
+        );
         TestHelper
             .GenerateMapper(source)
             .Should()
@@ -72,7 +76,11 @@ public class DictionaryImmutableTest
     [Fact]
     public void DictionaryToImmutableDictionaryExplicitCastedValue()
     {
-        var source = TestSourceBuilder.Mapping("Dictionary<string, long>", "System.Collections.Immutable.ImmutableDictionary<string, int>");
+        var source = TestSourceBuilder.Mapping(
+            "Dictionary<string, long>",
+            "System.Collections.Immutable.ImmutableDictionary<string, int>",
+            TestSourceBuilderOptions.WithDictionaryAndExplicitCast
+        );
         TestHelper
             .GenerateMapper(source)
             .Should()

--- a/test/Riok.Mapperly.Tests/Mapping/DictionaryTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/DictionaryTest.cs
@@ -29,7 +29,11 @@ public class DictionaryTest
     [Fact]
     public void DictionaryToDictionaryExplicitCastedValue()
     {
-        var source = TestSourceBuilder.Mapping("Dictionary<string, long>", "Dictionary<string, int>");
+        var source = TestSourceBuilder.Mapping(
+            "Dictionary<string, long>",
+            "Dictionary<string, int>",
+            TestSourceBuilderOptions.WithDictionaryAndExplicitCast
+        );
         TestHelper
             .GenerateMapper(source)
             .Should()
@@ -51,7 +55,7 @@ public class DictionaryTest
         var source = TestSourceBuilder.Mapping(
             "Dictionary<string, long>",
             "Dictionary<string, int>",
-            TestSourceBuilderOptions.WithDeepCloning
+            TestSourceBuilderOptions.WithDeepCloningDictionaryAndExplicitCast
         );
         TestHelper
             .GenerateMapper(source)
@@ -126,7 +130,11 @@ public class DictionaryTest
     [Fact]
     public void DictionaryToIDictionaryExplicitCastedValue()
     {
-        var source = TestSourceBuilder.Mapping("Dictionary<string, long>", "IDictionary<string, int>");
+        var source = TestSourceBuilder.Mapping(
+            "Dictionary<string, long>",
+            "IDictionary<string, int>",
+            TestSourceBuilderOptions.WithDictionaryAndExplicitCast
+        );
         TestHelper
             .GenerateMapper(source)
             .Should()

--- a/test/Riok.Mapperly.Tests/Mapping/EnumTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumTest.cs
@@ -49,6 +49,7 @@ public class EnumTest
         var source = TestSourceBuilder.Mapping(
             "C",
             "E",
+            TestSourceBuilderOptions.WithEnumUnderlyingTypeAndExplicitCast,
             "class C { public static explicit operator byte(C c) => 0; } }",
             "enum E : byte {A, B, C}"
         );

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableCustomTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableCustomTest.cs
@@ -5,7 +5,12 @@ public class EnumerableCustomTest
     [Fact]
     public void EnumerableToCustomCollection()
     {
-        var source = TestSourceBuilder.Mapping("IEnumerable<long>", "B", "class B : ICollection<int> { public void Add(int item) {} }");
+        var source = TestSourceBuilder.Mapping(
+            "IEnumerable<long>",
+            "B",
+            TestSourceBuilderOptions.WithEnumerableAndExplicitCast,
+            "class B : ICollection<int> { public void Add(int item) {} }"
+        );
         TestHelper
             .GenerateMapper(source)
             .Should()
@@ -24,7 +29,12 @@ public class EnumerableCustomTest
     [Fact]
     public void EnumerableToCustomSet()
     {
-        var source = TestSourceBuilder.Mapping("IEnumerable<long>", "B", "class B : ISet<int> { public void Add(int item) {} }");
+        var source = TestSourceBuilder.Mapping(
+            "IEnumerable<long>",
+            "B",
+            TestSourceBuilderOptions.WithEnumerableAndExplicitCast,
+            "class B : ISet<int> { public void Add(int item) {} }"
+        );
         TestHelper
             .GenerateMapper(source)
             .Should()
@@ -48,7 +58,7 @@ public class EnumerableCustomTest
             [MapProperty("Count", "MyCount")]
             partial B Map(IReadOnlyCollection<long> source);
             """,
-            "B",
+            TestSourceBuilderOptions.WithEnumerableAndExplicitCast,
             "class B : ICollection<int> { public int MyCount { get; set; } public void Add(int item) {} }"
         );
         TestHelper
@@ -73,6 +83,7 @@ public class EnumerableCustomTest
         var source = TestSourceBuilder.Mapping(
             "IEnumerable<long>",
             "B",
+            TestSourceBuilderOptions.WithEnumerableAndExplicitCast,
             "class B : ICollection<int> { public void Add(int item) {} public void EnsureCapacity(int capacity) {} }"
         );
         TestHelper
@@ -100,6 +111,7 @@ public class EnumerableCustomTest
         var source = TestSourceBuilder.Mapping(
             "A",
             "B",
+            TestSourceBuilderOptions.WithEnumerableAndExplicitCast,
             "class A : IEnumerable<double> { public int Value { get; set; } }",
             "class B : ICollection<int> { public void Add(int item) {} public int Value { get; set; } }"
         );
@@ -269,6 +281,7 @@ public class EnumerableCustomTest
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             "partial void Map(A source, B target);",
+            TestSourceBuilderOptions.WithEnumerableAndExplicitCast,
             "class A : IEnumerable<double> { public int Value { get; set; } }",
             "class B : ICollection<int> { public void Add(int item) {} public int Value { get; set; } }"
         );
@@ -291,6 +304,7 @@ public class EnumerableCustomTest
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             """[MapProperty("ValueSource", "ValueTarget")] public partial B Map(A source);""",
+            TestSourceBuilderOptions.WithEnumerableAndExplicitCast,
             "class A : IEnumerable<double> { public int ValueSource { get; set; } }",
             "class B : ICollection<int> { public void Add(int item) {} public int ValueTarget { get; set; } }"
         );
@@ -338,6 +352,7 @@ public class EnumerableCustomTest
             [ObjectFactory] B CreateB() => new();
             partial B Map(IEnumerable<long> source);
             """,
+            TestSourceBuilderOptions.WithEnumerableAndExplicitCast,
             "class B : ICollection<int> { public void Add(int item) {} }"
         );
         TestHelper

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableSetTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableSetTest.cs
@@ -5,7 +5,11 @@ public class EnumerableSetTest
     [Fact]
     public void EnumerableToReadOnlySet()
     {
-        var source = TestSourceBuilder.Mapping("IEnumerable<long>", "IReadOnlySet<int>");
+        var source = TestSourceBuilder.Mapping(
+            "IEnumerable<long>",
+            "IReadOnlySet<int>",
+            TestSourceBuilderOptions.WithEnumerableAndExplicitCast
+        );
         TestHelper
             .GenerateMapper(source)
             .Should()
@@ -19,7 +23,7 @@ public class EnumerableSetTest
     [Fact]
     public void EnumerableToSet()
     {
-        var source = TestSourceBuilder.Mapping("IEnumerable<long>", "ISet<int>");
+        var source = TestSourceBuilder.Mapping("IEnumerable<long>", "ISet<int>", TestSourceBuilderOptions.WithEnumerableAndExplicitCast);
         TestHelper
             .GenerateMapper(source)
             .Should()
@@ -33,7 +37,7 @@ public class EnumerableSetTest
     [Fact]
     public void EnumerableToHashSet()
     {
-        var source = TestSourceBuilder.Mapping("IEnumerable<long>", "HashSet<int>");
+        var source = TestSourceBuilder.Mapping("IEnumerable<long>", "HashSet<int>", TestSourceBuilderOptions.WithEnumerableAndExplicitCast);
         TestHelper
             .GenerateMapper(source)
             .Should()
@@ -47,7 +51,11 @@ public class EnumerableSetTest
     [Fact]
     public void EnumerableToSortedSet()
     {
-        var source = TestSourceBuilder.Mapping("IEnumerable<long>", "SortedSet<int>");
+        var source = TestSourceBuilder.Mapping(
+            "IEnumerable<long>",
+            "SortedSet<int>",
+            TestSourceBuilderOptions.WithEnumerableAndExplicitCast
+        );
         TestHelper
             .GenerateMapper(source)
             .Should()

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
@@ -139,7 +139,7 @@ public class EnumerableTest
     [Fact]
     public void ArrayToArrayOfCastedTypes()
     {
-        var source = TestSourceBuilder.Mapping("long[]", "int[]");
+        var source = TestSourceBuilder.Mapping("long[]", "int[]", TestSourceBuilderOptions.WithEnumerableAndExplicitCast);
         TestHelper
             .GenerateMapper(source)
             .Should()
@@ -252,7 +252,11 @@ public class EnumerableTest
     [Fact]
     public void EnumerableToReadOnlyCollectionOfCastedTypes()
     {
-        var source = TestSourceBuilder.Mapping("IEnumerable<long>", "IReadOnlyCollection<int>");
+        var source = TestSourceBuilder.Mapping(
+            "IEnumerable<long>",
+            "IReadOnlyCollection<int>",
+            TestSourceBuilderOptions.WithEnumerableAndExplicitCast
+        );
         TestHelper
             .GenerateMapper(source)
             .Should()
@@ -292,7 +296,7 @@ public class EnumerableTest
     [Fact]
     public void EnumerableToIListOfCastedTypes()
     {
-        var source = TestSourceBuilder.Mapping("IEnumerable<long>", "IList<int>");
+        var source = TestSourceBuilder.Mapping("IEnumerable<long>", "IList<int>", TestSourceBuilderOptions.WithEnumerableAndExplicitCast);
         TestHelper
             .GenerateMapper(source)
             .Should()
@@ -304,7 +308,7 @@ public class EnumerableTest
     [Fact]
     public void EnumerableToListOfCastedTypes()
     {
-        var source = TestSourceBuilder.Mapping("IEnumerable<long>", "List<int>");
+        var source = TestSourceBuilder.Mapping("IEnumerable<long>", "List<int>", TestSourceBuilderOptions.WithEnumerableAndExplicitCast);
         TestHelper
             .GenerateMapper(source)
             .Should()
@@ -316,7 +320,11 @@ public class EnumerableTest
     [Fact]
     public void EnumerableToIReadOnlyListOfCastedTypes()
     {
-        var source = TestSourceBuilder.Mapping("IEnumerable<long>", "IReadOnlyList<int>");
+        var source = TestSourceBuilder.Mapping(
+            "IEnumerable<long>",
+            "IReadOnlyList<int>",
+            TestSourceBuilderOptions.WithEnumerableAndExplicitCast
+        );
         TestHelper
             .GenerateMapper(source)
             .Should()

--- a/test/Riok.Mapperly.Tests/Mapping/InstantiableMapperWithStaticMethodsTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/InstantiableMapperWithStaticMethodsTest.cs
@@ -36,7 +36,7 @@ public class InstantiableMapperWithStaticMethodsTest
             {
                 public partial class Mappers
                 {
-                    [Mapper]
+                    [Mapper(EnabledConversions = MappingConversionType.ExplicitCast)]
                     public partial class CarMapper
                     {
                         static partial int ToInt(double value);

--- a/test/Riok.Mapperly.Tests/Mapping/MapperTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/MapperTest.cs
@@ -48,7 +48,7 @@ public class MapperTest
             {
                 public static partial class Mappers
                 {
-                    [Mapper]
+                    [Mapper(EnabledConversions = MappingConversionType.ExplicitCast)]
                     public partial class CarMapper
                     {
                         public partial int ToInt(double value);
@@ -72,7 +72,7 @@ public class MapperTest
             {
                 public static partial class Mappers
                 {
-                    [Mapper]
+                    [Mapper(EnabledConversions = MappingConversionType.ExplicitCast)]
                     public partial class CarMapper
                     {
                         public partial int ToInt(double value);
@@ -98,7 +98,7 @@ public class MapperTest
                 [Obsolete]
                 public static partial class Mappers
                 {
-                    [Mapper]
+                    [Mapper(EnabledConversions = MappingConversionType.ExplicitCast)]
                     public partial class CarMapper
                     {
                         public partial int ToInt(double value);
@@ -124,7 +124,7 @@ public class MapperTest
             {
                 public partial class Mappers : BaseClass
                 {
-                    [Mapper]
+                    [Mapper(EnabledConversions = MappingConversionType.ExplicitCast)]
                     public partial class CarMapper
                     {
                         public partial int ToInt(double value);

--- a/test/Riok.Mapperly.Tests/Mapping/NullableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/NullableTest.cs
@@ -1,3 +1,4 @@
+using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.Diagnostics;
 
 namespace Riok.Mapperly.Tests.Mapping;
@@ -48,7 +49,7 @@ public class NullableTest
     [Fact]
     public void NullablePrimitiveToOtherNullablePrimitiveShouldWork()
     {
-        var source = TestSourceBuilder.Mapping("decimal?", "int?");
+        var source = TestSourceBuilder.Mapping("decimal?", "int?", TestSourceBuilderOptions.WithExplicitCast);
         TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return source == null ? default(int?) : (int)source.Value;");
     }
 

--- a/test/Riok.Mapperly.Tests/Mapping/QueryableProjectionEnumerableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/QueryableProjectionEnumerableTest.cs
@@ -8,6 +8,7 @@ public class QueryableProjectionEnumerableTest
         var source = TestSourceBuilder.Mapping(
             "System.Linq.IQueryable<A>",
             "System.Linq.IQueryable<B>",
+            TestSourceBuilderOptions.WithQueryableAndEnumerableExplicitCast,
             "class A { public IEnumerable<long> Values { get; set; } }",
             "class B { public IEnumerable<int> Values { get; set; } }"
         );
@@ -21,6 +22,7 @@ public class QueryableProjectionEnumerableTest
         var source = TestSourceBuilder.Mapping(
             "System.Linq.IQueryable<A>",
             "System.Linq.IQueryable<B>",
+            TestSourceBuilderOptions.WithQueryableAndEnumerableExplicitCast,
             "class A { public long[] Values { get; set; } }",
             "class B { public int[] Values { get; set; } }"
         );

--- a/test/Riok.Mapperly.Tests/Mapping/QueryableProjectionTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/QueryableProjectionTest.cs
@@ -70,6 +70,7 @@ public class QueryableProjectionTest
             [MapProperty("StringValue", "StringValue2")] private partial B MapToB(A source);
             [MapProperty("LongValue", "IntValue")] private partial D MapToD(C source);
             """,
+            TestSourceBuilderOptions.WithQueryableAndExplicitCast,
             "class A { public string StringValue { get; set; } public C NestedValue { get; set; } }",
             "class B { public string StringValue2 { get; set; } public D NestedValue { get; set; } }",
             "class C { public long LongValue { get; set; } public E NestedValue { get; set; } }",
@@ -214,7 +215,7 @@ public class QueryableProjectionTest
         var source = TestSourceBuilder.Mapping(
             "System.Linq.IQueryable<long>",
             "System.Linq.IQueryable<int>",
-            TestSourceBuilderOptions.WithReferenceHandling
+            TestSourceBuilderOptions.WithReferenceHandlingAndQueryableAndExplicitCast
         );
 
         TestHelper

--- a/test/Riok.Mapperly.Tests/Mapping/ToObjectDeepCloningTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ToObjectDeepCloningTest.cs
@@ -7,14 +7,14 @@ public class ToObjectDeepCloningTest
     [Fact]
     public void ClassToObjectDeepCloning()
     {
-        var source = TestSourceBuilder.Mapping("A", "object", TestSourceBuilderOptions.WithDeepCloning, "class A {}");
+        var source = TestSourceBuilder.Mapping("A", "object", TestSourceBuilderOptions.WithDeepCloningAndExplicitCast, "class A {}");
         TestHelper.GenerateMapper(source).Should().HaveMapMethodBody("return (object)MapToA(source);");
     }
 
     [Fact]
     public void ObjectToObjectDeepCloning()
     {
-        var source = TestSourceBuilder.Mapping("object", "object", TestSourceBuilderOptions.WithDeepCloning);
+        var source = TestSourceBuilder.Mapping("object", "object", TestSourceBuilderOptions.WithDeepCloningAndExplicitCast);
         TestHelper
             .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
             .Should()
@@ -26,7 +26,7 @@ public class ToObjectDeepCloningTest
     [Fact]
     public void NullableObjectToNullableObjectDeepCloning()
     {
-        var source = TestSourceBuilder.Mapping("object?", "object?", TestSourceBuilderOptions.WithDeepCloning);
+        var source = TestSourceBuilder.Mapping("object?", "object?", TestSourceBuilderOptions.WithDeepCloningAndExplicitCast);
         TestHelper
             .GenerateMapper(source, TestHelperOptions.AllowInfoDiagnostics)
             .Should()
@@ -62,7 +62,7 @@ public class ToObjectDeepCloningTest
         var source = TestSourceBuilder.Mapping(
             "A",
             "object",
-            TestSourceBuilderOptions.WithDeepCloning,
+            TestSourceBuilderOptions.WithDeepCloningAndExplicitCast,
             "struct A { public string Value { get; set; } }"
         );
         TestHelper.GenerateMapper(source).Should().HaveMapMethodBody("return (object)MapToA(source);");

--- a/test/Riok.Mapperly.Tests/Mapping/UserMethodTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/UserMethodTest.cs
@@ -190,7 +190,7 @@ public class UserMethodTest
             using System.Collections.Generic;
             using Riok.Mapperly.Abstractions;
 
-            [Mapper]
+            [Mapper(EnabledConversions = MappingConversionType.ExplicitCast)]
             public partial class BaseMapper : BaseMapper3
             {
                 public string MyMapping(int value)
@@ -233,7 +233,7 @@ public class UserMethodTest
             using System.Collections.Generic;
             using Riok.Mapperly.Abstractions;
 
-            [Mapper]
+            [Mapper(EnabledConversions = MappingConversionType.ExplicitCast | MappingConversionType.Enumerable)]
             public partial class BaseMapper : BaseMapper3
             {
                 public void MyMapping(List<int> src, List<string> dst) { }
@@ -275,7 +275,7 @@ public class UserMethodTest
             using System.Collections.Generic;
             using Riok.Mapperly.Abstractions;
 
-            [Mapper]
+            [Mapper(EnabledConversions = MappingConversionType.ExplicitCast)]
             internal sealed abstract partial class BaseMapper
             {
                 public partial B AToB(A source);
@@ -301,7 +301,7 @@ public class UserMethodTest
             using System.Collections.Generic;
             using Riok.Mapperly.Abstractions;
 
-            [Mapper]
+            [Mapper(EnabledConversions = MappingConversionType.ExplicitCast | MappingConversionType.ToStringMethod)]
             public partial class BaseMapper
             {
                 public virtual partial B AToB(A source);
@@ -310,13 +310,13 @@ public class UserMethodTest
                 public partial short IntToShort(int value);
             }
 
-            [Mapper]
+            [Mapper(EnabledConversions = MappingConversionType.ExplicitCast | MappingConversionType.ToStringMethod)]
             public partial class BaseMapper2 : BaseMapper
             {
                 public override partial B AToB(A source);
             }
 
-            [Mapper]
+            [Mapper(EnabledConversions = MappingConversionType.ExplicitCast | MappingConversionType.ToStringMethod)]
             public partial class BaseMapper3 : BaseMapper
             {
                 public sealed override partial B AToB(A source);

--- a/test/Riok.Mapperly.Tests/TestSourceBuilderOptions.cs
+++ b/test/Riok.Mapperly.Tests/TestSourceBuilderOptions.cs
@@ -30,7 +30,37 @@ public record TestSourceBuilderOptions(
     public static readonly TestSourceBuilderOptions Default = new();
     public static readonly TestSourceBuilderOptions AsStatic = new(Static: true);
     public static readonly TestSourceBuilderOptions WithDeepCloning = new(UseDeepCloning: true);
+    public static readonly TestSourceBuilderOptions WithDeepCloningAndExplicitCast = new TestSourceBuilderOptions(
+        UseDeepCloning: true,
+        EnabledConversions: MappingConversionType.ExplicitCast
+    );
+    public static readonly TestSourceBuilderOptions WithDeepCloningDictionaryAndExplicitCast = new TestSourceBuilderOptions(
+        UseDeepCloning: true,
+        EnabledConversions: MappingConversionType.Dictionary | MappingConversionType.ExplicitCast
+    );
+    public static readonly TestSourceBuilderOptions WithDictionaryAndExplicitCast = new TestSourceBuilderOptions(
+        EnabledConversions: MappingConversionType.Dictionary | MappingConversionType.ExplicitCast
+    );
+    public static readonly TestSourceBuilderOptions WithEnumUnderlyingTypeAndExplicitCast = new TestSourceBuilderOptions(
+        EnabledConversions: MappingConversionType.EnumUnderlyingType | MappingConversionType.ExplicitCast
+    );
+    public static readonly TestSourceBuilderOptions WithEnumerableAndExplicitCast = new TestSourceBuilderOptions(
+        EnabledConversions: MappingConversionType.Enumerable | MappingConversionType.ExplicitCast
+    );
+    public static readonly TestSourceBuilderOptions WithQueryableAndExplicitCast = new TestSourceBuilderOptions(
+        EnabledConversions: MappingConversionType.Queryable | MappingConversionType.ExplicitCast
+    );
+    public static readonly TestSourceBuilderOptions WithQueryableAndEnumerableExplicitCast = new TestSourceBuilderOptions(
+        EnabledConversions: MappingConversionType.Queryable | MappingConversionType.Enumerable | MappingConversionType.ExplicitCast
+    );
+    public static readonly TestSourceBuilderOptions WithExplicitCast = new TestSourceBuilderOptions(
+        EnabledConversions: MappingConversionType.ExplicitCast
+    );
     public static readonly TestSourceBuilderOptions WithReferenceHandling = new(UseReferenceHandling: true);
+    public static readonly TestSourceBuilderOptions WithReferenceHandlingAndQueryableAndExplicitCast = new(
+        UseReferenceHandling: true,
+        EnabledConversions: MappingConversionType.Queryable | MappingConversionType.ExplicitCast
+    );
     public static readonly TestSourceBuilderOptions WithDisabledAutoUserMappings = new(AutoUserMappings: false);
 
     public static readonly TestSourceBuilderOptions PreferParameterizedConstructors = new(PreferParameterlessConstructors: false);


### PR DESCRIPTION


# Add Default MappingTypeConversion

## Description

Added a new flag for a Default MappingTypeConversion, this is a breaking change that will set the default configuration for a mapper to exclude the ExplicitCast Conversion, this will prevent accidental data loss for Explicit Casting. 

A lot of the changes are in the test cases, I had to "Explicitly" Add the flags to correctly test the new behavior on existing test cases to ensure they would work

Fixes #1638 

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
