### PR TITLE
Fix syntax errors in tests

### DIFF
--- a/test/Riok.Mapperly.Tests/Mapping/IncludeMappingConfigurationTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/IncludeMappingConfigurationTest.cs
@@ -101,7 +101,7 @@ public class IncludeMappingConfigurationTest
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             """
-            [MapValue(nameof(A.Value), Use = nameof(GetValue))]
+            [MapValue(nameof(B.Value), Use = nameof(GetValue))]
             partial B MapOther(A a);
 
             [IncludeMappingConfiguration(nameof(MapOther))]
@@ -121,7 +121,7 @@ public class IncludeMappingConfigurationTest
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             """
-            [MapPropertyFromSource(nameof(A.Value))]
+            [MapPropertyFromSource(nameof(B.Value))]
             private partial B MapOther(A source);
 
             [IncludeMappingConfiguration(nameof(MapOther))]
@@ -255,7 +255,7 @@ public class IncludeMappingConfigurationTest
             public static partial B Map(A a);
 
             [IncludeMappingConfiguration(nameof(Map))]
-            [MapProperty(nameof(A.SourceName2), nameof(B.DestinationName2))]
+            [MapProperty(nameof(ADerived.SourceName2), nameof(BDerived.DestinationName2))]
             public static partial BDerived MapDerived(ADerived a);
             """,
             "class A { public string SourceName1 { get; set; } }",

--- a/test/Riok.Mapperly.Tests/Mapping/NamedMappingTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/NamedMappingTest.cs
@@ -45,7 +45,7 @@ public class NamedMappingTest
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             """
-            [MapValue(nameof(A.Value), Use = "CustomGetValue")]
+            [MapValue(nameof(B.Value), Use = "CustomGetValue")]
             partial B Map(A a);
 
             [NamedMapping("CustomGetValue")]

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
@@ -11,7 +11,7 @@ public class ObjectPropertyFlatteningTest
             "[MapProperty(nameof(@A.Value.Id), nameof(B.MyValueId))] partial B Map(A source);",
             "class A { public C Value { get; set; } }",
             "class B { public string MyValueId { get; set; } }",
-            "class C { public string Id { get; set; }"
+            "class C { public string Id { get; set; } }"
         );
 
         TestHelper
@@ -33,7 +33,7 @@ public class ObjectPropertyFlatteningTest
             "[MapProperty(nameof(@D.Value.Id), nameof(D.MyValueId))] partial B Map(A source);",
             "class A { public C Value { get; set; } }",
             "class B { public string MyValueId { get; set; } }",
-            "class C { public string Id { get; set; }",
+            "class C { public string Id { get; set; } }",
             "class D { public string? MyValueId { get; set; } public C? Value { get; set; } }"
         );
 
@@ -56,7 +56,7 @@ public class ObjectPropertyFlatteningTest
             "[MapProperty(nameof(@My.A.Value.Id), nameof(B.MyValueId))] partial B Map(My.A source);",
             "namespace My { class A { public C Value { get; set; } } } ",
             "class B { public string MyValueId { get; set; } }",
-            "class C { public string Id { get; set; }"
+            "class C { public string Id { get; set; } }"
         );
 
         TestHelper
@@ -78,7 +78,7 @@ public class ObjectPropertyFlatteningTest
             "[MapProperty(nameof(@My.Nested.A.Value.Id), nameof(B.MyValueId))] partial B Map(My.Nested.A source);",
             "namespace My { public class Nested { public class A { public C Value { get; set; } } } }",
             "class B { public string MyValueId { get; set; } }",
-            "class C { public string Id { get; set; }"
+            "class C { public string Id { get; set; } }"
         );
 
         TestHelper
@@ -100,7 +100,7 @@ public class ObjectPropertyFlatteningTest
             "[MapProperty(new string[]{nameof(C.Value), nameof(C.Value.Id)}, nameof(B.MyValueId))] partial B Map(A source);",
             "class A { public C Value { get; set; } }",
             "class B { public string MyValueId { get; set; } }",
-            "class C { public string Id { get; set; }"
+            "class C { public string Id { get; set; } }"
         );
 
         TestHelper
@@ -122,7 +122,7 @@ public class ObjectPropertyFlatteningTest
             "[MapProperty(new string[]{nameof(C.Value), nameof(C.Value.Id)}, new string[] {nameof(B.MyValueId)})] partial B Map(A source);",
             "class A { public C Value { get; set; } }",
             "class B { public string MyValueId { get; set; } }",
-            "class C { public string Id { get; set; }"
+            "class C { public string Id { get; set; } }"
         );
 
         TestHelper
@@ -144,7 +144,7 @@ public class ObjectPropertyFlatteningTest
             """[MapProperty($"{nameof(C.Value)}.{nameof(C.Value.Id)}", nameof(B.MyValueId))] partial B Map(A source);""",
             "class A { public C Value { get; set; } }",
             "class B { public string MyValueId { get; set; } }",
-            "class C { public string Id { get; set; }"
+            "class C { public string Id { get; set; } }"
         );
 
         TestHelper
@@ -166,7 +166,7 @@ public class ObjectPropertyFlatteningTest
             "[MapProperty($\"Value.Id\", \"MyValueId\")] partial B Map(A source);",
             "class A { public C Value { get; set; } }",
             "class B { public string MyValueId { get; set; } }",
-            "class C { public string Id { get; set; }"
+            "class C { public string Id { get; set; } }"
         );
 
         TestHelper
@@ -189,7 +189,7 @@ public class ObjectPropertyFlatteningTest
             "B",
             "class A { public C Value { get; set; } }",
             "class B { public string ValueId { get; set; } }",
-            "class C { public string Id { get; set; }"
+            "class C { public string Id { get; set; } }"
         );
 
         TestHelper
@@ -212,7 +212,7 @@ public class ObjectPropertyFlatteningTest
             "B",
             "class A { public C Value { get; set; } public string ValueId { get; set; } }",
             "class B { public string ValueId { get; set; } }",
-            "class C { public string Id { get; set; }"
+            "class C { public string Id { get; set; } }"
         );
 
         TestHelper
@@ -240,7 +240,7 @@ public class ObjectPropertyFlatteningTest
             "B",
             "class A { public C? Value { get; set; } }",
             "class B { public string ValueId { get; set; } }",
-            "class C { public string Id { get; set; }"
+            "class C { public string Id { get; set; } }"
         );
 
         TestHelper
@@ -445,7 +445,7 @@ public class ObjectPropertyFlatteningTest
             "[MapProperty($\"MyValueId\", \"Value.Id\")] partial B Map(A source);",
             "class A { public string MyValueId { get; set; } }",
             "class B { public C Value { get; set; } }",
-            "class C { public string Id { get; set; }"
+            "class C { public string Id { get; set; } }"
         );
 
         TestHelper
@@ -467,7 +467,7 @@ public class ObjectPropertyFlatteningTest
             "[MapProperty(nameof(A.MyValueId), nameof(@B.Value.Id))] partial B Map(A source);",
             "class A { public string MyValueId { get; set; }  }",
             "class B { public C Value { get; set; } }",
-            "class C { public string Id { get; set; }"
+            "class C { public string Id { get; set; } }"
         );
 
         TestHelper
@@ -486,10 +486,10 @@ public class ObjectPropertyFlatteningTest
     public void ManualUnflattenedPropertyWithTargetArray()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
-            "[MapProperty(nameof(C.MyValueId), new string[] { nameof(B.Value), nameof(B.Value.Id) })] partial B Map(A source);",
-            "class A { public string MyValueId { get; set; }  }",
+            "[MapProperty(nameof(A.MyValueId), new string[] { nameof(B.Value), nameof(B.Value.Id) })] partial B Map(A source);",
+            "class A { public string MyValueId { get; set; } }",
             "class B { public C Value { get; set; } }",
-            "class C { public string Id { get; set; }"
+            "class C { public string Id { get; set; } }"
         );
 
         TestHelper
@@ -511,7 +511,7 @@ public class ObjectPropertyFlatteningTest
             """[MapProperty(nameof(A.MyValueId), $"{nameof(B.Value)}.{nameof(B.Value.Id)}")] partial B Map(A source);""",
             "class A { public string MyValueId { get; set; }  }",
             "class B { public C Value { get; set; } }",
-            "class C { public string Id { get; set; }"
+            "class C { public string Id { get; set; } }"
         );
 
         TestHelper


### PR DESCRIPTION
# Fix syntax errors in tests

## Description

I found several syntax errors in the test input sources. Some are made by me. I would like to push a fix.

I found this while investigating `CreateNameOfMemberPath` and whether it could be used for the full path referencing of other methods. Interestingly, there were too many cases when the fallback code ran, which led to this realization. The fallback still runs, but in cases where the error is intentional.

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [ ] Hard-to-understand areas of my code are commented
- [ ] The documentation is updated (as applicable)
- [ ] Unit tests are added/updated
- [ ] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
