### PR TITLE
docs: add info that derived type mappings do not support additional type parameters

### DIFF
--- a/docs/docs/configuration/additional-mapping-parameters.mdx
+++ b/docs/docs/configuration/additional-mapping-parameters.mdx
@@ -69,4 +69,5 @@ Mappings with additional parameters do have some limitions:
   (it is not used by Mapperly when encountering a nested mapping for the given types),
   see also [default mapping methods](./user-implemented-methods.mdx##default-mapping-methods).
 - Generic and runtime target type mappings do not support additional type parameters.
+- Derived type mappings do not support additional type parameters.
   :::


### PR DESCRIPTION
Rel. https://github.com/riok/mapperly/issues/1765#issuecomment-3122186666