### PR TITLE
fix: full nameof should only be applied if the @ optin prefix is set

### DIFF
--- a/docs/docs/breaking-changes/5-0.md
+++ b/docs/docs/breaking-changes/5-0.md
@@ -12,3 +12,43 @@ description: How to upgrade to Mapperly 5.0 and a list of all its breaking chang
 
 - Only .NET Framework 4.8 and .NET 8.0 and later versions are supported. Earlier .NET versions may still work with new Roslyn compiler SDKs but are not tested.
 - Mapperly now respects `IFormatProvider` overloads when mapping using `Parse` methods.
+- The fullnameof feature does not apply automatically to three-segment paths.
+
+### `fullnameof` fix
+
+In previous versions, the `fullnameof` feature was accidentally applied automatically to three-segment paths, even without the `@` prefix.
+This behavior has been corrected, and the `@` prefix is now required to enable the feature.
+
+To migrate, review your codebase and ensure that all three-segment paths are prefixed with `@` if the full name is expected (instead of just the last segment).
+
+Example:
+
+```csharp
+[MapProperty(nameof(Car.Make.Id), nameof(CarDto.MakeId))]
+```
+
+In previous versions this resulted in:
+
+```csharp
+[MapProperty("Make.Id", "MakeId")]
+```
+
+In v5.0 this will result in:
+
+```csharp
+[MapProperty("Id", "MakeId")]
+```
+
+Unless `fullnameof` is applied:
+
+```csharp
+[MapProperty(nameof(@Car.Make.Id), nameof(CarDto.MakeId))]
+```
+
+Which will result in:
+
+```csharp
+[MapProperty("Make.Id", "MakeId")]
+```
+
+See also the [full-nameof documentation](../configuration/full-nameof.md).

--- a/src/Riok.Mapperly/Configuration/AttributeDataAccessor.cs
+++ b/src/Riok.Mapperly/Configuration/AttributeDataAccessor.cs
@@ -244,7 +244,7 @@ public class AttributeDataAccessor(SymbolAccessor symbolAccessor)
             memberRefOperation = memberRefOperation.GetFirstChildOperation<IMemberReferenceOperation>();
 
             // if not fullNameOf only consider the last member path segment
-            if (!fullNameOf && memberPath.Count > 1)
+            if (!fullNameOf)
                 break;
         }
 


### PR DESCRIPTION
If the nameof contained exactly three segments, fullnameof ways always applied, even if the fullnameof optin prefix @ is not present

Closes https://github.com/riok/mapperly/issues/1891