### PR TITLE
Add DI-based composition for nested mappings

### DIFF
--- a/docs/docs/configuration/dependency-injection-composition.mdx
+++ b/docs/docs/configuration/dependency-injection-composition.mdx
@@ -1,0 +1,162 @@
+---
+sidebar_position: 11
+description: Compose nested mappings via DI using IMapper and IExistingMapper
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# DI-based composition for nested mappings
+
+Mapperly can optionally compose nested complex mappings via your dependency injection container.
+If an appropriate mapper service is registered, Mapperly will use it; otherwise it falls back to the generated mapping.
+
+This works for:
+
+- New-instance mappings via `IMapper<TSource, TDestination>`
+- Existing-target (void) mappings via `IExistingMapper<TSource, TDestination>`
+
+It’s opt-in: it activates only if your mapper exposes an `IServiceProvider`.
+
+## Setup
+
+Expose an `IServiceProvider` on your mapper and mark it with `[MapperServiceProvider]`.
+
+```csharp
+using System;
+using Riok.Mapperly.Abstractions;
+
+[Mapper]
+public partial class MyMapper
+{
+    [MapperServiceProvider]
+    public IServiceProvider Services { get; }
+
+    public MyMapper(IServiceProvider services) => Services = services;
+
+    public partial Dto Map(Model src);
+    public partial void Map(Model src, Dto dst);
+}
+```
+
+Register nested mapper services in your DI container:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Riok.Mapperly.Abstractions;
+
+var services = new ServiceCollection();
+// for new-instance nested mappings
+services.AddSingleton<IMapper<NestedModel, NestedDto>, MyNestedMapper>();
+// for existing-target nested mappings
+services.AddSingleton<IExistingMapper<NestedModel, NestedDto>, MyNestedMapper>();
+var sp = services.BuildServiceProvider();
+
+var mapper = new MyMapper(sp);
+```
+
+Your nested mapper can implement one or both interfaces:
+
+```csharp
+using Riok.Mapperly.Abstractions;
+
+file sealed class MyNestedMapper
+    : IMapper<NestedModel, NestedDto>,
+      IExistingMapper<NestedModel, NestedDto>
+{
+    public NestedDto Map(NestedModel src) => new() { Value = src.Value + 5 };
+    public void Map(NestedModel src, NestedDto dst) => dst.Value = src.Value + 10;
+}
+```
+
+## How it works
+
+When mapping a complex member (for example `dst.Nested = ...` or `Map(src.Nested, dst.Nested)`):
+
+- New-instance: Mapperly first tries to resolve `IMapper<S, T>` from `IServiceProvider`. If found, it calls `Map(S)` and assigns the result. If not found, it uses the generated mapping.
+- Existing-target: For void mappings, Mapperly first tries `IExistingMapper<S, T>` and calls `Map(S, T)`; otherwise it falls back to the generated existing-target mapping.
+
+To avoid repeated DI lookups, Mapperly caches the resolved services per mapper instance (lazy-initialized).
+
+## Limitations
+
+- Not available for static mappers.
+- Not available for expression-based mappings such as queryable projections.
+- Requires an `IServiceProvider` property/field marked with `[MapperServiceProvider]` (or the only readable `IServiceProvider` member).
+
+## Example
+
+<Tabs>
+  <TabItem value="model" label="Model">
+
+```csharp
+public class Model { public NestedModel Nested { get; set; } = new(); }
+public class NestedModel { public int Value { get; set; } }
+public class Dto { public NestedDto Nested { get; set; } = new(); }
+public class NestedDto { public int Value { get; set; } }
+```
+
+  </TabItem>
+  <TabItem value="mapping" label="Mapping">
+
+```csharp
+[Mapper]
+public partial class DiCompositionMapper
+{
+    [MapperServiceProvider]
+    public IServiceProvider Services { get; }
+    public DiCompositionMapper(IServiceProvider services) => Services = services;
+
+    public partial Dto Map(Model src);           // uses IMapper<NestedModel, NestedDto> if available
+    public partial void Map(Model src, Dto dst);  // uses IExistingMapper<NestedModel, NestedDto> if available
+}
+```
+
+  </TabItem>
+  <TabItem value="usage" label="Usage">
+
+```csharp
+var services = new ServiceCollection()
+    .AddSingleton<IMapper<NestedModel, NestedDto>>(new MyNestedMapper())
+    .AddSingleton<IExistingMapper<NestedModel, NestedDto>>(new MyNestedMapper())
+    .BuildServiceProvider();
+
+var mapper = new DiCompositionMapper(services);
+
+var src = new Model { Nested = new NestedModel { Value = 10 } };
+var dto = mapper.Map(src);      // dto.Nested.Value == 15 via DI IMapper
+
+var dst = new Dto();
+mapper.Map(src, dst);           // dst.Nested.Value == 20 via DI IExistingMapper
+```
+
+  </TabItem>
+</Tabs>
+
+## Reference
+
+Interfaces in `Riok.Mapperly.Abstractions`:
+
+```csharp
+public interface IMapper<in TSource, out TDestination>
+{
+    TDestination Map(TSource source);
+}
+
+public interface IExistingMapper<in TSource, in TDestination>
+{
+    void Map(TSource source, TDestination destination);
+}
+```
+
+Attribute to expose DI:
+
+```csharp
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class MapperServiceProviderAttribute : Attribute { }
+```
+
+See also:
+
+- [Existing target object](./existing-target.mdx)
+- [Queryable projections](./queryable-projections.mdx)

--- a/src/Riok.Mapperly.Abstractions/IExistingMapper.cs
+++ b/src/Riok.Mapperly.Abstractions/IExistingMapper.cs
@@ -1,0 +1,17 @@
+namespace Riok.Mapperly.Abstractions;
+
+/// <summary>
+/// Optional contract for mappers that map into an existing destination instance.
+/// Used for DI-based composition in existing-target member mappings.
+/// </summary>
+/// <typeparam name="TSource">The source type.</typeparam>
+/// <typeparam name="TDestination">The destination type.</typeparam>
+public interface IExistingMapper<in TSource, in TDestination>
+{
+    /// <summary>
+    /// Maps the source to the destination instance.
+    /// </summary>
+    /// <param name="source">The source instance.</param>
+    /// <param name="destination">The destination instance to map into.</param>
+    void Map(TSource source, TDestination destination);
+}

--- a/src/Riok.Mapperly.Abstractions/IMapper.cs
+++ b/src/Riok.Mapperly.Abstractions/IMapper.cs
@@ -1,0 +1,14 @@
+namespace Riok.Mapperly.Abstractions;
+
+/// <summary>
+/// Simple mapping interface to allow DI based composition for nested mappings.
+/// </summary>
+/// <typeparam name="TSource">The source type.</typeparam>
+/// <typeparam name="TDestination">The destination type.</typeparam>
+public interface IMapper<in TSource, out TDestination>
+{
+    /// <summary>
+    /// Maps the provided <paramref name="source"/> to a new <typeparamref name="TDestination"/> instance.
+    /// </summary>
+    TDestination Map(TSource source);
+}

--- a/src/Riok.Mapperly.Abstractions/MapperServiceProviderAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperServiceProviderAttribute.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics;
+
+namespace Riok.Mapperly.Abstractions;
+
+/// <summary>
+/// Marks a readable member on a mapper which provides an <see cref="IServiceProvider"/> instance.
+/// When present, nested complex member mappings can optionally resolve an <c>IMapper&lt;TS, TD&gt;</c> service
+/// from the provider and delegate the nested mapping to it; otherwise the generated mapping is used.
+/// </summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+[Conditional("MAPPERLY_ABSTRACTIONS_SCOPE_RUNTIME")]
+public sealed class MapperServiceProviderAttribute : Attribute;

--- a/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/DescriptorBuilder.cs
@@ -11,6 +11,7 @@ using Riok.Mapperly.Descriptors.Mappings.UserMappings;
 using Riok.Mapperly.Descriptors.ObjectFactories;
 using Riok.Mapperly.Descriptors.UnsafeAccess;
 using Riok.Mapperly.Diagnostics;
+using Riok.Mapperly.Emit.Syntax;
 using Riok.Mapperly.Helpers;
 using Riok.Mapperly.Symbols;
 
@@ -76,6 +77,9 @@ public class DescriptorBuilder
 
     public (MapperDescriptor descriptor, DiagnosticCollection diagnostics) Build(CancellationToken cancellationToken)
     {
+        DetectMapperServiceProviderMember();
+        // Propagate SP member name to builder context so mapping builders can use it
+        _builderContext.ServiceProviderMemberName = _mapperDescriptor.ServiceProviderMemberName;
         ConfigureMemberVisibility();
         ReserveMethodNames();
         ExtractUserMappings();
@@ -93,6 +97,69 @@ public class DescriptorBuilder
         AddMappingsToDescriptor();
         AddAccessorsToDescriptor();
         return (_mapperDescriptor, _diagnostics);
+    }
+
+    private void DetectMapperServiceProviderMember()
+    {
+        // Only instance mappers can use DI
+        if (_mapperDescriptor.Symbol.IsStatic)
+            return;
+
+        var spAttrMembers = _symbolAccessor
+            .GetAllMembers(_mapperDescriptor.Symbol)
+            .Where(m => _attributeAccessor.HasAttribute<MapperServiceProviderAttribute>(m))
+            .ToList();
+
+        // Prefer a readable property/field with type IServiceProvider
+        foreach (var m in spAttrMembers)
+        {
+            var t = m switch
+            {
+                IPropertySymbol { GetMethod: not null } p => p.Type,
+                IFieldSymbol f => f.Type,
+                _ => null,
+            };
+
+            if (t == null)
+                continue;
+
+            if (!SymbolEqualityComparer.Default.Equals(t, _builderContext.Types.IServiceProvider))
+            {
+                continue;
+            }
+
+            _mapperDescriptor.ServiceProviderMemberName = m.Name;
+            break;
+        }
+
+        // Fallback: if no attribute is found, try to detect a single readable IServiceProvider member
+        if (_mapperDescriptor.ServiceProviderMemberName is not null)
+        {
+            return;
+        }
+
+        var spMembersByType = _symbolAccessor
+            .GetAllMembers(_mapperDescriptor.Symbol)
+            .Where(m =>
+            {
+                if (m is not (IPropertySymbol { GetMethod: not null } or IFieldSymbol))
+                {
+                    return false;
+                }
+                var t = m switch
+                {
+                    IPropertySymbol p => p.Type,
+                    IFieldSymbol f => f.Type,
+                    _ => null,
+                };
+                return t != null && SymbolEqualityComparer.Default.Equals(t, _builderContext.Types.IServiceProvider);
+            })
+            .ToList();
+
+        if (spMembersByType.Count == 1)
+        {
+            _mapperDescriptor.ServiceProviderMemberName = spMembersByType[0].Name;
+        }
     }
 
     /// <summary>
@@ -219,6 +286,174 @@ public class DescriptorBuilder
     {
         // add generated mappings to the mapper
         _mapperDescriptor.AddMethodMappings(_mappings.MethodMappings);
+        // add any DI cache fields + helpers
+        EmitDiHelpers();
+    }
+
+    private void EmitDiHelpers()
+    {
+        foreach (var (fieldName, mapperIface) in _builderContext.RequestedDiMapperCacheFields)
+        {
+            EmitDiCacheField(fieldName, mapperIface);
+            EmitDiHelperMethod(fieldName, mapperIface);
+        }
+    }
+
+    private void EmitDiCacheField(string fieldName, INamedTypeSymbol mapperIface)
+    {
+        var mapperTypeNullable = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.NullableType(
+            SyntaxFactoryHelper.FullyQualifiedIdentifier(mapperIface)
+        );
+        var lazyGeneric = LazyGeneric(GlobalSystemAlias(), mapperTypeNullable);
+        var lazyNullable = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.NullableType(lazyGeneric).AddLeadingSpace().AddTrailingSpace();
+
+        var variable = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.VariableDeclarator(fieldName);
+        var declaration = Microsoft
+            .CodeAnalysis.CSharp.SyntaxFactory.VariableDeclaration(lazyNullable)
+            .WithVariables(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SeparatedList([variable]));
+        var fieldDecl = Microsoft
+            .CodeAnalysis.CSharp.SyntaxFactory.FieldDeclaration(declaration)
+            .WithModifiers(
+                Microsoft.CodeAnalysis.CSharp.SyntaxFactory.TokenList(
+                    Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Token(Microsoft.CodeAnalysis.CSharp.SyntaxKind.PrivateKeyword)
+                )
+            );
+        _mapperDescriptor.AddAdditionalMember(fieldDecl);
+    }
+
+    private void EmitDiHelperMethod(string fieldName, INamedTypeSymbol mapperIface)
+    {
+        var mapperTypeNullable = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.NullableType(
+            SyntaxFactoryHelper.FullyQualifiedIdentifier(mapperIface)
+        );
+        var methodName = "GetOrNull_" + fieldName.TrimStart('_');
+        var returnType = Microsoft
+            .CodeAnalysis.CSharp.SyntaxFactory.NullableType(SyntaxFactoryHelper.FullyQualifiedIdentifier(mapperIface))
+            .AddLeadingSpace()
+            .AddTrailingSpace();
+
+        var thisExpr = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ThisExpression();
+        var fieldAccess = SyntaxFactoryHelper.MemberAccess(thisExpr, fieldName);
+        var lazyTypeForNew = LazyGeneric(GlobalSystemAlias(), mapperTypeNullable).AddLeadingSpace();
+
+        Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax spAccess =
+            _mapperDescriptor.ServiceProviderMemberName == null
+                ? thisExpr
+                : SyntaxFactoryHelper.MemberAccess(thisExpr, _mapperDescriptor.ServiceProviderMemberName);
+        var invoker = new SyntaxFactoryHelper(_mapperDescriptor.SupportedFeatures);
+        var getService = BuildGetService(spAccess, mapperIface);
+        var asIface = AsIface(getService, mapperIface);
+        var lambda = NoArgLambda(asIface);
+        var newLazy = Microsoft
+            .CodeAnalysis.CSharp.SyntaxFactory.ObjectCreationExpression(lazyTypeForNew)
+            .WithArgumentList(
+                Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ArgumentList(
+                    Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SingletonSeparatedList(
+                        Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Argument(lambda)
+                    )
+                )
+            );
+        var coalesceAssign = SyntaxFactoryHelper.CoalesceAssignment(fieldAccess, newLazy);
+        var localDecl = invoker
+            .AddIndentation()
+            .AddIndentation()
+            .AddIndentation()
+            .DeclareLocalVariable("cached", Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParenthesizedExpression(coalesceAssign));
+        var ret = invoker
+            .AddIndentation()
+            .AddIndentation()
+            .AddIndentation()
+            .Return(
+                SyntaxFactoryHelper.MemberAccess(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.IdentifierName("cached"), nameof(Lazy<>.Value))
+            );
+        var method = Microsoft
+            .CodeAnalysis.CSharp.SyntaxFactory.MethodDeclaration(returnType, methodName)
+            .WithModifiers(
+                Microsoft.CodeAnalysis.CSharp.SyntaxFactory.TokenList(
+                    Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Token(Microsoft.CodeAnalysis.CSharp.SyntaxKind.PrivateKeyword)
+                )
+            )
+            .WithBody(invoker.AddIndentation().AddIndentation().Block([localDecl, ret]));
+        _mapperDescriptor.AddAdditionalMember(method);
+    }
+
+    private static Microsoft.CodeAnalysis.CSharp.Syntax.AliasQualifiedNameSyntax GlobalSystemAlias()
+    {
+        return Microsoft.CodeAnalysis.CSharp.SyntaxFactory.AliasQualifiedName(
+            Microsoft.CodeAnalysis.CSharp.SyntaxFactory.IdentifierName(
+                Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Token(Microsoft.CodeAnalysis.CSharp.SyntaxKind.GlobalKeyword)
+            ),
+            Microsoft.CodeAnalysis.CSharp.SyntaxFactory.IdentifierName("System")
+        );
+    }
+
+    private static Microsoft.CodeAnalysis.CSharp.Syntax.QualifiedNameSyntax LazyGeneric(
+        Microsoft.CodeAnalysis.CSharp.Syntax.AliasQualifiedNameSyntax globalSystem,
+        Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax typeArg
+    )
+    {
+        return Microsoft.CodeAnalysis.CSharp.SyntaxFactory.QualifiedName(
+            globalSystem,
+            Microsoft
+                .CodeAnalysis.CSharp.SyntaxFactory.GenericName("Lazy")
+                .WithTypeArgumentList(
+                    Microsoft.CodeAnalysis.CSharp.SyntaxFactory.TypeArgumentList(
+                        Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SingletonSeparatedList<Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax>(
+                            typeArg
+                        )
+                    )
+                )
+        );
+    }
+
+    private static Microsoft.CodeAnalysis.CSharp.Syntax.InvocationExpressionSyntax BuildGetService(
+        Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax spAccess,
+        INamedTypeSymbol iface
+    )
+    {
+        var typeofExpr = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.TypeOfExpression(SyntaxFactoryHelper.FullyQualifiedIdentifier(iface));
+        return Microsoft.CodeAnalysis.CSharp.SyntaxFactory.InvocationExpression(
+            SyntaxFactoryHelper.MemberAccess(spAccess, nameof(IServiceProvider.GetService)),
+            Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ArgumentList(
+                Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SingletonSeparatedList(
+                    Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Argument(typeofExpr)
+                )
+            )
+        );
+    }
+
+    private static Microsoft.CodeAnalysis.CSharp.Syntax.BinaryExpressionSyntax AsIface(
+        Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expr,
+        INamedTypeSymbol iface
+    )
+    {
+        return Microsoft
+            .CodeAnalysis.CSharp.SyntaxFactory.BinaryExpression(
+                Microsoft.CodeAnalysis.CSharp.SyntaxKind.AsExpression,
+                expr,
+                SyntaxFactoryHelper.FullyQualifiedIdentifier(iface)
+            )
+            .WithOperatorToken(
+                Microsoft
+                    .CodeAnalysis.CSharp.SyntaxFactory.Token(Microsoft.CodeAnalysis.CSharp.SyntaxKind.AsKeyword)
+                    .WithLeadingTrivia(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Space)
+                    .WithTrailingTrivia(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Space)
+            );
+    }
+
+    private static Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedLambdaExpressionSyntax NoArgLambda(
+        Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax body
+    )
+    {
+        return Microsoft
+            .CodeAnalysis.CSharp.SyntaxFactory.ParenthesizedLambdaExpression(body)
+            .WithParameterList(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParameterList())
+            .WithArrowToken(
+                Microsoft
+                    .CodeAnalysis.CSharp.SyntaxFactory.Token(Microsoft.CodeAnalysis.CSharp.SyntaxKind.EqualsGreaterThanToken)
+                    .WithLeadingTrivia(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Space)
+                    .WithTrailingTrivia(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Space)
+            );
     }
 
     private void AddAccessorsToDescriptor()

--- a/src/Riok.Mapperly/Descriptors/MapperDescriptor.cs
+++ b/src/Riok.Mapperly/Descriptors/MapperDescriptor.cs
@@ -12,6 +12,7 @@ public class MapperDescriptor
 {
     private readonly MapperDeclaration _declaration;
     private readonly List<MethodMapping> _methodMappings = [];
+    private readonly List<MemberDeclarationSyntax> _additionalMembers = [];
 
     public MapperDescriptor(MapperDeclaration declaration, UniqueNameBuilder nameBuilder, SupportedFeatures supportedFeatures)
     {
@@ -44,7 +45,14 @@ public class MapperDescriptor
 
     public IReadOnlyCollection<MethodMapping> MethodMappings => _methodMappings;
 
+    public IReadOnlyCollection<MemberDeclarationSyntax> AdditionalMembers => _additionalMembers;
+
+    // Name of the service provider member on the mapper (property/field). Null if none.
+    public string? ServiceProviderMemberName { get; set; }
+
     public void AddMethodMappings(IReadOnlyCollection<MethodMapping> mappings) => _methodMappings.AddRange(mappings);
+
+    public void AddAdditionalMember(MemberDeclarationSyntax member) => _additionalMembers.Add(member);
 
     private string BuildName(INamedTypeSymbol symbol)
     {

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/UserMethodMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/UserMethodMappingBodyBuilder.cs
@@ -1,3 +1,4 @@
+using Riok.Mapperly.Descriptors.Mappings;
 using Riok.Mapperly.Descriptors.Mappings.UserMappings;
 using Riok.Mapperly.Diagnostics;
 
@@ -39,6 +40,11 @@ public static class UserMethodMappingBodyBuilder
         var delegateMapping = ctx.BuildMapping(new TypeMappingKey(mapping), options);
         if (delegateMapping != null)
         {
+            // Prevent DI early-return recursion on the root mapping by disabling it on the delegate if applicable.
+            if (delegateMapping is NewInstanceObjectMemberMethodMapping m)
+            {
+                m.DisableDiEarlyReturn = true;
+            }
             mapping.SetDelegateMapping(delegateMapping);
             return;
         }

--- a/src/Riok.Mapperly/Descriptors/Mappings/DiFirstExistingTargetDelegateMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/DiFirstExistingTargetDelegateMapping.cs
@@ -1,0 +1,42 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Descriptors.Mappings.ExistingTarget;
+using Riok.Mapperly.Emit.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Riok.Mapperly.Emit.Syntax.SyntaxFactoryHelper;
+
+namespace Riok.Mapperly.Descriptors.Mappings;
+
+/// <summary>
+/// Wraps an existing-target mapping and first tries to delegate mapping to a DI-provided <see cref="IExistingMapper{TSource,TDestination}"/>
+/// if absent, uses the inner mapping. Only used for instance mappers and statements (not expressions).
+/// </summary>
+public class DiFirstExistingTargetDelegateMapping(
+    IExistingTargetMapping innerMapping,
+    string cacheFieldName,
+    ITypeSymbol sourceType,
+    ITypeSymbol targetType
+) : ExistingTargetMapping(sourceType, targetType)
+{
+    public override IEnumerable<StatementSyntax> Build(TypeMappingBuildContext ctx, ExpressionSyntax target)
+    {
+        // Build:
+        // var __di = this.GetOrNull_<cache>();
+        // if (__di != null) { __di.Map(source, target); } else { <inner> }
+        var thisExpr = ThisExpression();
+        var helperName = "GetOrNull_" + cacheFieldName.TrimStart('_');
+        var helperCall = ctx.SyntaxFactory.Invocation(MemberAccess(thisExpr, helperName));
+
+        var diVarName = ctx.NameBuilder.New("diMapper");
+        var diVarId = IdentifierName(diVarName);
+        var decl = ctx.SyntaxFactory.DeclareLocalVariable(diVarName, helperCall);
+
+        var notNull = IsNotNull(diVarId);
+        var mapCall = ctx.SyntaxFactory.Invocation(MemberAccess(diVarId, "Map"), ctx.Source, target);
+        var thenStmt = ctx.SyntaxFactory.AddIndentation().ExpressionStatement(mapCall);
+        var elseBody = innerMapping.Build(ctx, target).Select(s => s.AddIndentation()).ToArray();
+        var ifStmt = ctx.SyntaxFactory.If(notNull, [thenStmt], elseBody.Length == 0 ? null : elseBody);
+        return [decl, ifStmt];
+    }
+}

--- a/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/SimpleMappingBuilderContext.cs
@@ -46,7 +46,12 @@ public class SimpleMappingBuilderContext(
             ctx.ExistingTargetMappingBuilder,
             ctx.InlinedMappings,
             diagnosticLocation ?? ctx._diagnosticLocation
-        ) { }
+        )
+    {
+        // propagate DI settings and share cache fields dictionary
+        ServiceProviderMemberName = ctx.ServiceProviderMemberName;
+        RequestedDiMapperCacheFields = ctx.RequestedDiMapperCacheFields;
+    }
 
     public MapperDeclaration MapperDeclaration { get; } = mapperDeclaration;
 
@@ -74,6 +79,14 @@ public class SimpleMappingBuilderContext(
     /// and the body of these mappings is never built.
     /// </summary>
     protected InlinedExpressionMappingCollection InlinedMappings { get; } = inlinedMappings;
+
+    /// <summary>
+    /// Name of the mapper member annotated with [MapperServiceProvider] which exposes an IServiceProvider. Null if none.
+    /// </summary>
+    public string? ServiceProviderMemberName { get; set; }
+
+    // Tracks requested cached DI mapper fields: fieldName -> constructed interface type (IMapper<S,T> or IExistingMapper<S,T>)
+    internal Dictionary<string, INamedTypeSymbol> RequestedDiMapperCacheFields { get; } = [];
 
     public SemanticModel? GetSemanticModel(SyntaxTree syntaxTree) => _compilationContext.GetSemanticModel(syntaxTree);
 

--- a/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
+++ b/src/Riok.Mapperly/Descriptors/WellKnownTypes.cs
@@ -12,6 +12,11 @@ public class WellKnownTypes(Compilation compilation)
 
     public INamedTypeSymbol? TimeOnly => TryGet("System.TimeOnly");
 
+    public INamedTypeSymbol? IServiceProvider => TryGet("System.IServiceProvider");
+
+    public INamedTypeSymbol? IMapper2 => TryGet("Riok.Mapperly.Abstractions.IMapper`2");
+    public INamedTypeSymbol? IExistingMapper2 => TryGet("Riok.Mapperly.Abstractions.IExistingMapper`2");
+
     public INamedTypeSymbol? NotNullIfNotNullAttribute => TryGet("System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute");
 
     public INamedTypeSymbol? UnsafeAccessorAttribute => TryGet("System.Runtime.CompilerServices.UnsafeAccessorAttribute");

--- a/src/Riok.Mapperly/Emit/SourceEmitter.cs
+++ b/src/Riok.Mapperly/Emit/SourceEmitter.cs
@@ -61,6 +61,10 @@ public static class SourceEmitter
         CancellationToken cancellationToken
     )
     {
+        foreach (var member in descriptor.AdditionalMembers)
+        {
+            yield return member;
+        }
         foreach (var mapping in descriptor.MethodMappings)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/test/Riok.Mapperly.Abstractions.Tests/_snapshots/PublicApiTest.PublicApiHasNotChanged.verified.cs
+++ b/test/Riok.Mapperly.Abstractions.Tests/_snapshots/PublicApiTest.PublicApiHasNotChanged.verified.cs
@@ -26,6 +26,14 @@ namespace Riok.Mapperly.Abstractions
         public FormatProviderAttribute() { }
         public bool Default { get; set; }
     }
+    public interface IExistingMapper<in TSource, in TDestination>
+    {
+        void Map(TSource source, TDestination destination);
+    }
+    public interface IMapper<in TSource, out TDestination>
+    {
+        TDestination Map(TSource source);
+    }
     [System.Flags]
     public enum IgnoreObsoleteMembersStrategy
     {
@@ -206,6 +214,12 @@ namespace Riok.Mapperly.Abstractions
     {
         public MapperRequiredMappingAttribute(Riok.Mapperly.Abstractions.RequiredMappingStrategy requiredMappingStrategy) { }
         public Riok.Mapperly.Abstractions.RequiredMappingStrategy RequiredMappingStrategy { get; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
+    [System.Diagnostics.Conditional("MAPPERLY_ABSTRACTIONS_SCOPE_RUNTIME")]
+    public sealed class MapperServiceProviderAttribute : System.Attribute
+    {
+        public MapperServiceProviderAttribute() { }
     }
     [System.Flags]
     public enum MappingConversionType

--- a/test/Riok.Mapperly.IntegrationTests/DiCompositionMapperTest.cs
+++ b/test/Riok.Mapperly.IntegrationTests/DiCompositionMapperTest.cs
@@ -1,0 +1,117 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.IntegrationTests.Dto;
+using Riok.Mapperly.IntegrationTests.Mapper;
+using Shouldly;
+using Xunit;
+
+namespace Riok.Mapperly.IntegrationTests
+{
+    public class DiCompositionMapperTest
+    {
+        [Fact]
+        public void UsesDiMapperWhenAvailable()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IMapper<DINestedModel, DINestedDto>>(new NestedMapper());
+            var sp = services.BuildServiceProvider();
+            var mapper = new DiCompositionMapper(sp);
+            var src = new DITestModel { Nested = new DINestedModel { Value = 10 } };
+            var res = mapper.RootMap(src);
+            res.Nested.Value.ShouldBe(15);
+        }
+
+        [Fact]
+        public void FallsBackWhenServiceMissing()
+        {
+            var services = new ServiceCollection().BuildServiceProvider();
+            var mapper = new DiCompositionMapper(services);
+            var src = new DITestModel { Nested = new DINestedModel { Value = 10 } };
+            var res = mapper.RootMap(src);
+            // default generated mapping copies value as-is
+            res.Nested.Value.ShouldBe(10);
+        }
+
+        [Fact]
+        public void UsesDiMapperWhenAvailableForExistingMapping()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IExistingMapper<DINestedModel, DINestedDto>>(new NestedMapper());
+            var sp = services.BuildServiceProvider();
+            var mapper = new DiCompositionMapper(sp);
+            var src = new DITestModel { Nested = new DINestedModel { Value = 10 } };
+            var res = new DIDto();
+            mapper.RootMap(src, res);
+            res.Nested.Value.ShouldBe(20);
+        }
+
+        [Fact]
+        public void UsesDiMapperWithinCollectionsWhenAvailable()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IMapper<DINestedModel, DINestedDto>>(new NestedMapper());
+            var sp = services.BuildServiceProvider();
+            var mapper = new DiCompositionMapper(sp);
+
+            var src = new DITestModel
+            {
+                NestedList = [new DINestedModel { Value = 1 }, new DINestedModel { Value = 2 }],
+                NestedDictionary = new Dictionary<string, DINestedModel>
+                {
+                    ["a"] = new() { Value = 3 },
+                    ["b"] = new() { Value = 4 },
+                },
+                NestedSet = [new DINestedModel { Value = 5 }, new DINestedModel { Value = 6 }],
+                // keep SortedSet empty to avoid comparer requirements on destination type
+                NestedSortedSet = [],
+            };
+
+            var res = mapper.RootMap(src);
+
+            res.NestedList.Select(x => x.Value).ShouldBe([6, 7], ignoreOrder: false);
+            res.NestedDictionary["a"].Value.ShouldBe(8);
+            res.NestedDictionary["b"].Value.ShouldBe(9);
+            res.NestedSet.Select(x => x.Value).Order().ShouldBe([10, 11]);
+            res.NestedSortedSet.Count.ShouldBe(0);
+        }
+
+        [Fact]
+        public void FallsBackWithinCollectionsWhenServiceMissing()
+        {
+            var services = new ServiceCollection();
+            var sp = services.BuildServiceProvider();
+            var mapper = new DiCompositionMapper(sp);
+
+            var src = new DITestModel
+            {
+                NestedList = [new DINestedModel { Value = 1 }, new DINestedModel { Value = 2 }],
+                NestedDictionary = new Dictionary<string, DINestedModel>
+                {
+                    ["a"] = new() { Value = 3 },
+                    ["b"] = new() { Value = 4 },
+                },
+                NestedSet = [new DINestedModel { Value = 5 }, new DINestedModel { Value = 6 }],
+                // keep SortedSet empty to avoid comparer requirements on destination type
+                NestedSortedSet = [],
+            };
+
+            var res = mapper.RootMap(src);
+
+            res.NestedList.Select(x => x.Value).ShouldBe(new[] { 1, 2 }, ignoreOrder: false);
+            res.NestedDictionary["a"].Value.ShouldBe(3);
+            res.NestedDictionary["b"].Value.ShouldBe(4);
+            res.NestedSet.Select(x => x.Value).Order().ShouldBe(new[] { 5, 6 });
+            res.NestedSortedSet.Count.ShouldBe(0);
+        }
+    }
+
+    // helper nested mapper used by tests
+    sealed file class NestedMapper : IMapper<DINestedModel, DINestedDto>, IExistingMapper<DINestedModel, DINestedDto>
+    {
+        public DINestedDto Map(DINestedModel source) => new() { Value = source.Value + 5 };
+
+        public void Map(DINestedModel source, DINestedDto destination) => destination.Value = source.Value + 10;
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/Dto/DIDto.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Dto/DIDto.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Riok.Mapperly.IntegrationTests.Dto
+{
+    public class DIDto
+    {
+        public DINestedDto Nested { get; set; } = new();
+        public List<DINestedDto> NestedList { get; set; } = [];
+        public Dictionary<string, DINestedDto> NestedDictionary { get; set; } = new();
+        public HashSet<DINestedDto> NestedSet { get; set; } = [];
+        public SortedSet<DINestedDto> NestedSortedSet { get; set; } = [];
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/Dto/DINestedDto.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Dto/DINestedDto.cs
@@ -1,0 +1,7 @@
+namespace Riok.Mapperly.IntegrationTests.Dto
+{
+    public class DINestedDto
+    {
+        public int Value { get; set; }
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/Dto/DINestedModel.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Dto/DINestedModel.cs
@@ -1,0 +1,7 @@
+namespace Riok.Mapperly.IntegrationTests.Dto
+{
+    public class DINestedModel
+    {
+        public int Value { get; set; }
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/Dto/DITestModel.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Dto/DITestModel.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Riok.Mapperly.IntegrationTests.Dto
+{
+    public class DITestModel
+    {
+        public DINestedModel Nested { get; set; } = new();
+
+        public List<DINestedModel> NestedList { get; set; } = [];
+        public Dictionary<string, DINestedModel> NestedDictionary { get; set; } = new();
+        public HashSet<DINestedModel> NestedSet { get; set; } = [];
+        public SortedSet<DINestedModel> NestedSortedSet { get; set; } = [];
+    }
+}

--- a/test/Riok.Mapperly.IntegrationTests/Mapper/DiCompositionMapper.cs
+++ b/test/Riok.Mapperly.IntegrationTests/Mapper/DiCompositionMapper.cs
@@ -1,0 +1,19 @@
+using System;
+using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.IntegrationTests.Dto;
+
+namespace Riok.Mapperly.IntegrationTests.Mapper
+{
+    [Mapper]
+    public partial class DiCompositionMapper
+    {
+        [MapperServiceProvider]
+        public IServiceProvider Services { get; }
+
+        public DiCompositionMapper(IServiceProvider services) => Services = services;
+
+        public partial DIDto RootMap(DITestModel src);
+
+        public partial void RootMap(DITestModel src, DIDto dst);
+    }
+}


### PR DESCRIPTION
# Feature: DI mapper fallback for nested complex mappings

## Description

Introduces DI composition for nested mappings using IMapper<TSource, TDestination> and IExistingMapper<TSource, TDestination> interfaces. Mappers can now delegate nested member mappings to DI-provided services if an IServiceProvider is exposed and registered. Includes new abstractions, attribute, code generation logic, documentation, and integration tests for DI composition scenarios.

Fixes #1922

## Checklist

- [ ] The existing code style is followed
- [ ] The commit message follows our guidelines
- [ ] Performed a self-review of my code
- [ ] Hard-to-understand areas of my code are commented
- [ ] The documentation is updated (as applicable)
- [ ] Unit tests are added/updated
- [ ] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
