### PR TITLE
fix: handle single segment fullnameof

### DIFF
--- a/src/Riok.Mapperly/Configuration/PropertyReferences/StringMemberPath.cs
+++ b/src/Riok.Mapperly/Configuration/PropertyReferences/StringMemberPath.cs
@@ -9,7 +9,7 @@ public readonly record struct StringMemberPath(ImmutableEquatableArray<string> P
     public StringMemberPath(IEnumerable<string> path)
         : this(path.ToImmutableEquatableArray()) { }
 
-    public string RootName => Path[0];
+    public string RootName => Path.FirstOrDefault() ?? string.Empty;
     public string FullName => string.Join(MemberPathConstants.MemberAccessSeparatorString, Path);
     public int PathCount => Path.Count;
     public IEnumerable<string> MemberNames => Path;


### PR DESCRIPTION
#  Handle empty path in RootName

## Description

This PR fixes the crash when the target is `fullname` but only has a single part. (f.e, Class only)
I'm unsure what it should do if it is a single part. For now, I made the simplest fix, but it doesn't really feel right.

I also created a test when the source property is a single part. This also behaves oddly:
- If the destination is a string, then it generates this: `destination.StringProperty = source.ToString()` Is this intentional?
- If it is not, then the map fails.



Fixes #1906

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [ ] Hard-to-understand areas of my code are commented
- [ ] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [ ] Integration tests are added/updated (as applicable, especially if feature/bug depends on Roslyn or framework version in use)
