### PR TITLE
feat: Add SnakeCase strategy to PropertyNameMappingStrategy

### DIFF
--- a/docs/docs/configuration/mapper.mdx
+++ b/docs/docs/configuration/mapper.mdx
@@ -209,29 +209,16 @@ or by setting the `IgnoreObsoleteMembersStrategy` option of the `MapperAttribute
 ### Property name mapping strategy
 
 By default, property and field names are matched using a case sensitive strategy.
-If all properties/fields differ only in casing, for example `ModelName` on the source
-and `modelName` on the target,
-the `MapperAttribute` can be used with the `PropertyNameMappingStrategy` option.
+If properties/fields differ in naming conventions, the `MapperAttribute` can be used with the `PropertyNameMappingStrategy` option.
 
-```csharp
-// highlight-start
-[Mapper(PropertyNameMappingStrategy = PropertyNameMappingStrategy.CaseInsensitive)]
-// highlight-end
-public partial class CarMapper
-{
-    public partial CarDto ToDto(Car car);
-}
+Available strategies:
 
-public class Car
-{
-    public string ModelName { get; set; }
-}
-
-public class CarDto
-{
-    public string modelName { get; set; }
-}
-```
+| Name            | Description                                                              |
+| --------------- | ------------------------------------------------------------------------ |
+| CaseSensitive   | Matches properties by their exact name (default)                         |
+| CaseInsensitive | Matches properties ignoring case differences                             |
+| SnakeCase       | Matches properties by converting to `snake_case` before comparison       |
+| UpperSnakeCase  | Matches properties by converting to `UPPER_SNAKE_CASE` before comparison |
 
 ### `null` values
 

--- a/src/Riok.Mapperly.Abstractions/PropertyNameMappingStrategy.cs
+++ b/src/Riok.Mapperly.Abstractions/PropertyNameMappingStrategy.cs
@@ -14,4 +14,16 @@ public enum PropertyNameMappingStrategy
     /// Matches a property by its name in case insensitive manner.
     /// </summary>
     CaseInsensitive,
+
+    /// <summary>
+    /// Matches a property by converting both source and target property names to snake_case before comparison.
+    /// For example, "FirstName" would match "first_name".
+    /// </summary>
+    SnakeCase,
+
+    /// <summary>
+    /// Matches a property by converting both source and target property names to SNAKE_CASE before comparison.
+    /// For example, "FirstName" would match "FIRST_NAME".
+    /// </summary>
+    UpperSnakeCase,
 }

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingBuilderContext.cs
@@ -259,8 +259,10 @@ public abstract class MembersMappingBuilderContext<T>(MappingBuilderContext buil
         bool? ignoreCase = null
     )
     {
-        ignoreCase ??= BuilderContext.Configuration.Mapper.PropertyNameMappingStrategy == PropertyNameMappingStrategy.CaseInsensitive;
-        var pathCandidates = MemberPathCandidateBuilder.BuildMemberPathCandidates(targetMemberName);
+        var strategy = BuilderContext.Configuration.Mapper.PropertyNameMappingStrategy;
+        ignoreCase ??= strategy == PropertyNameMappingStrategy.CaseInsensitive;
+
+        var pathCandidates = MemberPathCandidateBuilder.BuildMemberPathCandidates(targetMemberName, strategy);
 
         // First, try to find the property on (a sub-path of) the source type itself. (If this is undesired, an Ignore property can be used.)
         if (TryFindSourcePath(pathCandidates, ignoreCase.Value, out sourceMemberPath))

--- a/src/Riok.Mapperly/Descriptors/MemberPathCandidateBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MemberPathCandidateBuilder.cs
@@ -1,4 +1,6 @@
+using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.Configuration.PropertyReferences;
+using Riok.Mapperly.Helpers;
 
 namespace Riok.Mapperly.Descriptors;
 
@@ -7,36 +9,61 @@ public static class MemberPathCandidateBuilder
     /// <summary>
     /// Maximum number of indices which are considered to compute the member path candidates.
     /// </summary>
-    private const int MaxPascalCaseIndices = 8;
+    private const int MaxPermutationIndices = 8;
 
     /// <summary>
-    /// Splits a name into pascal case chunks and joins them together in all possible combinations.
+    /// Splits a name into chunks and joins them together in all possible combinations.
     /// <example><c>"MyValueId"</c> leads to <c>[["MyValueId"], ["My", "ValueId"], ["MyValue", "Id"], ["My", "Value", "Id"]</c></example>
     /// </summary>
     /// <param name="name">The name to build candidates from.</param>
+    /// <param name="strategy">The naming strategy to use.</param>
     /// <returns>The joined member path groups.</returns>
-    public static IEnumerable<StringMemberPath> BuildMemberPathCandidates(string name)
+    public static IEnumerable<StringMemberPath> BuildMemberPathCandidates(string name, PropertyNameMappingStrategy strategy)
     {
-        if (name.Length == 0)
-            yield break;
+        if (string.IsNullOrEmpty(name))
+            return [];
 
-        // yield full string
-        // as a fast path (often member match by their exact name)
-        yield return new StringMemberPath([name]);
+        return BuildCandidates(name, strategy).Prepend(new StringMemberPath([name])).DistinctBy(x => x.FullName);
+    }
 
-        var indices = GetPascalCaseSplitIndices(name).Take(MaxPascalCaseIndices).ToArray();
-        if (indices.Length == 0)
-            yield break;
-
-        // try all permutations, skipping the first because the full string is already yielded
-        var permutationsCount = 1 << indices.Length;
-        for (var i = 1; i < permutationsCount; i++)
+    private static IEnumerable<StringMemberPath> BuildCandidates(string name, PropertyNameMappingStrategy strategy)
+    {
+        return strategy switch
         {
-            yield return new StringMemberPath(BuildPermutationParts(name, indices, i));
+            PropertyNameMappingStrategy.SnakeCase => BuildSnakeCaseCandidates(name, name.ToSnakeCase()),
+            PropertyNameMappingStrategy.UpperSnakeCase => BuildSnakeCaseCandidates(name, name.ToUpperSnakeCase()),
+            _ => BuildPermutations(name, char.IsUpper, skipSeparator: false),
+        };
+    }
+
+    private static IEnumerable<StringMemberPath> BuildSnakeCaseCandidates(string originalName, string snakeCaseName)
+    {
+        var snakeCasePermutations = BuildPermutations(snakeCaseName, static c => c == '_', skipSeparator: true);
+
+        // PascalCase Fallback
+        var pascalCaseSource = originalName.Contains('_', StringComparison.Ordinal) ? originalName.ToPascalCase() : originalName;
+        var pascalCasePermutations = BuildCandidates(pascalCaseSource, PropertyNameMappingStrategy.CaseSensitive);
+        return snakeCasePermutations.Concat(pascalCasePermutations);
+    }
+
+    private static IEnumerable<StringMemberPath> BuildPermutations(string name, Func<char, bool> isSeparator, bool skipSeparator)
+    {
+        var indices = GetSplitIndices(name, isSeparator).Take(MaxPermutationIndices).ToArray();
+
+        // try all permutations
+        var permutationsCount = 1 << indices.Length;
+        for (var i = 0; i < permutationsCount; i++)
+        {
+            yield return new StringMemberPath(BuildPermutationParts(name, indices, i, skipSeparator));
         }
     }
 
-    private static IEnumerable<string> BuildPermutationParts(string source, int[] splitIndices, int enabledSplitPositions)
+    private static IEnumerable<string> BuildPermutationParts(
+        string source,
+        int[] splitIndices,
+        int enabledSplitPositions,
+        bool skipSplitIndex
+    )
     {
         var lastSplitIndex = 0;
         var currentSplitPosition = 1;
@@ -45,7 +72,7 @@ public static class MemberPathCandidateBuilder
             if ((enabledSplitPositions & currentSplitPosition) == currentSplitPosition)
             {
                 yield return source.Substring(lastSplitIndex, splitIndex - lastSplitIndex);
-                lastSplitIndex = splitIndex;
+                lastSplitIndex = splitIndex + (skipSplitIndex ? 1 : 0);
             }
 
             currentSplitPosition <<= 1;
@@ -55,11 +82,11 @@ public static class MemberPathCandidateBuilder
             yield return source.Substring(lastSplitIndex);
     }
 
-    private static IEnumerable<int> GetPascalCaseSplitIndices(string str)
+    private static IEnumerable<int> GetSplitIndices(string str, Func<char, bool> isSeparator)
     {
         for (var i = 1; i < str.Length; i++)
         {
-            if (char.IsUpper(str[i]))
+            if (isSeparator(str[i]))
                 yield return i;
         }
     }

--- a/test/Riok.Mapperly.Abstractions.Tests/_snapshots/PublicApiTest.PublicApiHasNotChanged.verified.cs
+++ b/test/Riok.Mapperly.Abstractions.Tests/_snapshots/PublicApiTest.PublicApiHasNotChanged.verified.cs
@@ -268,6 +268,8 @@ namespace Riok.Mapperly.Abstractions
     {
         CaseSensitive = 0,
         CaseInsensitive = 1,
+        SnakeCase = 2,
+        UpperSnakeCase = 3,
     }
     [System.Flags]
     public enum RequiredMappingStrategy

--- a/test/Riok.Mapperly.Tests/Descriptors/MemberPathCandidateBuilderTest.cs
+++ b/test/Riok.Mapperly.Tests/Descriptors/MemberPathCandidateBuilderTest.cs
@@ -1,3 +1,4 @@
+using Riok.Mapperly.Abstractions;
 using Riok.Mapperly.Descriptors;
 
 namespace Riok.Mapperly.Tests.Descriptors;
@@ -5,14 +6,65 @@ namespace Riok.Mapperly.Tests.Descriptors;
 public class MemberPathCandidateBuilderTest
 {
     [Theory]
-    [InlineData("", new string[] { })]
-    [InlineData("a", new[] { "a" })]
-    [InlineData("A", new[] { "A" })]
-    [InlineData("aA", new[] { "aA", "a.A" })]
-    [InlineData("AB", new[] { "AB", "A.B" })]
-    [InlineData("Value", new[] { "Value" })]
-    [InlineData("MyValue", new[] { "MyValue", "My.Value" })]
-    [InlineData("MyValueId", new[] { "MyValueId", "My.ValueId", "MyValue.Id", "My.Value.Id" })]
+    [InlineData("", new string[] { }, new string[] { }, new string[] { })]
+    [InlineData("a", new[] { "a" }, new[] { "a" }, new[] { "a", "A" })]
+    [InlineData("aa", new[] { "aa" }, new[] { "aa" }, new[] { "aa", "AA" })]
+    [InlineData("A", new[] { "A" }, new[] { "A", "a" }, new[] { "A" })]
+    [InlineData("aA", new[] { "aA", "a.A" }, new[] { "aA", "a_a", "a.a", "a.A" }, new[] { "aA", "A_A", "A.A", "a.A" })]
+    [InlineData(
+        "aAA",
+        new[] { "aAA", "a.AA", "aA.A", "a.A.A" },
+        new[] { "aAA", "a_aa", "a.aa", "a.AA", "aA.A", "a.A.A" },
+        new[] { "aAA", "A_AA", "A.AA", "a.AA", "aA.A", "a.A.A" }
+    )]
+    [InlineData("AB", new[] { "AB", "A.B" }, new[] { "AB", "ab", "A.B" }, new[] { "AB", "A.B" })]
+    [InlineData("Value", new[] { "Value" }, new[] { "Value", "value" }, new[] { "Value", "VALUE" })]
+    [InlineData(
+        "MyValue",
+        new[] { "MyValue", "My.Value" },
+        new[] { "MyValue", "my_value", "my.value", "My.Value" },
+        new[] { "MyValue", "MY_VALUE", "MY.VALUE", "My.Value" }
+    )]
+    [InlineData(
+        "MyValueId",
+        new[] { "MyValueId", "My.ValueId", "MyValue.Id", "My.Value.Id" },
+        new[] { "MyValueId", "my_value_id", "my.value_id", "my_value.id", "my.value.id", "My.ValueId", "MyValue.Id", "My.Value.Id" },
+        new[] { "MyValueId", "MY_VALUE_ID", "MY.VALUE_ID", "MY_VALUE.ID", "MY.VALUE.ID", "My.ValueId", "MyValue.Id", "My.Value.Id" }
+    )]
+    [InlineData(
+        "my_value_id",
+        new[] { "my_value_id" },
+        new[] { "my_value_id", "my.value_id", "my_value.id", "my.value.id", "MyValueId", "My.ValueId", "MyValue.Id", "My.Value.Id" },
+        new[]
+        {
+            "my_value_id",
+            "MY_VALUE_ID",
+            "MY.VALUE_ID",
+            "MY_VALUE.ID",
+            "MY.VALUE.ID",
+            "MyValueId",
+            "My.ValueId",
+            "MyValue.Id",
+            "My.Value.Id",
+        }
+    )]
+    [InlineData(
+        "MY_VALUE_ID",
+        null,
+        new[]
+        {
+            "MY_VALUE_ID",
+            "my_value_id",
+            "my.value_id",
+            "my_value.id",
+            "my.value.id",
+            "MyValueId",
+            "My.ValueId",
+            "MyValue.Id",
+            "My.Value.Id",
+        },
+        new[] { "MY_VALUE_ID", "MY.VALUE_ID", "MY_VALUE.ID", "MY.VALUE.ID", "MyValueId", "My.ValueId", "MyValue.Id", "My.Value.Id" }
+    )]
     [InlineData(
         "MyValueIdNum",
         new[]
@@ -25,16 +77,84 @@ public class MemberPathCandidateBuilderTest
             "My.ValueId.Num",
             "MyValue.Id.Num",
             "My.Value.Id.Num",
+        },
+        new[]
+        {
+            "MyValueIdNum",
+            "my_value_id_num",
+            "my.value_id_num",
+            "my_value.id_num",
+            "my.value.id_num",
+            "my_value_id.num",
+            "my.value_id.num",
+            "my_value.id.num",
+            "my.value.id.num",
+            "My.ValueIdNum",
+            "MyValue.IdNum",
+            "My.Value.IdNum",
+            "MyValueId.Num",
+            "My.ValueId.Num",
+            "MyValue.Id.Num",
+            "My.Value.Id.Num",
+        },
+        new[]
+        {
+            "MyValueIdNum",
+            "MY_VALUE_ID_NUM",
+            "MY.VALUE_ID_NUM",
+            "MY_VALUE.ID_NUM",
+            "MY.VALUE.ID_NUM",
+            "MY_VALUE_ID.NUM",
+            "MY.VALUE_ID.NUM",
+            "MY_VALUE.ID.NUM",
+            "MY.VALUE.ID.NUM",
+            "My.ValueIdNum",
+            "MyValue.IdNum",
+            "My.Value.IdNum",
+            "MyValueId.Num",
+            "My.ValueId.Num",
+            "MyValue.Id.Num",
+            "My.Value.Id.Num",
         }
     )]
-    public void BuildMemberPathCandidatesShouldWork(string name, string[] chunks)
+    public void BuildMemberPathCandidatesShouldWork(
+        string name,
+        string[]? caseSensitiveChunks,
+        string[]? snakeCaseChunks,
+        string[]? upperSnakeCaseChunks
+    )
     {
-        MemberPathCandidateBuilder.BuildMemberPathCandidates(name).Select(x => x.FullName).ShouldBe(chunks);
+        if (caseSensitiveChunks != null)
+        {
+            MemberPathCandidateBuilder
+                .BuildMemberPathCandidates(name, PropertyNameMappingStrategy.CaseSensitive)
+                .Select(x => x.FullName)
+                .ShouldBe(caseSensitiveChunks);
+        }
+
+        if (snakeCaseChunks != null)
+        {
+            MemberPathCandidateBuilder
+                .BuildMemberPathCandidates(name, PropertyNameMappingStrategy.SnakeCase)
+                .Select(x => x.FullName)
+                .ShouldBe(snakeCaseChunks);
+        }
+
+        if (upperSnakeCaseChunks != null)
+        {
+            MemberPathCandidateBuilder
+                .BuildMemberPathCandidates(name, PropertyNameMappingStrategy.UpperSnakeCase)
+                .Select(x => x.FullName)
+                .ShouldBe(upperSnakeCaseChunks);
+        }
     }
 
     [Fact]
-    public void BuildMemberPathCandidatesWithPascalCaseShouldLimitPermutations()
+    public void BuildMemberPathCandidatesShouldLimitPermutations()
     {
-        MemberPathCandidateBuilder.BuildMemberPathCandidates("NOT_A_PASCAL_CASE_STRING").Count().ShouldBe(256);
+        MemberPathCandidateBuilder
+            .BuildMemberPathCandidates("NOT_A_PASCAL_CASE_STRING", PropertyNameMappingStrategy.CaseSensitive)
+            .Count()
+            .ShouldBe(256);
     }
 }

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
@@ -247,6 +247,52 @@ public class ObjectPropertyTest
     }
 
     [Fact]
+    public void WithPropertyNameMappingStrategySnakeCaseOnTarget()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A source);",
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.SnakeCase },
+            "class A { public string FirstName { get; set; } public string LastName { get; set; } }",
+            "class B { public string first_name { get; set; } public string last_name { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.first_name = source.FirstName;
+                target.last_name = source.LastName;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void WithPropertyNameMappingStrategySnakeCaseOnSource()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial A Map(B source);",
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.SnakeCase },
+            "class A { public string FirstName { get; set; } public string LastName { get; set; } }",
+            "class B { public string first_name { get; set; } public string last_name { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::A();
+                target.FirstName = source.first_name;
+                target.LastName = source.last_name;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public Task WithPropertyNameMappingStrategyCaseSensitive()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
@@ -666,5 +712,433 @@ public class ObjectPropertyTest
             .Should()
             .HaveDiagnostic(DiagnosticDescriptors.InvalidMapPropertyAttributeUsage, "Invalid usage of the MapPropertyAttribute")
             .HaveAssertedAllDiagnostics();
+    }
+
+    [Fact]
+    public void WithPropertyNameMappingStrategyUpperSnakeCaseOnTarget()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A source);",
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.UpperSnakeCase },
+            "class A { public string FirstName { get; set; } public string LastName { get; set; } }",
+            "class B { public string FIRST_NAME { get; set; } public string LAST_NAME { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.FIRST_NAME = source.FirstName;
+                target.LAST_NAME = source.LastName;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void WithPropertyNameMappingStrategyUpperSnakeCaseOnSource()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial A Map(B source);",
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.UpperSnakeCase },
+            "class A { public string FirstName { get; set; } public string LastName { get; set; } }",
+            "class B { public string FIRST_NAME { get; set; } public string LAST_NAME { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::A();
+                target.FirstName = source.FIRST_NAME;
+                target.LastName = source.LAST_NAME;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void SnakeCaseShouldPreferExactMatchOverPascalCase()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A source);",
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.SnakeCase },
+            "class A { public string my_value_id { get; set; } public string MyValueId { get; set; } }",
+            "class B { public string my_value_id { get; set; } public string MyValueId { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.my_value_id = source.my_value_id;
+                target.MyValueId = source.MyValueId;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void UpperSnakeCaseShouldPreferExactMatchOverPascalCase()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A source);",
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.UpperSnakeCase },
+            "class A { public string MY_VALUE_ID { get; set; } public string MyValueId { get; set; } }",
+            "class B { public string MY_VALUE_ID { get; set; } public string MyValueId { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.MY_VALUE_ID = source.MY_VALUE_ID;
+                target.MyValueId = source.MyValueId;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void SnakeCaseShouldMapToPascalCaseWhenNoExactMatch()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A source);",
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.SnakeCase },
+            "class A { public string FirstName { get; set; } public string LastName { get; set; } }",
+            "class B { public string first_name { get; set; } public string last_name { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.first_name = source.FirstName;
+                target.last_name = source.LastName;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void UpperSnakeCaseShouldMapToPascalCaseWhenNoExactMatch()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A source);",
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.UpperSnakeCase },
+            "class A { public string FirstName { get; set; } public string LastName { get; set; } }",
+            "class B { public string FIRST_NAME { get; set; } public string LAST_NAME { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.FIRST_NAME = source.FirstName;
+                target.LAST_NAME = source.LastName;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void SnakeCaseShouldSupportNestedPropertyFlattening()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            partial B Map(A source);
+            """,
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.SnakeCase },
+            "class A { public C my_object { get; set; } }",
+            "class B { public string my_object_child_value { get; set; } }",
+            "class C { public string child_value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.my_object_child_value = source.my_object.child_value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void UpperSnakeCaseShouldSupportNestedPropertyFlattening()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            partial B Map(A source);
+            """,
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.UpperSnakeCase },
+            "class A { public C MY_OBJECT { get; set; } }",
+            "class B { public string MY_OBJECT_CHILD_VALUE { get; set; } }",
+            "class C { public string CHILD_VALUE { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.MY_OBJECT_CHILD_VALUE = source.MY_OBJECT.CHILD_VALUE;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void SnakeCaseShouldMapExactSnakeCaseToSnakeCase()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A source);",
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.SnakeCase },
+            "class A { public string my_property_name { get; set; } public int user_id { get; set; } }",
+            "class B { public string my_property_name { get; set; } public int user_id { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.my_property_name = source.my_property_name;
+                target.user_id = source.user_id;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void UpperSnakeCaseShouldMapExactUpperSnakeCaseToUpperSnakeCase()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A source);",
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.UpperSnakeCase },
+            "class A { public string MY_PROPERTY_NAME { get; set; } public int USER_ID { get; set; } }",
+            "class B { public string MY_PROPERTY_NAME { get; set; } public int USER_ID { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.MY_PROPERTY_NAME = source.MY_PROPERTY_NAME;
+                target.USER_ID = source.USER_ID;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void SnakeCaseShouldMapPascalCaseToPascalCaseWhenNoSnakeCaseMatch()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A source);",
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.SnakeCase },
+            "class A { public string MyProperty { get; set; } public int UserId { get; set; } }",
+            "class B { public string MyProperty { get; set; } public int UserId { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.MyProperty = source.MyProperty;
+                target.UserId = source.UserId;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void UpperSnakeCaseShouldMapPascalCaseToPascalCaseWhenNoUpperSnakeCaseMatch()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A source);",
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.UpperSnakeCase },
+            "class A { public string MyProperty { get; set; } public int UserId { get; set; } }",
+            "class B { public string MyProperty { get; set; } public int UserId { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.MyProperty = source.MyProperty;
+                target.UserId = source.UserId;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void SnakeCaseShouldPreferExactMatchEvenWithPascalCaseAvailable()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A source);",
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.SnakeCase },
+            "class A { public string my_value { get; set; } }",
+            "class B { public string my_value { get; set; } public string MyValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.my_value = source.my_value;
+                target.MyValue = source.my_value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void UpperSnakeCaseShouldPreferExactMatchEvenWithPascalCaseAvailable()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A source);",
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.UpperSnakeCase },
+            "class A { public string MY_VALUE { get; set; } }",
+            "class B { public string MY_VALUE { get; set; } public string MyValue { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.MY_VALUE = source.MY_VALUE;
+                target.MyValue = source.MY_VALUE;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void SnakeCaseShouldSupportComplexNestedPropertyFlattening()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            partial B Map(A source);
+            """,
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.SnakeCase },
+            "class A { public C my_user_profile { get; set; } }",
+            "class B { public string my_user_profile_user_name { get; set; } public int my_user_profile_user_age { get; set; } }",
+            "class C { public string user_name { get; set; } public int user_age { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.my_user_profile_user_name = source.my_user_profile.user_name;
+                target.my_user_profile_user_age = source.my_user_profile.user_age;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void UpperSnakeCaseShouldSupportComplexNestedPropertyFlattening()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            partial B Map(A source);
+            """,
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.UpperSnakeCase },
+            "class A { public C MY_USER_PROFILE { get; set; } }",
+            "class B { public string MY_USER_PROFILE_USER_NAME { get; set; } public int MY_USER_PROFILE_USER_AGE { get; set; } }",
+            "class C { public string USER_NAME { get; set; } public int USER_AGE { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.MY_USER_PROFILE_USER_NAME = source.MY_USER_PROFILE.USER_NAME;
+                target.MY_USER_PROFILE_USER_AGE = source.MY_USER_PROFILE.USER_AGE;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void SnakeCasePropertyNameMappingWithAdditionalParameter()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            partial B Map(A source, int userAge);
+            """,
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.SnakeCase },
+            "class A { public string UserName { get; set; } }",
+            "class B { public string user_name { get; set; } public int user_age { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.user_name = source.UserName;
+                target.user_age = userAge;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void UpperSnakeCasePropertyNameMappingWithAdditionalParameter()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            partial B Map(A source, int userAge);
+            """,
+            new TestSourceBuilderOptions { PropertyNameMappingStrategy = PropertyNameMappingStrategy.UpperSnakeCase },
+            "class A { public string UserName { get; set; } }",
+            "class B { public string USER_NAME { get; set; } public int USER_AGE { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.USER_NAME = source.UserName;
+                target.USER_AGE = userAge;
+                return target;
+                """
+            );
     }
 }


### PR DESCRIPTION
# Add SnakeCase Property Name Mapping Strategy

## Description

This PR adds support for `SnakeCase` as a new property name mapping strategy in Mapperly, enabling automatic mapping between PascalCase properties in C# source objects and snake_case properties in target objects.

### Motivation

In modern C# development, it's common to work with external systems or code generators that produce DTOs with snake_case property names (e.g., from JSON APIs, database schemas, or code generation tools). Currently, mapping between C# PascalCase properties and snake_case properties requires manual `[MapProperty]` attributes for each property, which is tedious and error-prone for large objects.

This feature is particularly valuable when:
- Working with auto-generated C# DTOs from external contracts that use snake_case naming
- Integrating with APIs that follow snake_case conventions (common in Python, Ruby, or REST APIs)
- The source contracts cannot be modified due to external dependencies or architectural constraints

### Changes Made

- Added `SnakeCase` enum value to `PropertyNameMappingStrategy` with XML documentation
- Implemented snake_case to PascalCase conversion for property matching in `MemberPathCandidateBuilder`
- Updated `MemberPathCandidateBuilder` with new overload supporting naming strategies
- Modified `MembersMappingBuilderContext` to use SnakeCase strategy when configured
- Updated PublicAPI snapshot to reflect new enum value
- Added comprehensive test case for SnakeCase property mapping validation

### Usage Example

```csharp
[Mapper(PropertyNameMappingStrategy = PropertyNameMappingStrategy.SnakeCase)]
public partial class MyMapper
{
    public partial TargetDto Map(SourceDto source);
}

// Maps automatically:
// source.FirstName -> target.first_name
// source.LastName -> target.last_name
```

This allows developers to map properties between PascalCase source objects and snake_case target objects (e.g., `FirstName` -> `first_name`) by simply setting `PropertyNameMappingStrategy = PropertyNameMappingStrategy.SnakeCase`.

Fixes # (issue - if applicable)

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [ ] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [ ] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)