### PR TITLE
feat: Optimize source generation by using GetText

### DIFF
--- a/src/Riok.Mapperly/Helpers/IncrementalValuesProviderExtensions.cs
+++ b/src/Riok.Mapperly/Helpers/IncrementalValuesProviderExtensions.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
 using Riok.Mapperly.Output;
 
 namespace Riok.Mapperly.Helpers;


### PR DESCRIPTION
# Optimize source generation by using GetText

## Description

This is a small improvement I wished to send in for a while:
This way of the source text generation is better, since it internally contains a decision: if the output size is larger than the Large Object Heap limit, then it uses `LargeTextWriter`, which breaks the source apart, so the LOH allocation is avoided. On the benchmark, there is no visible change, but I think it is worth it.

Fixes # (issue)

## Checklist

- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [ ] Hard-to-understand areas of my code are commented
- [ ] The documentation is updated (as applicable)
- [ ] Unit tests are added/updated
- [ ] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
