### PR TITLE
fix: add support for reserved keyword labels in mapping parameters

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingState.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingState.cs
@@ -210,7 +210,8 @@ internal class MembersMappingState(
                 _unmappedSourceMemberNames.Remove(sourceMember.Name);
                 break;
             case SourceMemberType.AdditionalMappingMethodParameter:
-                _unmappedAdditionalSourceMemberNames.Remove(sourceMember.Name);
+                // trim verbatim identifier prefix
+                _unmappedAdditionalSourceMemberNames.Remove(sourceMember.Name.TrimStart('@'));
                 break;
         }
     }

--- a/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.cs
+++ b/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.cs
@@ -116,8 +116,15 @@ public readonly partial struct SyntaxFactoryHelper(SupportedFeatures supportedFe
         return LocalDeclarationStatement(variableDeclaration).AddLeadingLineFeed(Indentation);
     }
 
-    public static NameColonSyntax SpacedNameColon(string name) =>
-        NameColon(IdentifierName(name), TrailingSpacedToken(SyntaxKind.ColonToken));
+    public static NameColonSyntax SpacedNameColon(string name)
+    {
+        if (SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None)
+        {
+            name = "@" + name;
+        }
+
+        return NameColon(IdentifierName(name), TrailingSpacedToken(SyntaxKind.ColonToken));
+    }
 
     private static IEnumerable<SyntaxNodeOrToken> Join(SyntaxToken sep, bool insertTrailingSeparator, IEnumerable<SyntaxNode> nodes)
     {

--- a/test/Riok.Mapperly.Tests/Mapping/MapperTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/MapperTest.cs
@@ -172,11 +172,4 @@ public class MapperTest
 
         return TestHelper.VerifyGenerator(source);
     }
-
-    [Fact]
-    public void RestrictedKeywordParametersShouldBeEscaped()
-    {
-        var source = TestSourceBuilder.MapperWithBody("public partial string Map(int @object);");
-        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return @object.ToString();");
-    }
 }

--- a/test/Riok.Mapperly.Tests/Mapping/ReservedKeywordTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ReservedKeywordTest.cs
@@ -1,0 +1,97 @@
+using Riok.Mapperly.Abstractions;
+
+namespace Riok.Mapperly.Tests.Mapping;
+
+public class ReservedKeywordTest
+{
+    [Fact]
+    public void ReservedKeywordInCtorArgumentShouldBeEscaped()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.WithRequiredMappingStrategy(RequiredMappingStrategy.Source),
+            """
+            class A
+            {
+                public bool Private { get; set; }
+            }
+            """,
+            """
+            class B
+            {
+                public B(string? remark = null, bool @private = false)
+                {
+                    Remark = remark;
+                    Private = @private;
+                }
+
+                public bool Private { get; set; }
+                public string? Remark { get; set; }
+            }
+            """
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B(@private: source.Private);
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ReservedKeywordInSourceParameterShouldBeEscaped()
+    {
+        var source = TestSourceBuilder.MapperWithBody("public partial string Map(int @object);");
+        TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return @object.ToString();");
+    }
+
+    [Fact]
+    public void ReservedKeywordInSourceParameterOfObjectMappingShouldBeEscaped()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A @event);",
+            "class A { public int Value { get; set; } }",
+            "class B { public int Value { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                target.Value = @event.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ReservedKeywordInAdditionalParameterShouldBeEscaped()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "partial B Map(A src, int @event);",
+            "class A { public string StringValue { get; set; } }",
+            "class B { public string StringValue { get; set; } public int Event { get; init; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B()
+                {
+                    Event = @event,
+                };
+                target.StringValue = src.StringValue;
+                return target;
+                """
+            );
+    }
+}


### PR DESCRIPTION
* fixes the usage of reserved keywords in additional mapping parameters
* fixes the usage of reserved keywords in constructor argument labels

Fixes #2128 