### PR TITLE
fix: [MapperConstructor] overrides copy constructor selection (#2196)

### DIFF
--- a/docs/docs/breaking-changes/5-0.md
+++ b/docs/docs/breaking-changes/5-0.md
@@ -18,34 +18,7 @@ description: How to upgrade to Mapperly 5.0 and a list of all its breaking chang
 - Inaccessible members from other assemblies are now included in the mapping process if `IncludedMembers` or `IncludedConstructors` options are configured to include them.
 - Constructor mappings with nullable source types no longer generate null guards when the constructor parameter accepts null, see below.
 - `MaybeNull` attributes are now respected for fields, properties and constructor parameters.
-
-## Constructor mappings with nullable source skip null guard
-
-When mapping a nullable source type to a target type via a single-parameter constructor,
-Mapperly previously always generated a null guard (throwing `ArgumentNullException` or using a fallback value).
-Starting with v5.0, if the constructor parameter accepts the nullable source type, Mapperly passes the value directly without a null guard.
-
-Previously:
-
-```csharp
-public record Dto(int[]? Array);
-
-// Generated:
-public partial Dto Map(int[]? source)
-{
-    return source == null ? throw new ArgumentNullException(nameof(source)) : new Dto(source);
-}
-```
-
-Now:
-
-```csharp
-// Generated:
-public partial Dto Map(int[]? source)
-{
-    return new Dto(source);
-}
-```
+- Copy constructors are no longer selected over constructors annotated with `[MapperConstructor]` or when `[MapProperty]` configurations are present.
 
 ## Inaccessible members from other assemblies included
 
@@ -174,3 +147,74 @@ Which will result in:
 ```
 
 See also the [full-nameof documentation](../configuration/full-nameof.md).
+
+## Constructor mappings with nullable source skip null guard
+
+When mapping a nullable source type to a target type via a single-parameter constructor,
+Mapperly previously always generated a null guard (throwing `ArgumentNullException` or using a fallback value).
+Starting with v5.0, if the constructor parameter accepts the nullable source type, Mapperly passes the value directly without a null guard.
+
+Previously:
+
+```csharp
+public record Dto(int[]? Array);
+
+// Generated:
+public partial Dto Map(int[]? source)
+{
+    return source == null ? throw new ArgumentNullException(nameof(source)) : new Dto(source);
+}
+```
+
+Now:
+
+```csharp
+// Generated:
+public partial Dto Map(int[]? source)
+{
+    return new Dto(source);
+}
+```
+
+## Constructor selection
+
+Previously, when a type had a copy constructor (a single-parameter constructor accepting the same type),
+Mapperly always used it, even when `[MapperConstructor]` was placed on a different constructor or `[MapProperty]` configurations were present.
+This caused `[MapProperty(Use = ...)]` annotations to be silently ignored.
+
+Starting with v5.0, copy constructors are skipped when:
+
+- `[MapperConstructor]` is placed on a different constructor.
+- `[MapProperty]` configurations are present on a same-type mapping (e.g. deep cloning with property transformations).
+
+Previously:
+
+```csharp
+public class Document
+{
+    [MapperConstructor]
+    public Document() { }
+    public Document(Document other) { Title = other.Title; }
+    public string Title { get; init; }
+}
+
+// Generated (copy constructor used, [MapperConstructor] ignored):
+public partial Document Clone(Document source)
+{
+    return new Document(source);
+}
+```
+
+Now:
+
+```csharp
+// Generated ([MapperConstructor] respected):
+public partial Document Clone(Document source)
+{
+    var target = new Document()
+    {
+        Title = source.Title,
+    };
+    return target;
+}
+```

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/CtorMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/CtorMappingBuilder.cs
@@ -18,11 +18,22 @@ public static class CtorMappingBuilder
         if (ctx.Target.TryGetNonNullable(out _))
             return null;
 
+        // If e member mappings are configured (e.g. [MapProperty]),
+        // do not use it as it bypasses property-by-property mapping
+        if (ctx.Configuration.Members.ExplicitMappings.Count > 0)
+            return null;
+
         if (ctx.Target is not INamedTypeSymbol namedTarget)
             return null;
 
+        // resolve ctors which have the source as single argument
         var ctor = FindSingleArgCtor(namedTarget, ctx.Source, ctx.SymbolAccessor);
         if (ctor == null)
+            return null;
+
+        // if another constructor is explicitly marked with [MapperConstructor],
+        // do not use the copy constructor and let the member mapping builder handle it
+        if (HasMapperConstructorOnDifferentCtor(namedTarget, ctor, ctx.SymbolAccessor))
             return null;
 
         return new CtorMapping(ctx.Source, ctx.Target, ctx.InstanceConstructors.BuildForConstructor(ctor));
@@ -36,9 +47,19 @@ public static class CtorMappingBuilder
         if (ctx.Target is not INamedTypeSymbol namedTarget)
             return null;
 
+        // If e member mappings are configured (e.g. [MapProperty]),
+        // do not use it as it bypasses property-by-property mapping
+        if (ctx.Configuration.Members.ExplicitMappings.Count > 0)
+            return null;
+
         // resolve ctors which have the source as single argument
         var ctor = FindSingleArgCtor(namedTarget, ctx.Source, ctx.SymbolAccessor);
         if (ctor == null)
+            return null;
+
+        // if another constructor is explicitly marked with [MapperConstructor],
+        // do not use the copy constructor and let the member mapping builder handle it
+        if (HasMapperConstructorOnDifferentCtor(namedTarget, ctor, ctx.SymbolAccessor))
             return null;
 
         return new CtorMapping(ctx.Source, ctx.Target, ctx.InstanceConstructors.BuildForConstructor(ctor));
@@ -52,4 +73,13 @@ public static class CtorMappingBuilder
                 && SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type.NonNullable(), sourceType.NonNullable())
                 && sourceType.HasSameOrStricterNullability(m.Parameters[0].Type)
             );
+
+    private static bool HasMapperConstructorOnDifferentCtor(
+        INamedTypeSymbol target,
+        IMethodSymbol copyCtor,
+        SymbolAccessor symbolAccessor
+    ) =>
+        target.InstanceConstructors.Any(ctor =>
+            !SymbolEqualityComparer.Default.Equals(ctor, copyCtor) && symbolAccessor.HasAttribute<MapperConstructorAttribute>(ctor)
+        );
 }

--- a/test/Riok.Mapperly.Tests/Mapping/CtorTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/CtorTest.cs
@@ -183,4 +183,186 @@ public class CtorTest
         var source = TestSourceBuilder.Mapping("A?", "B", "class A { }", "class B { public B(A? a) {} }");
         TestHelper.GenerateMapper(source).Should().HaveSingleMethodBody("return new global::B(source);");
     }
+
+    [Fact]
+    public void DeepCloneClassWithCopyCtorAndMapperConstructorShouldUseAttributedCtor()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapProperty(nameof(A.Value), nameof(A.Value), Use = nameof(Transform))]
+            public partial A Clone(A source);
+
+            [UserMapping(Default = false)]
+            private string Transform(string value) => $"transformed-{value}";
+            """,
+            TestSourceBuilderOptions.WithDeepCloning,
+            """
+            class A
+            {
+                [MapperConstructor]
+                public A() { }
+                public A(A other) { Value = other.Value; }
+                public required string Value { get; init; }
+            }
+            """
+        );
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::A()
+                {
+                    Value = Transform(source.Value),
+                };
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MapperConstructorShouldOverrideCopyCtorWithoutDeepCloning()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            """
+            class A
+            {
+                public int Value { get; set; }
+            }
+            """,
+            """
+            class B
+            {
+                [MapperConstructor]
+                public B() { }
+                public B(A other) { Value = other.Value; }
+                public int Value { get; set; }
+            }
+            """
+        );
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MapPropertyShouldOverrideCopyCtorSelection()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapProperty(nameof(A.Value), nameof(A.Value), Use = nameof(Transform))]
+            public partial A Clone(A source);
+
+            [UserMapping(Default = false)]
+            private string Transform(string value) => $"transformed-{value}";
+            """,
+            TestSourceBuilderOptions.WithDeepCloning,
+            """
+            class A
+            {
+                public A() { }
+                public A(A other) { Value = other.Value; }
+                public required string Value { get; init; }
+            }
+            """
+        );
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::A()
+                {
+                    Value = Transform(source.Value),
+                };
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void NullableSourceMapperConstructorShouldOverrideCopyCtorSelection()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "public partial B Map(A? source);",
+            """
+            class A
+            {
+                public int Value { get; set; }
+            }
+            """,
+            """
+            class B
+            {
+                [MapperConstructor]
+                public B() { }
+                public B(A value) { Value = value.Value; }
+                public int Value { get; set; }
+            }
+            """
+        );
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                if (source == null)
+                    throw new global::System.ArgumentNullException(nameof(source));
+                var target = new global::B();
+                target.Value = source.Value;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void NullableSourceMapPropertyShouldOverrideCopyCtorSelection()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapProperty(nameof(A.Value), nameof(B.Value), Use = nameof(Transform))]
+            public partial B Map(A? source);
+
+            [UserMapping(Default = false)]
+            private string Transform(string value) => $"transformed-{value}";
+            """,
+            """
+            class A
+            {
+                public required string Value { get; init; }
+            }
+            """,
+            """
+            class B
+            {
+                public B() { }
+                public B(A value) { Value = value.Value; }
+                public required string Value { get; init; }
+            }
+            """
+        );
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                if (source == null)
+                    throw new global::System.ArgumentNullException(nameof(source));
+                var target = new global::B()
+                {
+                    Value = Transform(source.Value),
+                };
+                return target;
+                """
+            );
+    }
 }

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFromSourceTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFromSourceTest.cs
@@ -137,7 +137,29 @@ public class ObjectPropertyFromSourceTest
             .Should()
             .HaveSingleMethodBody(
                 """
-                return new global::B(source);
+                var target = new global::B(source);
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ToConstructorParameterWithProperties()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapPropertyFromSource(\"value\")] partial B Map(A source);",
+            "class A { public int IntValue { get; set; } public int IntValue2 { get; set;} }",
+            "class B { public B(A value, int intValue) { public int IntValue2 { get; set; } } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B(source, source.IntValue);
+                target.IntValue2 = source.IntValue2;
+                return target;
                 """
             );
     }


### PR DESCRIPTION
Fixes https://github.com/riok/mapperly/issues/2196