### PR TITLE
fix: do not emit RMG012 for getter-only target members with queryable projections

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
@@ -104,7 +104,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
             return;
 
         var initOnlyTargetMembers = includeAllMembers
-            ? ctx.EnumerateUnmappedTargetMembers().Where(x => x.CanSet || x.CanOnlySetViaInitializer()).ToArray()
+            ? ctx.EnumerateUnmappedTargetMembers().Where(x => x.CanSet).ToArray()
             : ctx.EnumerateUnmappedTargetMembers().Where(x => x.CanOnlySetViaInitializer()).ToArray();
         foreach (var targetMember in initOnlyTargetMembers)
         {

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/NewInstanceObjectMemberMappingBodyBuilder.cs
@@ -104,7 +104,7 @@ public static class NewInstanceObjectMemberMappingBodyBuilder
             return;
 
         var initOnlyTargetMembers = includeAllMembers
-            ? ctx.EnumerateUnmappedTargetMembers().ToArray()
+            ? ctx.EnumerateUnmappedTargetMembers().Where(x => x.CanSet || x.CanOnlySetViaInitializer()).ToArray()
             : ctx.EnumerateUnmappedTargetMembers().Where(x => x.CanOnlySetViaInitializer()).ToArray();
         foreach (var targetMember in initOnlyTargetMembers)
         {

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyTest.cs
@@ -120,6 +120,21 @@ public class ObjectPropertyTest
     }
 
     [Fact]
+    public void ShouldIgnoreReadOnlyPropertyWithProjection()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            partial System.Linq.IQueryable<B> ProjectToB(System.Linq.IQueryable<A> q);
+            partial B MapToB(A source);
+            """,
+            "class A { public string FirstName { get; set; } public string LastName { get; set; } }",
+            """class B { public string FirstName { get; set; } public string LastName { get; set; } public string FullName => FirstName + " " + LastName; }"""
+        );
+
+        TestHelper.GenerateMapper(source, TestHelperOptions.AllowAndIncludeAllDiagnostics).Should().HaveAssertedAllDiagnostics();
+    }
+
+    [Fact]
     public void ShouldIgnoreIndexedProperty()
     {
         var source = TestSourceBuilder.Mapping(


### PR DESCRIPTION
# Do not emit RMG012 for getter-only target members with queryable projections

## Description

When a mapper has a queryable projection and getter-only properties (expression-bodied or { get; }) Mapperly is incorrectly triggering RMG012. BuildInitMemberMappings included all target members in expression context without checking if they could actually be set.

Fixes #2226

## Checklist

- [x] I did not use AI tools to generate this PR, or I have manually verified that the code is correct, optimal, and follows the project guidelines and architecture
- [x] I understand that low-quality, AI-generated PRs will be closed immediately without further explanation
- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [ ] Hard-to-understand areas of my code are commented
- [ ] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [ ] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
