### PR TITLE
fix: generic and runtime target type mappings with derived types

### DIFF
--- a/docs/docs/breaking-changes/5-0.md
+++ b/docs/docs/breaking-changes/5-0.md
@@ -20,6 +20,7 @@ description: How to upgrade to Mapperly 5.0 and a list of all its breaking chang
 - `MaybeNull` attributes are now respected for fields, properties and constructor parameters when reading values.
 - `AllowNull` attributes are now respected for fields, properties and constructor parameters when writing values.
 - Copy constructors are no longer selected over constructors annotated with `[MapperConstructor]` or when `[MapProperty]` configurations are present.
+- Generic and runtime target type mappings now correctly match derived types handled by a child `[MapDerivedType]` mapping.
 
 ## Inaccessible members from other assemblies included
 
@@ -217,5 +218,112 @@ public partial Document Clone(Document source)
         Title = source.Title,
     };
     return target;
+}
+```
+
+## Generic and runtime target type mappings with derived type child mappings
+
+When a child mapping (mapping method with a `[MapDerivedType]` attribute) was used inside a
+generic or runtime target type mapping, the type matching did not work for certain scenarios and
+threw an `ArgumentException`.
+
+This was caused by an inverted assignability check in the generated code,
+preventing proper type resolution when mapping to a specific derived target type.
+
+Example:
+
+```csharp
+[Mapper]
+public partial class MyMapper
+{
+    public partial T MapGeneric<T>(object source);
+
+    public partial object MapRuntimeTargetType(object source, Type targetType);
+
+    [MapDerivedType<Banana, BananaDto>]
+    public partial FruitDto MapDerivedTypes(Fruit source);
+}
+
+public class Fruit : Organic {}
+public class Banana: Fruit {}
+public class FruitDto {}
+public class BananaDto : FruitDto {}
+```
+
+Executing the mapping below failed before:
+
+```csharp
+var mapper = new MyMapper();
+var banana = new Banana { Bar = "Banana Bar" };
+
+// throws ArgumentException: Cannot map Banana to BananaDto as there is no known type mapping
+var dto = mapper.MapGeneric<BananaDto>(banana);
+```
+
+Previously:
+
+```csharp
+// Generated
+public partial T MapGeneric<T>(object source)
+{
+    return source switch
+    {
+        global::Fruit x when typeof(T).IsAssignableFrom(typeof(global::FruitDto)) => (T)(object)MapDerivedTypes(x),
+        _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to {typeof(T)} as there is no known type mapping", nameof(source)),
+    };
+}
+
+// Generated
+public partial object MapRuntimeTargetType(object source, global::System.Type targetType)
+{
+    return source switch
+    {
+        global::Fruit x when targetType.IsAssignableFrom(typeof(global::FruitDto)) => MapDerivedTypes(x),
+        _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to {targetType} as there is no known type mapping", nameof(source)),
+    };
+}
+
+// Generated
+public partial global::FruitDto MapDerivedTypes(global::Fruit source)
+{
+    return source switch
+    {
+        global::Banana x => MapToBananaDto(x),
+        _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to FruitDto as there is no known derived type mapping", nameof(source)),
+    };
+}
+```
+
+Now:
+
+```csharp
+// Generated
+public partial T MapGeneric<T>(object source)
+{
+    return source switch
+    {
+        global::Fruit x when typeof(global::FruitDto).IsAssignableFrom(typeof(T)) => (T)(object)MapDerivedTypes(x),
+        _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to {typeof(T)} as there is no known type mapping", nameof(source)),
+    };
+}
+
+// Generated
+public partial object MapRuntimeTargetType(object source, global::System.Type targetType)
+{
+    return source switch
+    {
+        global::Fruit x when typeof(global::FruitDto).IsAssignableFrom(targetType) => MapDerivedTypes(x),
+        _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to {targetType} as there is no known type mapping", nameof(source)),
+    };
+}
+
+// Generated
+public partial global::FruitDto MapDerivedTypes(global::Fruit source)
+{
+    return source switch
+    {
+        global::Banana x => MapToBananaDto(x),
+        _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to FruitDto as there is no known derived type mapping", nameof(source)),
+    };
 }
 ```

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/RuntimeTargetTypeMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/RuntimeTargetTypeMappingBodyBuilder.cs
@@ -119,7 +119,11 @@ public static class RuntimeTargetTypeMappingBodyBuilder
             .ThenBy(x => x.TargetType.IsNullable())
             .GroupBy(x => new TypeMappingKey(x, includeNullability: false))
             .Select(x => x.First())
-            .Select(x => new RuntimeTargetTypeMapping(x, ctx.Compilation.HasImplicitConversion(x.TargetType, ctx.Target)))
+            .Select(x => new RuntimeTargetTypeMapping(
+                x,
+                ctx.Compilation.HasImplicitConversion(x.TargetType, ctx.Target),
+                (x as UserDefinedNewInstanceMethodMapping)?.IsDerivedTypeMapping == true
+            ))
             .ToList();
 
         if (runtimeTargetTypeMappings.Count == 0)

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/RuntimeTargetTypeMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/RuntimeTargetTypeMappingBodyBuilder.cs
@@ -119,7 +119,11 @@ public static class RuntimeTargetTypeMappingBodyBuilder
             .ThenBy(x => x.TargetType.IsNullable())
             .GroupBy(x => new TypeMappingKey(x, includeNullability: false))
             .Select(x => x.First())
-            .Select(x => new RuntimeTargetTypeMapping(x, ctx.Compilation.HasImplicitConversion(x.TargetType, ctx.Target)))
+            .Select(x => new RuntimeTargetTypeMapping(
+                x,
+                ctx.Compilation.HasImplicitConversion(x.TargetType, ctx.Target),
+                x is UserDefinedNewInstanceMethodMapping { IsDerivedTypeMapping: true }
+            ))
             .ToList();
 
         if (runtimeTargetTypeMappings.Count == 0)

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceMethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceMethodMapping.cs
@@ -15,12 +15,15 @@ public class UserDefinedNewInstanceMethodMapping(
     MethodParameter sourceParameter,
     MethodParameter? referenceHandlerParameter,
     ITypeSymbol targetType,
-    bool enableReferenceHandling
+    bool enableReferenceHandling,
+    bool isDerivedTypeMapping
 ) : NewInstanceMethodMapping(method, sourceParameter, referenceHandlerParameter, targetType), INewInstanceUserMapping
 {
     private INewInstanceMapping? _delegateMapping;
 
     public new IMethodSymbol Method { get; } = method;
+
+    public bool IsDerivedTypeMapping => isDerivedTypeMapping;
 
     private MethodMapping? DelegateMethodMapping => _delegateMapping as MethodMapping;
 

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceRuntimeTargetTypeMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceRuntimeTargetTypeMapping.cs
@@ -91,10 +91,16 @@ public abstract class UserDefinedNewInstanceRuntimeTargetTypeMapping(
 
     protected virtual ExpressionSyntax? BuildSwitchArmWhenClause(ExpressionSyntax runtimeTargetType, RuntimeTargetTypeMapping mapping)
     {
-        // targetType.IsAssignableFrom(typeof(ADto))
+        var mappingTargetType = TypeOfExpression(FullyQualifiedIdentifier(mapping.Mapping.TargetType.NonNullable()));
+
+        // Derived type mapping: A => ADto (runtime target type) or A => BaseDto (runtime target type), BaseDto (mapping target type).
+        // typeof(BaseDto).IsAssignableFrom(runtimeTargetType)
+
+        // Non-derived type mapping: A => ADto (runtime target type) or A => BaseDto (runtime target type), ADto (mapping target type).
+        // runtimeTargetType.IsAssignableFrom(ADto)
         return InvocationWithoutIndention(
-            MemberAccess(runtimeTargetType, IsAssignableFromMethodName),
-            TypeOfExpression(FullyQualifiedIdentifier(mapping.Mapping.TargetType.NonNullable()))
+            MemberAccess(mapping.IsDerivedTypeMapping ? mappingTargetType : runtimeTargetType, IsAssignableFromMethodName),
+            mapping.IsDerivedTypeMapping ? runtimeTargetType : mappingTargetType
         );
     }
 

--- a/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceRuntimeTargetTypeMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/UserMappings/UserDefinedNewInstanceRuntimeTargetTypeMapping.cs
@@ -91,10 +91,16 @@ public abstract class UserDefinedNewInstanceRuntimeTargetTypeMapping(
 
     protected virtual ExpressionSyntax? BuildSwitchArmWhenClause(ExpressionSyntax runtimeTargetType, RuntimeTargetTypeMapping mapping)
     {
-        // targetType.IsAssignableFrom(typeof(ADto))
+        var mappingTargetType = TypeOfExpression(FullyQualifiedIdentifier(mapping.Mapping.TargetType.NonNullable()));
+
+        // Derived type mapping: A => ADto (runtimeTargetType) or A => BaseDto (runtimeTargetType), BaseDto (mappingTargetType).
+        // typeof(BaseDto).IsAssignableFrom(runtimeTargetType)
+
+        // Non-derived type mapping: A => ADto (runtimeTargetType) or A => BaseDto (runtimeTargetType), ADto (mappingTargetType).
+        // runtimeTargetType.IsAssignableFrom(ADto)
         return InvocationWithoutIndention(
-            MemberAccess(runtimeTargetType, IsAssignableFromMethodName),
-            TypeOfExpression(FullyQualifiedIdentifier(mapping.Mapping.TargetType.NonNullable()))
+            MemberAccess(mapping.IsDerivedTypeMapping ? mappingTargetType : runtimeTargetType, IsAssignableFromMethodName),
+            mapping.IsDerivedTypeMapping ? runtimeTargetType : mappingTargetType
         );
     }
 

--- a/src/Riok.Mapperly/Descriptors/UserMethodMappingExtractor.cs
+++ b/src/Riok.Mapperly/Descriptors/UserMethodMappingExtractor.cs
@@ -338,7 +338,8 @@ public static class UserMethodMappingExtractor
             parameters.Source,
             parameters.ReferenceHandler,
             ctx.SymbolAccessor.UpgradeNullable(methodSymbol.ReturnType),
-            ctx.Configuration.Mapper.UseReferenceHandling
+            ctx.Configuration.Mapper.UseReferenceHandling,
+            ctx.AttributeAccessor.HasAttribute<MapDerivedTypeAttribute<object, object>>(methodSymbol)
         )
         {
             AdditionalSourceParameters = parameters.AdditionalParameters,

--- a/src/Riok.Mapperly/Descriptors/UserMethodMappingExtractor.cs
+++ b/src/Riok.Mapperly/Descriptors/UserMethodMappingExtractor.cs
@@ -340,7 +340,9 @@ public static class UserMethodMappingExtractor
             parameters.Source,
             parameters.ReferenceHandler,
             ctx.SymbolAccessor.UpgradeNullable(methodSymbol.ReturnType),
-            ctx.Configuration.Mapper.UseReferenceHandling
+            ctx.Configuration.Mapper.UseReferenceHandling,
+            ctx.AttributeAccessor.HasAttribute<MapDerivedTypeAttribute<object, object>>(methodSymbol)
+                || ctx.AttributeAccessor.HasAttribute<MapDerivedTypeAttribute>(methodSymbol)
         )
         {
             AdditionalSourceParameters = parameters.AdditionalParameters,

--- a/src/Riok.Mapperly/Symbols/RuntimeTargetTypeMapping.cs
+++ b/src/Riok.Mapperly/Symbols/RuntimeTargetTypeMapping.cs
@@ -2,4 +2,4 @@ using Riok.Mapperly.Descriptors.Mappings;
 
 namespace Riok.Mapperly.Symbols;
 
-public record RuntimeTargetTypeMapping(INewInstanceMapping Mapping, bool IsAssignableToMethodTargetType);
+public record RuntimeTargetTypeMapping(INewInstanceMapping Mapping, bool IsAssignableToMethodTargetType, bool IsDerivedTypeMapping);

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -767,7 +767,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 global::Riok.Mapperly.IntegrationTests.Models.AssemblyScopedModel x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.AssemblyScopedDto)) => global::Riok.Mapperly.IntegrationTests.Mapper.AssemblyScopedMappers.ToDto(x),
                 global::System.Collections.Generic.IReadOnlyCollection<global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyCollection<string>>> x when targetType.IsAssignableFrom(typeof(global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyCollection<int>>>)) => MapNestedLists(x),
                 global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Models.TestObject> x when targetType.IsAssignableFrom(typeof(global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto>)) => MapAllDtos(x),
-                object x when targetType.IsAssignableFrom(typeof(object)) => DerivedTypes(x),
+                object x when typeof(object).IsAssignableFrom(targetType) => DerivedTypes(x),
                 _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to {targetType} as there is no known type mapping", nameof(source)),
             };
         }
@@ -794,7 +794,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 global::Riok.Mapperly.IntegrationTests.Models.AssemblyScopedModel x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.AssemblyScopedDto)) => global::Riok.Mapperly.IntegrationTests.Mapper.AssemblyScopedMappers.ToDto(x),
                 global::System.Collections.Generic.IReadOnlyCollection<global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyCollection<string>>> x when targetType.IsAssignableFrom(typeof(global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyCollection<int>>>)) => MapNestedLists(x),
                 global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Models.TestObject> x when targetType.IsAssignableFrom(typeof(global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto>)) => MapAllDtos(x),
-                object x when targetType.IsAssignableFrom(typeof(object)) => DerivedTypes(x),
+                object x when typeof(object).IsAssignableFrom(targetType) => DerivedTypes(x),
                 null => default,
                 _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to {targetType} as there is no known type mapping", nameof(source)),
             };
@@ -822,7 +822,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 global::Riok.Mapperly.IntegrationTests.Models.AssemblyScopedModel x when typeof(TTarget).IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.AssemblyScopedDto)) => (TTarget)(object)global::Riok.Mapperly.IntegrationTests.Mapper.AssemblyScopedMappers.ToDto(x),
                 global::System.Collections.Generic.IReadOnlyCollection<global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyCollection<string>>> x when typeof(TTarget).IsAssignableFrom(typeof(global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyCollection<int>>>)) => (TTarget)(object)MapNestedLists(x),
                 global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Models.TestObject> x when typeof(TTarget).IsAssignableFrom(typeof(global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto>)) => (TTarget)(object)MapAllDtos(x),
-                object x when typeof(TTarget).IsAssignableFrom(typeof(object)) => (TTarget)(object)DerivedTypes(x),
+                object x when typeof(object).IsAssignableFrom(typeof(TTarget)) => (TTarget)(object)DerivedTypes(x),
                 null => throw new global::System.ArgumentNullException(nameof(source)),
                 _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to {typeof(TTarget)} as there is no known type mapping", nameof(source)),
             };

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
@@ -790,7 +790,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 global::Riok.Mapperly.IntegrationTests.Models.AssemblyScopedModel x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.AssemblyScopedDto)) => global::Riok.Mapperly.IntegrationTests.Mapper.AssemblyScopedMappers.ToDto(x),
                 global::System.Collections.Generic.IReadOnlyCollection<global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyCollection<string>>> x when targetType.IsAssignableFrom(typeof(global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyCollection<int>>>)) => MapNestedLists(x),
                 global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Models.TestObject> x when targetType.IsAssignableFrom(typeof(global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto>)) => MapAllDtos(x),
-                object x when targetType.IsAssignableFrom(typeof(object)) => DerivedTypes(x),
+                object x when typeof(object).IsAssignableFrom(targetType) => DerivedTypes(x),
                 _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to {targetType} as there is no known type mapping", nameof(source)),
             };
         }
@@ -817,7 +817,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 global::Riok.Mapperly.IntegrationTests.Models.AssemblyScopedModel x when targetType.IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.AssemblyScopedDto)) => global::Riok.Mapperly.IntegrationTests.Mapper.AssemblyScopedMappers.ToDto(x),
                 global::System.Collections.Generic.IReadOnlyCollection<global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyCollection<string>>> x when targetType.IsAssignableFrom(typeof(global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyCollection<int>>>)) => MapNestedLists(x),
                 global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Models.TestObject> x when targetType.IsAssignableFrom(typeof(global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto>)) => MapAllDtos(x),
-                object x when targetType.IsAssignableFrom(typeof(object)) => DerivedTypes(x),
+                object x when typeof(object).IsAssignableFrom(targetType) => DerivedTypes(x),
                 null => default,
                 _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to {targetType} as there is no known type mapping", nameof(source)),
             };
@@ -845,7 +845,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 global::Riok.Mapperly.IntegrationTests.Models.AssemblyScopedModel x when typeof(TTarget).IsAssignableFrom(typeof(global::Riok.Mapperly.IntegrationTests.Dto.AssemblyScopedDto)) => (TTarget)(object)global::Riok.Mapperly.IntegrationTests.Mapper.AssemblyScopedMappers.ToDto(x),
                 global::System.Collections.Generic.IReadOnlyCollection<global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyCollection<string>>> x when typeof(TTarget).IsAssignableFrom(typeof(global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyCollection<int>>>)) => (TTarget)(object)MapNestedLists(x),
                 global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Models.TestObject> x when typeof(TTarget).IsAssignableFrom(typeof(global::System.Collections.Generic.IEnumerable<global::Riok.Mapperly.IntegrationTests.Dto.TestObjectDto>)) => (TTarget)(object)MapAllDtos(x),
-                object x when typeof(TTarget).IsAssignableFrom(typeof(object)) => (TTarget)(object)DerivedTypes(x),
+                object x when typeof(object).IsAssignableFrom(typeof(TTarget)) => (TTarget)(object)DerivedTypes(x),
                 null => throw new global::System.ArgumentNullException(nameof(source)),
                 _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to {typeof(TTarget)} as there is no known type mapping", nameof(source)),
             };

--- a/test/Riok.Mapperly.Tests/Mapping/GenericDerivedTypeTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/GenericDerivedTypeTest.cs
@@ -29,7 +29,7 @@ public class GenericDerivedTypeTest
                 """
                 return source switch
                 {
-                    global::Base x when typeof(TTarget).IsAssignableFrom(typeof(global::BaseDto)) => (TTarget)(object)MapDerivedTypes(x),
+                    global::Base x when typeof(global::BaseDto).IsAssignableFrom(typeof(TTarget)) => (TTarget)(object)MapDerivedTypes(x),
                     null => throw new global::System.ArgumentNullException(nameof(source)),
                     _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to {typeof(TTarget)} as there is no known type mapping", nameof(source)),
                 };

--- a/test/Riok.Mapperly.Tests/Mapping/RuntimeTargetTypeMappingTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/RuntimeTargetTypeMappingTest.cs
@@ -165,7 +165,7 @@ public class RuntimeTargetTypeMappingTest
                 """
                 return source switch
                 {
-                    global::Base x when targetType.IsAssignableFrom(typeof(global::BaseDto)) => MapDerivedTypes(x),
+                    global::Base x when typeof(global::BaseDto).IsAssignableFrom(targetType) => MapDerivedTypes(x),
                     _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to {targetType} as there is no known type mapping", nameof(source)),
                 };
                 """

--- a/test/Riok.Mapperly.Tests/Mapping/RuntimeTargetTypeMappingTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/RuntimeTargetTypeMappingTest.cs
@@ -165,7 +165,39 @@ public class RuntimeTargetTypeMappingTest
                 """
                 return source switch
                 {
-                    global::Base x when targetType.IsAssignableFrom(typeof(global::BaseDto)) => MapDerivedTypes(x),
+                    global::Base x when typeof(global::BaseDto).IsAssignableFrom(targetType) => MapDerivedTypes(x),
+                    _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to {targetType} as there is no known type mapping", nameof(source)),
+                };
+                """
+            );
+    }
+
+    [Fact]
+    public void WithDerivedTypesUsingTypeOfArgumentsShouldUseBaseType()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            public partial object Map(object source, Type targetType);
+
+            [MapDerivedType(typeof(A), typeof(B))]
+            [MapDerivedType(typeof(C), typeof(D))]
+            partial BaseDto MapDerivedTypes(Base source);
+            """,
+            "class Base {}",
+            "class BaseDto {}",
+            "class A : Base {}",
+            "class B : BaseDto {}",
+            "class C : Base {}",
+            "class D : BaseDto {}"
+        );
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                return source switch
+                {
+                    global::Base x when typeof(global::BaseDto).IsAssignableFrom(targetType) => MapDerivedTypes(x),
                     _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to {targetType} as there is no known type mapping", nameof(source)),
                 };
                 """


### PR DESCRIPTION
# Fix generic and runtime target type mappings with derived types

## Description

If a user defined generic type or runtime target type mapping has a child mapping method which uses the `[MapDerivedType]` attribute, the parent method switch arm when clause was created wrongly (but only in that specific case). Fixes #1989 

This got fixed in this PR

Fixes # (issue)

## Checklist

- [x] I did not use AI tools to generate this PR, or I have manually verified that the code is correct, optimal, and follows the project guidelines and architecture
- [x] I understand that low-quality, AI-generated PRs will be closed immediately without further explanation
- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [ ] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
