### PR TITLE
fix: Add null checks when mapping nullable sources to non-nullable targets with MayBeNull and AllowNull Attribute

### DIFF
--- a/docs/docs/breaking-changes/5-0.md
+++ b/docs/docs/breaking-changes/5-0.md
@@ -17,8 +17,8 @@ description: How to upgrade to Mapperly 5.0 and a list of all its breaking chang
 - `Stack<T>` deep cloning now preserves the order of elements by default.
 - Inaccessible members from other assemblies are now included in the mapping process if `IncludedMembers` or `IncludedConstructors` options are configured to include them.
 - Constructor mappings with nullable source types no longer generate null guards when the constructor parameter accepts null, see below.
-- `MaybeNull` attributes are now respected for fields, properties and constructor parameters in read context.
-- `AllowNull` attributes are now respected for fields, properties and constructor parameters in write context.
+- `MaybeNull` attributes are now respected for fields, properties and constructor parameters when reading values.
+- `AllowNull` attributes are now respected for fields, properties and constructor parameters when writing values.
 - Copy constructors are no longer selected over constructors annotated with `[MapperConstructor]` or when `[MapProperty]` configurations are present.
 
 ## Inaccessible members from other assemblies included

--- a/docs/docs/breaking-changes/5-0.md
+++ b/docs/docs/breaking-changes/5-0.md
@@ -17,7 +17,8 @@ description: How to upgrade to Mapperly 5.0 and a list of all its breaking chang
 - `Stack<T>` deep cloning now preserves the order of elements by default.
 - Inaccessible members from other assemblies are now included in the mapping process if `IncludedMembers` or `IncludedConstructors` options are configured to include them.
 - Constructor mappings with nullable source types no longer generate null guards when the constructor parameter accepts null, see below.
-- `MaybeNull` attributes are now respected for fields, properties and constructor parameters.
+- `MaybeNull` attributes are now respected for fields, properties and constructor parameters in read context.
+- `AllowNull` attributes are now respected for fields, properties and constructor parameters in write context.
 - Copy constructors are no longer selected over constructors annotated with `[MapperConstructor]` or when `[MapProperty]` configurations are present.
 
 ## Inaccessible members from other assemblies included

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
@@ -35,7 +35,8 @@ public class MembersContainerBuilderContext<T>(MappingBuilderContext builderCont
         // set target member to null if null assignments are allowed
         // and the source is null
         var setMemberToNull =
-            BuilderContext.Configuration.Mapper.AllowNullPropertyAssignment && memberMapping.MemberInfo.TargetMember.Member.IsNullable;
+            BuilderContext.Configuration.Mapper.AllowNullPropertyAssignment
+            && memberMapping.MemberInfo.TargetMember.Member.Type.IsNullable();
 
         // if the member is explicitly set to null,
         // make sure the parent members are initialized/non-null,
@@ -76,7 +77,7 @@ public class MembersContainerBuilderContext<T>(MappingBuilderContext builderCont
 
         // if the source value is a non-nullable value,
         // the target should be non-null after this assignment and can be set as initialized.
-        if (!mapping.MemberInfo.IsSourceNullable && mapping.MemberInfo.TargetMember.MemberType.IsNullable())
+        if (!mapping.MemberInfo.IsSourceNullable && mapping.MemberInfo.TargetMember.Member.Type.IsNullable())
         {
             _initializedNullableTargetPaths.Add((container, mapping.MemberInfo.TargetMember));
         }

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersContainerBuilderContext.cs
@@ -35,8 +35,7 @@ public class MembersContainerBuilderContext<T>(MappingBuilderContext builderCont
         // set target member to null if null assignments are allowed
         // and the source is null
         var setMemberToNull =
-            BuilderContext.Configuration.Mapper.AllowNullPropertyAssignment
-            && memberMapping.MemberInfo.TargetMember.Member.Type.IsNullable();
+            BuilderContext.Configuration.Mapper.AllowNullPropertyAssignment && memberMapping.MemberInfo.TargetMember.Member.IsWriteNullable;
 
         // if the member is explicitly set to null,
         // make sure the parent members are initialized/non-null,
@@ -51,7 +50,7 @@ public class MembersContainerBuilderContext<T>(MappingBuilderContext builderCont
 
         var nullConditionSourcePath = new NonEmptyMemberPath(
             memberMapping.MemberInfo.SourceMember.MemberPath.RootType,
-            memberMapping.MemberInfo.SourceMember.MemberPath.PathWithoutTrailingNonNullable().ToList()
+            memberMapping.MemberInfo.SourceMember.MemberPath.ReadPathWithoutTrailingNonNullable().ToList()
         );
         var container = GetOrCreateNullDelegateMappingForPath(nullConditionSourcePath);
         AddMemberAssignmentMapping(container, memberMapping);
@@ -77,7 +76,7 @@ public class MembersContainerBuilderContext<T>(MappingBuilderContext builderCont
 
         // if the source value is a non-nullable value,
         // the target should be non-null after this assignment and can be set as initialized.
-        if (!mapping.MemberInfo.IsSourceNullable && mapping.MemberInfo.TargetMember.Member.Type.IsNullable())
+        if (!mapping.MemberInfo.IsSourceNullable && mapping.MemberInfo.TargetMember.Member.IsWriteNullable)
         {
             _initializedNullableTargetPaths.Add((container, mapping.MemberInfo.TargetMember));
         }
@@ -85,7 +84,7 @@ public class MembersContainerBuilderContext<T>(MappingBuilderContext builderCont
 
     private void AddNullMemberInitializers(IMemberAssignmentMappingContainer container, MemberPath path)
     {
-        foreach (var nullablePathList in path.ObjectPathNullableSubPaths())
+        foreach (var nullablePathList in path.ObjectReadPathNullableSubPaths())
         {
             var nullablePath = new NonEmptyMemberPath(path.RootType, nullablePathList);
             var type = nullablePath.Member.Type.NonNullable();
@@ -138,7 +137,7 @@ public class MembersContainerBuilderContext<T>(MappingBuilderContext builderCont
         // try to reuse parent path mappings and wrap inside them
         // if the parentMapping is the first nullable path, no need to access the path in the condition in a null-safe way.
         needsNullSafeAccess = false;
-        foreach (var nullablePathList in nullConditionSourcePath.ObjectPathNullableSubPaths().Reverse())
+        foreach (var nullablePathList in nullConditionSourcePath.ObjectReadPathNullableSubPaths().Reverse())
         {
             var nullablePath = new NonEmptyMemberPath(nullConditionSourcePath.RootType, nullablePathList);
             if (_nullDelegateMappings.TryGetValue(nullablePath, out var parentMappingContainer))

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingState.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingState.cs
@@ -28,7 +28,8 @@ internal sealed class MembersMappingState(
     Dictionary<string, List<MemberMappingConfiguration>> memberConfigsByRootTargetName,
     Dictionary<string, List<IMemberPathConfiguration>> configuredTargetMembersByRootName,
     HashSet<string> ignoredSourceMemberNames,
-    ParameterScope parameterScope
+    ParameterScope parameterScope,
+    SymbolAccessor symbolAccessor
 )
 {
     private readonly Dictionary<string, IMappableMember> _aliasedSourceMembers = new(StringComparer.OrdinalIgnoreCase);
@@ -58,7 +59,7 @@ internal sealed class MembersMappingState(
     public IReadOnlyDictionary<string, IMappableMember> AdditionalSourceMembers =>
         field ??= parameterScope.Parameters.Values.ToDictionary<MethodParameter, string, IMappableMember>(
             x => x.NormalizedName,
-            x => new ParameterSourceMember(x),
+            x => new ParameterSourceMember(x, symbolAccessor),
             StringComparer.OrdinalIgnoreCase
         );
 

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingStateBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/MembersMappingStateBuilder.cs
@@ -68,7 +68,8 @@ internal static class MembersMappingStateBuilder
             memberConfigsByRootTargetName,
             configuredTargetMembersByRootName.AsDictionary(),
             ignoredSourceMemberNames,
-            parameterScope
+            parameterScope,
+            ctx.SymbolAccessor
         );
     }
 

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NestedMappingsContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/BuilderContext/NestedMappingsContext.cs
@@ -70,7 +70,7 @@ public class NestedMappingsContext
     {
         if (
             _context.SymbolAccessor.TryFindMemberPath(
-                nestedMemberPath.MemberType,
+                nestedMemberPath.MemberReadType,
                 pathCandidates,
                 // Use empty ignore list to support ignoring a property for normal search while flattening its properties
                 Array.Empty<string>(),

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/MemberMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/MemberMappingBuilder.cs
@@ -85,7 +85,7 @@ internal static class MemberMappingBuilder
             return false;
         }
 
-        var memberTargetNullable = memberMappingInfo.TargetMember.MemberType.IsNullable();
+        var memberTargetNullable = memberMappingInfo.TargetMember.Member.Type.IsNullable();
         var delegateTargetNullable = delegateMapping.TargetType.IsNullable();
         var memberSourceNullable = memberMappingInfo.IsSourceNullable;
         var delegateSourceNullable = delegateMapping.SourceType.IsNullable();
@@ -209,7 +209,7 @@ internal static class MemberMappingBuilder
         // access the source in a null save matter (via ?.) but no other special handling required.
         if (
             ctx.BuilderContext.Configuration.Mapper.AllowNullPropertyAssignment
-            && (delegateMapping.SourceType.IsNullable() || delegateMapping.IsSynthetic && targetMember.Member.IsNullable)
+            && (delegateMapping.SourceType.IsNullable() || delegateMapping.IsSynthetic && targetMember.Member.Type.IsNullable())
         )
         {
             return new MappedMemberSourceValue(delegateMapping, sourceGetter, true, false);

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/MemberMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/MemberMappingBuilder.cs
@@ -89,11 +89,12 @@ internal static class MemberMappingBuilder
         var delegateTargetNullable = delegateMapping.TargetType.IsNullable();
         var memberSourceNullable = memberMappingInfo.IsSourceNullable;
         var delegateSourceNullable = delegateMapping.SourceType.IsNullable();
+        var memberTargetAcceptsNull = memberMappingInfo.TargetMember.MemberType.IsNullable();
 
         if (
             memberMappingInfo.Configuration?.SuppressNullMismatchDiagnostic != true
             && memberSourceNullable
-            && !memberTargetNullable
+            && !memberTargetAcceptsNull
             && !(delegateSourceNullable && !delegateTargetNullable)
         )
         {

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/MemberMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/MemberMappingBuilder.cs
@@ -85,7 +85,7 @@ internal static class MemberMappingBuilder
             return false;
         }
 
-        var memberTargetNullable = memberMappingInfo.TargetMember.Member.Type.IsNullable();
+        var memberTargetNullable = memberMappingInfo.TargetMember.Member.IsWriteNullable;
         var delegateTargetNullable = delegateMapping.TargetType.IsNullable();
         var memberSourceNullable = memberMappingInfo.IsSourceNullable;
         var delegateSourceNullable = delegateMapping.SourceType.IsNullable();
@@ -175,7 +175,7 @@ internal static class MemberMappingBuilder
     )
     {
         var nullFallback = NullFallbackValue.Default;
-        if (!delegateMapping.SourceType.IsNullable() && sourcePath.IsAnyNullable())
+        if (!delegateMapping.SourceType.IsNullable() && sourcePath.IsAnyReadNullable())
         {
             nullFallback = ctx.BuilderContext.GetNullFallbackValue(targetMemberType);
         }
@@ -199,7 +199,7 @@ internal static class MemberMappingBuilder
         var sourceGetter = sourceMember.BuildGetter(ctx.BuilderContext);
 
         // no member of the source path is nullable, no null handling needed
-        if (!sourceMember.IsAnyNullable())
+        if (!sourceMember.IsAnyReadNullable())
         {
             return new MappedMemberSourceValue(delegateMapping, sourceGetter, false, true);
         }
@@ -210,7 +210,7 @@ internal static class MemberMappingBuilder
         // access the source in a null save matter (via ?.) but no other special handling required.
         if (
             ctx.BuilderContext.Configuration.Mapper.AllowNullPropertyAssignment
-            && (delegateMapping.SourceType.IsNullable() || delegateMapping.IsSynthetic && targetMember.Member.Type.IsNullable())
+            && (delegateMapping.SourceType.IsNullable() || delegateMapping.IsSynthetic && targetMember.Member.IsWriteNullable)
         )
         {
             return new MappedMemberSourceValue(delegateMapping, sourceGetter, true, false);

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/MemberMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/MemberMappingBuilder.cs
@@ -85,11 +85,12 @@ internal static class MemberMappingBuilder
             return false;
         }
 
+        //var memberTargetNullable = memberMappingInfo.TargetMember.Member.Type.IsNullable();
         var memberTargetNullable = memberMappingInfo.TargetMember.Member.IsWriteNullable;
         var delegateTargetNullable = delegateMapping.TargetType.IsNullable();
         var memberSourceNullable = memberMappingInfo.IsSourceNullable;
         var delegateSourceNullable = delegateMapping.SourceType.IsNullable();
-        var memberTargetAcceptsNull = memberMappingInfo.TargetMember.MemberType.IsNullable();
+        var memberTargetAcceptsNull = memberMappingInfo.TargetMember.Member.IsWriteNullable;
 
         if (
             memberMappingInfo.Configuration?.SuppressNullMismatchDiagnostic != true
@@ -133,7 +134,7 @@ internal static class MemberMappingBuilder
             return false;
         }
 
-        sourceValue = BuildInlineNullHandlingMapping(ctx, delegateMapping, sourceMember.MemberPath, targetMember.MemberType);
+        sourceValue = BuildInlineNullHandlingMapping(ctx, delegateMapping, sourceMember.MemberPath, targetMember.MemberWriteType);
         return true;
     }
 

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/MemberMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/MemberMappingBuilder.cs
@@ -85,12 +85,10 @@ internal static class MemberMappingBuilder
             return false;
         }
 
-        //var memberTargetNullable = memberMappingInfo.TargetMember.Member.Type.IsNullable();
-        var memberTargetNullable = memberMappingInfo.TargetMember.Member.IsWriteNullable;
+        var memberTargetAcceptsNull = memberMappingInfo.TargetMember.Member.IsWriteNullable;
         var delegateTargetNullable = delegateMapping.TargetType.IsNullable();
         var memberSourceNullable = memberMappingInfo.IsSourceNullable;
         var delegateSourceNullable = delegateMapping.SourceType.IsNullable();
-        var memberTargetAcceptsNull = memberMappingInfo.TargetMember.Member.IsWriteNullable;
 
         if (
             memberMappingInfo.Configuration?.SuppressNullMismatchDiagnostic != true
@@ -109,8 +107,8 @@ internal static class MemberMappingBuilder
         }
 
         if (
-            (memberSourceNullable == delegateSourceNullable && memberTargetNullable == delegateTargetNullable)
-            || (memberSourceNullable && !memberTargetNullable && delegateSourceNullable && !delegateTargetNullable)
+            (memberSourceNullable == delegateSourceNullable && memberTargetAcceptsNull == delegateTargetNullable)
+            || (memberSourceNullable && !memberTargetAcceptsNull && delegateSourceNullable && !delegateTargetNullable)
         )
         {
             sourceValue = new MappedMemberSourceValue(

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/SourceValueBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/SourceValueBuilder.cs
@@ -201,7 +201,7 @@ internal static class SourceValueBuilder
             ctx.BuilderContext.ReportDiagnostic(
                 DiagnosticDescriptors.MapValueMethodTypeMismatch,
                 methodReferenceConfiguration.Name,
-                FormattedReturnType(namedMethodCandidates[0]),
+                ctx.BuilderContext.SymbolAccessor.UpgradeReturnNullable(namedMethodCandidates[0]).ToDisplayString(),
                 memberMappingInfo.TargetMember.ToDisplayString()
             );
             sourceValue = null;
@@ -218,18 +218,5 @@ internal static class SourceValueBuilder
             additionalParameterNames
         );
         return true;
-    }
-
-    private static string FormattedReturnType(IMethodSymbol methodSymbol)
-    {
-        bool hasNullableAttribute = methodSymbol
-            .GetReturnTypeAttributes()
-            .Any(a => string.Equals(a.AttributeClass?.Name, nameof(MaybeNullAttribute)));
-
-        var effectiveType = hasNullableAttribute
-            ? methodSymbol.ReturnType.WithNullableAnnotation(NullableAnnotation.Annotated)
-            : methodSymbol.ReturnType;
-
-        return effectiveType.ToDisplayString();
     }
 }

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/SourceValueBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/SourceValueBuilder.cs
@@ -77,7 +77,7 @@ internal static class SourceValueBuilder
         // but the provided value is null or default (for default IsNullable is also true)
         if (
             value.ConstantValue.IsNull
-            && memberMappingInfo.TargetMember.MemberType.IsReferenceType
+            && memberMappingInfo.TargetMember.MemberWriteType.IsReferenceType
             && !memberMappingInfo.TargetMember.Member.IsWriteNullable
         )
         {
@@ -92,8 +92,8 @@ internal static class SourceValueBuilder
         // target is value type but value is null
         if (
             value.ConstantValue.IsNull
-            && memberMappingInfo.TargetMember.MemberType.IsValueType
-            && !memberMappingInfo.TargetMember.MemberType.IsNullableValueType()
+            && memberMappingInfo.TargetMember.MemberWriteType.IsValueType
+            && !memberMappingInfo.TargetMember.MemberWriteType.IsNullableValueType()
             && value.Expression.IsKind(SyntaxKind.NullLiteralExpression)
         )
         {
@@ -116,7 +116,7 @@ internal static class SourceValueBuilder
 
         // use non-nullable target type to allow non-null value type assignments
         // to nullable value types
-        if (!SymbolEqualityComparer.Default.Equals(value.ConstantValue.Type, memberMappingInfo.TargetMember.MemberType.NonNullable()))
+        if (!SymbolEqualityComparer.Default.Equals(value.ConstantValue.Type, memberMappingInfo.TargetMember.MemberWriteType.NonNullable()))
         {
             ctx.BuilderContext.ReportDiagnostic(
                 DiagnosticDescriptors.MapValueTypeMismatch,
@@ -137,7 +137,7 @@ internal static class SourceValueBuilder
                 // expand enum member access to fully qualified identifier
                 // use simple member name approach instead of slower visitor pattern on the expression
                 var enumMemberName = ((MemberAccessExpressionSyntax)value.Expression).Name.Identifier.Text;
-                var enumTypeFullName = FullyQualifiedIdentifier(memberMappingInfo.TargetMember.MemberType.NonNullable());
+                var enumTypeFullName = FullyQualifiedIdentifier(memberMappingInfo.TargetMember.MemberWriteType.NonNullable());
                 sourceValue = new ConstantSourceValue(MemberAccess(enumTypeFullName, enumMemberName));
                 return true;
             case TypedConstantKind.Type:
@@ -186,7 +186,7 @@ internal static class SourceValueBuilder
         // to nullable value types
         // nullable is checked with nullable annotation
         var methodCandidates = namedMethodCandidates.Where(x =>
-            SymbolEqualityComparer.Default.Equals(x.ReturnType.NonNullable(), memberMappingInfo.TargetMember.MemberType.NonNullable())
+            SymbolEqualityComparer.Default.Equals(x.ReturnType.NonNullable(), memberMappingInfo.TargetMember.MemberWriteType.NonNullable())
         );
 
         if (!memberMappingInfo.TargetMember.Member.IsNullable)

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/SourceValueBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/SourceValueBuilder.cs
@@ -78,7 +78,7 @@ internal static class SourceValueBuilder
         if (
             value.ConstantValue.IsNull
             && memberMappingInfo.TargetMember.MemberType.IsReferenceType
-            && !memberMappingInfo.TargetMember.Member.IsNullable
+            && !memberMappingInfo.TargetMember.Member.Type.IsNullable()
         )
         {
             ctx.BuilderContext.ReportDiagnostic(
@@ -189,7 +189,7 @@ internal static class SourceValueBuilder
             SymbolEqualityComparer.Default.Equals(x.ReturnType.NonNullable(), memberMappingInfo.TargetMember.MemberType.NonNullable())
         );
 
-        if (!memberMappingInfo.TargetMember.Member.IsNullable)
+        if (!memberMappingInfo.TargetMember.Member.Type.IsNullable())
         {
             // Filter out methods that may return null when the target is non-nullable.
             methodCandidates = methodCandidates.Where(m => !ctx.BuilderContext.SymbolAccessor.MayReturnNull(m, false));

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/SourceValueBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/SourceValueBuilder.cs
@@ -189,7 +189,7 @@ internal static class SourceValueBuilder
             SymbolEqualityComparer.Default.Equals(x.ReturnType.NonNullable(), memberMappingInfo.TargetMember.MemberType.NonNullable())
         );
 
-        if (!memberMappingInfo.TargetMember.Member.Type.IsNullable())
+        if (!memberMappingInfo.TargetMember.Member.IsNullable)
         {
             // Filter out methods that may return null when the target is non-nullable.
             methodCandidates = methodCandidates.Where(m => !ctx.BuilderContext.SymbolAccessor.MayReturnNull(m, false));

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/SourceValueBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/SourceValueBuilder.cs
@@ -78,7 +78,7 @@ internal static class SourceValueBuilder
         if (
             value.ConstantValue.IsNull
             && memberMappingInfo.TargetMember.MemberType.IsReferenceType
-            && !memberMappingInfo.TargetMember.Member.Type.IsNullable()
+            && !memberMappingInfo.TargetMember.Member.IsWriteNullable
         )
         {
             ctx.BuilderContext.ReportDiagnostic(

--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/SourceValueBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/SourceValueBuilder.cs
@@ -189,7 +189,7 @@ internal static class SourceValueBuilder
             SymbolEqualityComparer.Default.Equals(x.ReturnType.NonNullable(), memberMappingInfo.TargetMember.MemberWriteType.NonNullable())
         );
 
-        if (!memberMappingInfo.TargetMember.Member.IsNullable)
+        if (!memberMappingInfo.TargetMember.Member.IsWriteNullable)
         {
             // Filter out methods that may return null when the target is non-nullable.
             methodCandidates = methodCandidates.Where(m => !ctx.BuilderContext.SymbolAccessor.MayReturnNull(m, false));
@@ -201,7 +201,7 @@ internal static class SourceValueBuilder
             ctx.BuilderContext.ReportDiagnostic(
                 DiagnosticDescriptors.MapValueMethodTypeMismatch,
                 methodReferenceConfiguration.Name,
-                namedMethodCandidates[0].ReturnType.ToDisplayString(),
+                FormattedReturnType(namedMethodCandidates[0]),
                 memberMappingInfo.TargetMember.ToDisplayString()
             );
             sourceValue = null;
@@ -218,5 +218,18 @@ internal static class SourceValueBuilder
             additionalParameterNames
         );
         return true;
+    }
+
+    private static string FormattedReturnType(IMethodSymbol methodSymbol)
+    {
+        bool hasNullableAttribute = methodSymbol
+            .GetReturnTypeAttributes()
+            .Any(a => string.Equals(a.AttributeClass?.Name, nameof(MaybeNullAttribute)));
+
+        var effectiveType = hasNullableAttribute
+            ? methodSymbol.ReturnType.WithNullableAnnotation(NullableAnnotation.Annotated)
+            : methodSymbol.ReturnType;
+
+        return effectiveType.ToDisplayString();
     }
 }

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberMappingInfo.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberMappingInfo.cs
@@ -18,7 +18,7 @@ public record MemberMappingInfo(
     public MemberMappingInfo(NonEmptyMemberPath targetMember, MemberValueMappingConfiguration configuration)
         : this(null, targetMember, configuration) { }
 
-    public bool IsSourceNullable => SourceMember?.MemberPath.IsAnyNullable() ?? ValueConfiguration?.Value?.ConstantValue.IsNull ?? true;
+    public bool IsSourceNullable => SourceMember?.MemberPath.IsAnyReadNullable() ?? ValueConfiguration?.Value?.ConstantValue.IsNull ?? true;
 
     private string DebuggerDisplay =>
         $"{SourceMember?.MemberPath.FullName ?? ValueConfiguration?.DescribeValue()} => {TargetMember.FullName}";

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberMappingInfo.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberMappingInfo.cs
@@ -34,7 +34,11 @@ public record MemberMappingInfo(
         if (SourceMember == null)
             throw new InvalidOperationException($"{SourceMember} and {TargetMember} need to be set to create a {nameof(TypeMappingKey)}");
 
-        return new TypeMappingKey(SourceMember.MemberPath.MemberType, TargetMember.MemberType, Configuration?.ToTypeMappingConfiguration());
+        return new TypeMappingKey(
+            SourceMember.MemberPath.MemberReadType,
+            TargetMember.MemberWriteType,
+            Configuration?.ToTypeMappingConfiguration()
+        );
     }
 
     public string DescribeSource()

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/SourceValue/MappedMemberSourceValue.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/SourceValue/MappedMemberSourceValue.cs
@@ -19,7 +19,7 @@ public class MappedMemberSourceValue(
     private readonly MemberPathGetter _sourceMember = sourceMember;
     private readonly INewInstanceMapping _delegateMapping = delegateMapping;
 
-    public bool RequiresSourceNullCheck => !nullConditionalAccess && _sourceMember.MemberPath.IsAnyNullable();
+    public bool RequiresSourceNullCheck => !nullConditionalAccess && _sourceMember.MemberPath.IsAnyReadNullable();
 
     public ExpressionSyntax Build(TypeMappingBuildContext ctx)
     {

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/SourceValue/NullMappedMemberSourceValue.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/SourceValue/NullMappedMemberSourceValue.cs
@@ -27,7 +27,7 @@ public class NullMappedMemberSourceValue(
     public ExpressionSyntax Build(TypeMappingBuildContext ctx)
     {
         // if the source is not nullable, return it directly.
-        if (!_sourceGetter.MemberPath.IsAnyNullable())
+        if (!_sourceGetter.MemberPath.IsAnyReadNullable())
         {
             ctx = ctx.WithSource(_sourceGetter.BuildAccess(ctx.Source));
             return _delegateMapping.Build(ctx);
@@ -49,7 +49,7 @@ public class NullMappedMemberSourceValue(
         // source.A?.B == null ? <null-substitute> : Map(source.A.B.Value)
         // use simplified coalesce expression for synthetic mappings:
         // source.A?.B ?? <null-substitute>
-        if (_delegateMapping.IsSynthetic && (useNullConditionalAccess || !_sourceGetter.MemberPath.IsAnyObjectPathNullable()))
+        if (_delegateMapping.IsSynthetic && (useNullConditionalAccess || !_sourceGetter.MemberPath.IsAnyObjectReadPathNullable()))
         {
             var nullConditionalSourceAccess = _sourceGetter.BuildAccess(ctx.Source, nullConditional: true);
             var nameofSourceAccess = _sourceGetter.BuildAccess(ctx.Source, nullConditional: false);

--- a/src/Riok.Mapperly/Descriptors/Mappings/MethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MethodMapping.cs
@@ -39,7 +39,7 @@ public abstract class MethodMapping : ITypeMapping, IParameterizedMapping
     protected MethodMapping(ITypeSymbol sourceType, ITypeSymbol targetType)
     {
         TargetType = targetType;
-        SourceParameter = new MethodParameter(SourceParameterIndex, DefaultSourceParameterName, sourceType);
+        SourceParameter = new MethodParameter(SourceParameterIndex, DefaultSourceParameterName, sourceType, null);
         _returnType = targetType;
     }
 

--- a/src/Riok.Mapperly/Descriptors/Mappings/MethodMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MethodMapping.cs
@@ -39,7 +39,7 @@ public abstract class MethodMapping : ITypeMapping, IParameterizedMapping
     protected MethodMapping(ITypeSymbol sourceType, ITypeSymbol targetType)
     {
         TargetType = targetType;
-        SourceParameter = new MethodParameter(SourceParameterIndex, DefaultSourceParameterName, sourceType, null);
+        SourceParameter = new MethodParameter(SourceParameterIndex, DefaultSourceParameterName, sourceType);
         _returnType = targetType;
     }
 

--- a/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
@@ -91,18 +91,6 @@ public class SymbolAccessor(CompilationContext compilationContext, INamedTypeSym
         };
     }
 
-    public bool IsNullable(ISymbol symbol)
-    {
-        return symbol switch
-        {
-            ITypeSymbol t => t.IsNullable(),
-            IPropertySymbol p => p.Type.IsNullable(),
-            IFieldSymbol f => f.Type.IsNullable(),
-            IParameterSymbol p => p.Type.IsNullable(),
-            _ => false,
-        };
-    }
-
     public bool IsReadNullable(ISymbol symbol)
     {
         return symbol switch

--- a/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
@@ -146,6 +146,30 @@ public class SymbolAccessor(CompilationContext compilationContext, INamedTypeSym
 
     public MethodParameter WrapMethodParameter(IParameterSymbol symbol) => new(symbol, UpgradeNullable(symbol.Type));
 
+    public ITypeSymbol UpgradeReturnNullable(IMethodSymbol methodSymbol)
+    {
+        TryUpgradeReturnNullable(methodSymbol, out var upgradedReturnSymbol);
+        return upgradedReturnSymbol ?? methodSymbol.ReturnType;
+    }
+
+    private bool TryUpgradeReturnNullable(IMethodSymbol methodSymbol, [NotNullWhen(true)] out ITypeSymbol? upgradedReturnSymbol)
+    {
+        upgradedReturnSymbol = default;
+
+        if (methodSymbol.ReturnsVoid || methodSymbol.ReturnType.IsValueType)
+        {
+            return false;
+        }
+
+        if (!TryHasAttribute<MaybeNullAttribute>(methodSymbol.GetReturnTypeAttributes()))
+        {
+            return false;
+        }
+
+        upgradedReturnSymbol = methodSymbol.ReturnType.WithNullableAnnotation(NullableAnnotation.Annotated);
+        return true;
+    }
+
     /// <summary>
     /// Upgrade the nullability of a symbol from <see cref="NullableAnnotation.None"/> to <see cref="NullableAnnotation.Annotated"/>.
     /// Value types are not upgraded.

--- a/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
@@ -96,9 +96,33 @@ public class SymbolAccessor(CompilationContext compilationContext, INamedTypeSym
         return symbol switch
         {
             ITypeSymbol t => t.IsNullable(),
+            IPropertySymbol p => p.Type.IsNullable(),
+            IFieldSymbol f => f.Type.IsNullable(),
+            IParameterSymbol p => p.Type.IsNullable(),
+            _ => false,
+        };
+    }
+
+    public bool IsReadNullable(ISymbol symbol)
+    {
+        return symbol switch
+        {
+            ITypeSymbol t => t.IsNullable(),
             IPropertySymbol p => p.Type.IsNullable() || TryHasAttribute<MaybeNullAttribute>(p),
             IFieldSymbol f => f.Type.IsNullable() || TryHasAttribute<MaybeNullAttribute>(f),
             IParameterSymbol p => p.Type.IsNullable() || TryHasAttribute<MaybeNullAttribute>(p),
+            _ => false,
+        };
+    }
+
+    public bool IsWriteNullable(ISymbol symbol)
+    {
+        return symbol switch
+        {
+            ITypeSymbol t => t.IsNullable(),
+            IPropertySymbol p => p.Type.IsNullable() || TryHasAttribute<AllowNullAttribute>(p),
+            IFieldSymbol f => f.Type.IsNullable() || TryHasAttribute<AllowNullAttribute>(f),
+            IParameterSymbol p => p.Type.IsNullable() || TryHasAttribute<AllowNullAttribute>(p),
             _ => false,
         };
     }

--- a/src/Riok.Mapperly/Descriptors/UserMethodMappingExtractor.cs
+++ b/src/Riok.Mapperly/Descriptors/UserMethodMappingExtractor.cs
@@ -267,12 +267,8 @@ public static class UserMethodMappingExtractor
         string sourceParameterName
     )
     {
-        var targetType = ctx.SymbolAccessor.UpgradeNullable(method.ReturnType);
-
-        if (ctx.SymbolAccessor.TryHasAttribute<MaybeNullAttribute>(method.GetReturnTypeAttributes()))
-        {
-            targetType = targetType.WithNullableAnnotation(NullableAnnotation.Annotated);
-        }
+        var effectiveReturnType = ctx.SymbolAccessor.UpgradeReturnNullable(method);
+        var targetType = ctx.SymbolAccessor.UpgradeNullable(effectiveReturnType);
 
         if (!targetType.IsNullable() || ctx.SymbolAccessor.TryHasAttribute<NotNullAttribute>(method.GetReturnTypeAttributes()))
         {

--- a/src/Riok.Mapperly/Descriptors/UserMethodMappingExtractor.cs
+++ b/src/Riok.Mapperly/Descriptors/UserMethodMappingExtractor.cs
@@ -268,6 +268,12 @@ public static class UserMethodMappingExtractor
     )
     {
         var targetType = ctx.SymbolAccessor.UpgradeNullable(method.ReturnType);
+
+        if (ctx.SymbolAccessor.TryHasAttribute<MaybeNullAttribute>(method.GetReturnTypeAttributes()))
+        {
+            targetType = targetType.WithNullableAnnotation(NullableAnnotation.Annotated);
+        }
+
         if (!targetType.IsNullable() || ctx.SymbolAccessor.TryHasAttribute<NotNullAttribute>(method.GetReturnTypeAttributes()))
         {
             return (targetType, UserImplementedMethodMapping.TargetNullability.NeverNull);

--- a/src/Riok.Mapperly/Symbols/Members/ConstructorParameterMember.cs
+++ b/src/Riok.Mapperly/Symbols/Members/ConstructorParameterMember.cs
@@ -21,6 +21,8 @@ public class ConstructorParameterMember(IParameterSymbol symbol, SymbolAccessor 
     public ITypeSymbol Type { get; } = accessor.UpgradeNullable(symbol.Type);
     public INamedTypeSymbol ContainingType { get; } = symbol.ContainingType;
     public bool IsNullable => accessor.IsNullable(Symbol);
+    public bool IsReadNullable => accessor.IsReadNullable(Symbol);
+    public bool IsWriteNullable => accessor.IsWriteNullable(Symbol);
     public bool CanGet => false;
     public bool CanGetDirectly => false;
     public bool CanSet => false;

--- a/src/Riok.Mapperly/Symbols/Members/ConstructorParameterMember.cs
+++ b/src/Riok.Mapperly/Symbols/Members/ConstructorParameterMember.cs
@@ -20,7 +20,6 @@ public class ConstructorParameterMember(IParameterSymbol symbol, SymbolAccessor 
 {
     public ITypeSymbol Type { get; } = accessor.UpgradeNullable(symbol.Type);
     public INamedTypeSymbol ContainingType { get; } = symbol.ContainingType;
-    public bool IsNullable => accessor.IsNullable(Symbol);
     public bool IsReadNullable => accessor.IsReadNullable(Symbol);
     public bool IsWriteNullable => accessor.IsWriteNullable(Symbol);
     public bool CanGet => false;

--- a/src/Riok.Mapperly/Symbols/Members/EmptyMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/EmptyMemberPath.cs
@@ -7,9 +7,6 @@ namespace Riok.Mapperly.Symbols.Members;
 public class EmptyMemberPath(ITypeSymbol rootType) : MemberPath(rootType, [])
 {
     public override IMappableMember? Member => null;
-
-    public override ITypeSymbol MemberType => RootType; //TODO - was the MayBeNull check not required here?
-
     public override ITypeSymbol MemberReadType => RootType; //after confirmation, add read null
 
     public override ITypeSymbol MemberWriteType => RootType; //after confirmation, add write null

--- a/src/Riok.Mapperly/Symbols/Members/EmptyMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/EmptyMemberPath.cs
@@ -12,6 +12,10 @@ public class EmptyMemberPath(ITypeSymbol rootType) : MemberPath(rootType, [])
 
     public override ITypeSymbol MemberWriteType => RootType;
 
+    public override bool IsAnyReadNullable() => false;
+
+    public override bool IsWriteNullable() => false;
+
     public override string ToDisplayString(bool includeRootType = true, bool includeMemberType = true) =>
         includeRootType ? RootType.ToDisplayString() : string.Empty;
 }

--- a/src/Riok.Mapperly/Symbols/Members/EmptyMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/EmptyMemberPath.cs
@@ -8,7 +8,11 @@ public class EmptyMemberPath(ITypeSymbol rootType) : MemberPath(rootType, [])
 {
     public override IMappableMember? Member => null;
 
-    public override ITypeSymbol MemberType => RootType;
+    public override ITypeSymbol MemberType => RootType; //TODO - was the MayBeNull check not required here?
+
+    public override ITypeSymbol MemberReadType => RootType; //after confirmation, add read null
+
+    public override ITypeSymbol MemberWriteType => RootType; //after confirmation, add write null
 
     public override string ToDisplayString(bool includeRootType = true, bool includeMemberType = true) =>
         includeRootType ? RootType.ToDisplayString() : string.Empty;

--- a/src/Riok.Mapperly/Symbols/Members/EmptyMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/EmptyMemberPath.cs
@@ -7,9 +7,10 @@ namespace Riok.Mapperly.Symbols.Members;
 public class EmptyMemberPath(ITypeSymbol rootType) : MemberPath(rootType, [])
 {
     public override IMappableMember? Member => null;
-    public override ITypeSymbol MemberReadType => RootType; //after confirmation, add read null
 
-    public override ITypeSymbol MemberWriteType => RootType; //after confirmation, add write null
+    public override ITypeSymbol MemberReadType => RootType;
+
+    public override ITypeSymbol MemberWriteType => RootType;
 
     public override string ToDisplayString(bool includeRootType = true, bool includeMemberType = true) =>
         includeRootType ? RootType.ToDisplayString() : string.Empty;

--- a/src/Riok.Mapperly/Symbols/Members/FieldMember.cs
+++ b/src/Riok.Mapperly/Symbols/Members/FieldMember.cs
@@ -17,7 +17,6 @@ public class FieldMember(IFieldSymbol symbol, SymbolAccessor symbolAccessor)
 {
     public ITypeSymbol Type { get; } = symbolAccessor.UpgradeNullable(symbol.Type);
     public INamedTypeSymbol ContainingType { get; } = symbol.ContainingType;
-    public bool IsNullable => symbolAccessor.IsNullable(Symbol);
     public bool IsReadNullable => symbolAccessor.IsReadNullable(Symbol);
     public bool IsWriteNullable => symbolAccessor.IsWriteNullable(Symbol);
     public bool CanGet => true;

--- a/src/Riok.Mapperly/Symbols/Members/FieldMember.cs
+++ b/src/Riok.Mapperly/Symbols/Members/FieldMember.cs
@@ -18,6 +18,8 @@ public class FieldMember(IFieldSymbol symbol, SymbolAccessor symbolAccessor)
     public ITypeSymbol Type { get; } = symbolAccessor.UpgradeNullable(symbol.Type);
     public INamedTypeSymbol ContainingType { get; } = symbol.ContainingType;
     public bool IsNullable => symbolAccessor.IsNullable(Symbol);
+    public bool IsReadNullable => symbolAccessor.IsReadNullable(Symbol);
+    public bool IsWriteNullable => symbolAccessor.IsWriteNullable(Symbol);
     public bool CanGet => true;
     public bool CanGetDirectly => symbolAccessor.IsDirectlyAccessible(Symbol);
     public bool CanSet => !Symbol.IsReadOnly;

--- a/src/Riok.Mapperly/Symbols/Members/IMappableMember.cs
+++ b/src/Riok.Mapperly/Symbols/Members/IMappableMember.cs
@@ -16,8 +16,6 @@ public interface IMappableMember
 
     INamedTypeSymbol? ContainingType { get; }
 
-    bool IsNullable { get; }
-
     bool IsReadNullable { get; }
 
     bool IsWriteNullable { get; }

--- a/src/Riok.Mapperly/Symbols/Members/IMappableMember.cs
+++ b/src/Riok.Mapperly/Symbols/Members/IMappableMember.cs
@@ -18,6 +18,10 @@ public interface IMappableMember
 
     bool IsNullable { get; }
 
+    bool IsReadNullable { get; }
+
+    bool IsWriteNullable { get; }
+
     /// <summary>
     /// Whether the member can be read using direct access or an unsafe accessor method.
     /// </summary>

--- a/src/Riok.Mapperly/Symbols/Members/MemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/MemberPath.cs
@@ -36,6 +36,18 @@ public abstract class MemberPath(ITypeSymbol rootType, IReadOnlyList<IMappableMe
     public abstract ITypeSymbol MemberType { get; }
 
     /// <summary>
+    /// Gets the type of the total path in the context of read, e.g. that of the <see cref="Member"/> if it exists, or the <see cref="RootType"/> otherwise.
+    /// If any part of the path is nullable, this type will be nullable too.
+    /// </summary>
+    public abstract ITypeSymbol MemberReadType { get; }
+
+    /// <summary>
+    /// Gets the type of the last part of path in the context of write, e.g. that of the <see cref="Member"/> if it exists, or the <see cref="RootType"/> otherwise.
+    /// If last part of the path is nullable, this type will be nullable too.
+    /// </summary>
+    public abstract ITypeSymbol MemberWriteType { get; }
+
+    /// <summary>
     /// Gets the full name of the path (e.g. A.B.C).
     /// </summary>
     public string FullName { get; } = string.Join(MemberAccessSeparator, path.Select(x => x.Name));
@@ -65,6 +77,8 @@ public abstract class MemberPath(ITypeSymbol rootType, IReadOnlyList<IMappableMe
     }
 
     public bool IsAnyReadNullable() => Path.Any(x => x.IsReadNullable);
+
+    public bool IsWriteNullable() => Path[^1].IsWriteNullable;
 
     public bool IsAnyNullable() => Path.Any(p => p.IsNullable);
 

--- a/src/Riok.Mapperly/Symbols/Members/MemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/MemberPath.cs
@@ -30,12 +30,6 @@ public abstract class MemberPath(ITypeSymbol rootType, IReadOnlyList<IMappableMe
     public abstract IMappableMember? Member { get; }
 
     /// <summary>
-    /// Gets the type of the total path, e.g. that of the <see cref="Member"/> if it exists, or the <see cref="RootType"/> otherwise.
-    /// If any part of the path is nullable, this type will be nullable too.
-    /// </summary>
-    public abstract ITypeSymbol MemberType { get; }
-
-    /// <summary>
     /// Gets the type of the total path in the context of read, e.g. that of the <see cref="Member"/> if it exists, or the <see cref="RootType"/> otherwise.
     /// If any part of the path is nullable, this type will be nullable too.
     /// </summary>
@@ -79,8 +73,6 @@ public abstract class MemberPath(ITypeSymbol rootType, IReadOnlyList<IMappableMe
     public bool IsAnyReadNullable() => Path.Any(x => x.IsReadNullable);
 
     public bool IsWriteNullable() => Path[^1].IsWriteNullable;
-
-    public bool IsAnyNullable() => Path.Any(p => p.IsNullable);
 
     public bool IsAnyObjectReadPathNullable() => ObjectPath.Any(p => p.IsReadNullable);
 

--- a/src/Riok.Mapperly/Symbols/Members/MemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/MemberPath.cs
@@ -44,29 +44,31 @@ public abstract class MemberPath(ITypeSymbol rootType, IReadOnlyList<IMappableMe
     /// Builds a member path skipping trailing path items which are non-nullable.
     /// </summary>
     /// <returns>The built path.</returns>
-    public IEnumerable<IMappableMember> PathWithoutTrailingNonNullable() => Path.Reverse().SkipWhile(x => !x.IsNullable).Reverse();
+    public IEnumerable<IMappableMember> ReadPathWithoutTrailingNonNullable() => Path.Reverse().SkipWhile(x => !x.IsReadNullable).Reverse();
 
     /// <summary>
     /// Returns an element for each nullable sub-path of the <see cref="ObjectPath"/>.
     /// If the <see cref="Member"/> is nullable, the entire <see cref="Path"/> is not returned.
     /// </summary>
     /// <returns>All nullable sub-paths of the <see cref="ObjectPath"/>.</returns>
-    public IEnumerable<IReadOnlyList<IMappableMember>> ObjectPathNullableSubPaths()
+    public IEnumerable<IReadOnlyList<IMappableMember>> ObjectReadPathNullableSubPaths()
     {
         var pathParts = new List<IMappableMember>(Path.Count);
         foreach (var pathPart in ObjectPath)
         {
             pathParts.Add(pathPart);
-            if (!pathPart.IsNullable)
+            if (!pathPart.IsReadNullable)
                 continue;
 
             yield return pathParts.ToArray();
         }
     }
 
+    public bool IsAnyReadNullable() => Path.Any(x => x.IsReadNullable);
+
     public bool IsAnyNullable() => Path.Any(p => p.IsNullable);
 
-    public bool IsAnyObjectPathNullable() => ObjectPath.Any(p => p.IsNullable);
+    public bool IsAnyObjectReadPathNullable() => ObjectPath.Any(p => p.IsReadNullable);
 
     public MemberPathGetter BuildGetter(SimpleMappingBuilderContext ctx) => MemberPathGetter.Build(ctx, this);
 

--- a/src/Riok.Mapperly/Symbols/Members/MemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/MemberPath.cs
@@ -70,9 +70,9 @@ public abstract class MemberPath(ITypeSymbol rootType, IReadOnlyList<IMappableMe
         }
     }
 
-    public bool IsAnyReadNullable() => Path.Any(x => x.IsReadNullable);
+    public abstract bool IsAnyReadNullable();
 
-    public bool IsWriteNullable() => Path[^1].IsWriteNullable;
+    public abstract bool IsWriteNullable();
 
     public bool IsAnyObjectReadPathNullable() => ObjectPath.Any(p => p.IsReadNullable);
 

--- a/src/Riok.Mapperly/Symbols/Members/MemberPathGetter.cs
+++ b/src/Riok.Mapperly/Symbols/Members/MemberPathGetter.cs
@@ -40,7 +40,7 @@ public class MemberPathGetter
         bool skipTrailingNonNullable = false
     )
     {
-        var path = skipTrailingNonNullable ? PathWithoutTrailingNonNullable() : _path;
+        var path = skipTrailingNonNullable ? ReadPathWithoutTrailingNonNullable() : _path;
         return BuildAccess(baseAccess, path, addValuePropertyOnNullable, nullConditional);
     }
 
@@ -56,7 +56,7 @@ public class MemberPathGetter
         {
             return path.AggregateWithPrevious(
                 baseAccess,
-                (expr, prevProp, prop) => prop.Getter.BuildAccess(expr, prop.Member.ContainingType, prevProp.Member?.IsNullable == true)
+                (expr, prevProp, prop) => prop.Getter.BuildAccess(expr, prop.Member.ContainingType, prevProp.Member?.IsReadNullable == true)
             );
         }
 
@@ -94,14 +94,14 @@ public class MemberPathGetter
 
     private ExpressionSyntax? BuildNonNullConditionWithoutConditionalAccess(ExpressionSyntax baseAccess)
     {
-        var nullablePath = PathWithoutTrailingNonNullable();
+        var nullablePath = ReadPathWithoutTrailingNonNullable();
         var access = baseAccess;
         var conditions = new List<BinaryExpressionSyntax>();
         foreach (var pathPart in nullablePath)
         {
             access = pathPart.Getter.BuildAccess(access, pathPart.Member.ContainingType);
 
-            if (!pathPart.Member.IsNullable)
+            if (!pathPart.Member.IsReadNullable)
                 continue;
 
             conditions.Add(IsNotNull(access));
@@ -110,8 +110,8 @@ public class MemberPathGetter
         return conditions.Count == 0 ? null : And(conditions);
     }
 
-    private IEnumerable<MemberGetterPair> PathWithoutTrailingNonNullable() =>
-        _path.Reverse().SkipWhile(x => !x.Member.IsNullable).Reverse();
+    private IEnumerable<MemberGetterPair> ReadPathWithoutTrailingNonNullable() =>
+        _path.Reverse().SkipWhile(x => !x.Member.IsReadNullable).Reverse();
 
     public override bool Equals(object? obj)
     {

--- a/src/Riok.Mapperly/Symbols/Members/NonEmptyMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/NonEmptyMemberPath.cs
@@ -26,7 +26,7 @@ public class NonEmptyMemberPath : MemberPath
     /// Gets the type of the <see cref="Member"/>. If any part of the path is nullable, this type will be nullable too.
     /// </summary>
     public override ITypeSymbol MemberType =>
-        IsAnyNullable() ? Member.Type.WithNullableAnnotation(NullableAnnotation.Annotated) : Member.Type;
+        IsAnyReadNullable() ? Member.Type.WithNullableAnnotation(NullableAnnotation.Annotated) : Member.Type;
 
     public MemberPathSetter BuildSetter(SimpleMappingBuilderContext ctx) => MemberPathSetter.Build(ctx, this);
 

--- a/src/Riok.Mapperly/Symbols/Members/NonEmptyMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/NonEmptyMemberPath.cs
@@ -36,6 +36,10 @@ public class NonEmptyMemberPath : MemberPath
 
     public MemberPathSetter BuildSetter(SimpleMappingBuilderContext ctx) => MemberPathSetter.Build(ctx, this);
 
+    public override bool IsAnyReadNullable() => Path.Any(x => x.IsReadNullable);
+
+    public override bool IsWriteNullable() => Path[^1].IsWriteNullable;
+
     public override string ToDisplayString(bool includeRootType = true, bool includeMemberType = true)
     {
         var ofType = includeMemberType ? $" of type {Member.Type.ToDisplayString()}" : null;

--- a/src/Riok.Mapperly/Symbols/Members/NonEmptyMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/NonEmptyMemberPath.cs
@@ -12,6 +12,9 @@ public class NonEmptyMemberPath : MemberPath
             throw new ArgumentException("Parameter can not be empty!", nameof(path));
     }
 
+    private ITypeSymbol? _memberReadType;
+    private ITypeSymbol? _memberWriteType;
+
     /// <summary>
     /// Gets the last part of the path.
     /// </summary>
@@ -26,13 +29,13 @@ public class NonEmptyMemberPath : MemberPath
     /// Gets the type of the <see cref="Member"/> in the context of read. If any part of the path is nullable, this type will be nullable too.
     /// </summary>
     public override ITypeSymbol MemberReadType =>
-        IsAnyReadNullable() ? Member.Type.WithNullableAnnotation(NullableAnnotation.Annotated) : Member.Type;
+        _memberReadType ??= IsAnyReadNullable() ? Member.Type.WithNullableAnnotation(NullableAnnotation.Annotated) : Member.Type;
 
     /// <summary>
     /// Gets the type of the <see cref="Member"/> in the context of write. If last part of the path is nullable, this type will be nullable too.
     /// </summary>
     public override ITypeSymbol MemberWriteType =>
-        IsWriteNullable() ? Member.Type.WithNullableAnnotation(NullableAnnotation.Annotated) : Member.Type;
+        _memberWriteType ??= IsWriteNullable() ? Member.Type.WithNullableAnnotation(NullableAnnotation.Annotated) : Member.Type;
 
     public MemberPathSetter BuildSetter(SimpleMappingBuilderContext ctx) => MemberPathSetter.Build(ctx, this);
 

--- a/src/Riok.Mapperly/Symbols/Members/NonEmptyMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/NonEmptyMemberPath.cs
@@ -29,7 +29,7 @@ public class NonEmptyMemberPath : MemberPath
         IsAnyReadNullable() ? Member.Type.WithNullableAnnotation(NullableAnnotation.Annotated) : Member.Type;
 
     /// <summary>
-    /// Gets the type of the <see cref="Member"/> in the context of write. If any part of the path is nullable, this type will be nullable too.
+    /// Gets the type of the <see cref="Member"/> in the context of write. If last part of the path is nullable, this type will be nullable too.
     /// </summary>
     public override ITypeSymbol MemberWriteType =>
         IsWriteNullable() ? Member.Type.WithNullableAnnotation(NullableAnnotation.Annotated) : Member.Type;

--- a/src/Riok.Mapperly/Symbols/Members/NonEmptyMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/NonEmptyMemberPath.cs
@@ -23,16 +23,14 @@ public class NonEmptyMemberPath : MemberPath
     public string RootName => Path[0].Name;
 
     /// <summary>
-    /// Gets the type of the <see cref="Member"/>. If any part of the path is nullable, this type will be nullable too.
+    /// Gets the type of the <see cref="Member"/> in the context of read. If any part of the path is nullable, this type will be nullable too.
     /// </summary>
-    public override ITypeSymbol MemberType =>
-        IsAnyReadNullable() ? Member.Type.WithNullableAnnotation(NullableAnnotation.Annotated) : Member.Type;
-
-    //todo - summary
     public override ITypeSymbol MemberReadType =>
         IsAnyReadNullable() ? Member.Type.WithNullableAnnotation(NullableAnnotation.Annotated) : Member.Type;
 
-    //todo - summary
+    /// <summary>
+    /// Gets the type of the <see cref="Member"/> in the context of write. If any part of the path is nullable, this type will be nullable too.
+    /// </summary>
     public override ITypeSymbol MemberWriteType =>
         IsWriteNullable() ? Member.Type.WithNullableAnnotation(NullableAnnotation.Annotated) : Member.Type;
 

--- a/src/Riok.Mapperly/Symbols/Members/NonEmptyMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/NonEmptyMemberPath.cs
@@ -13,6 +13,7 @@ public class NonEmptyMemberPath : MemberPath
     }
 
     private ITypeSymbol? _memberReadType;
+
     private ITypeSymbol? _memberWriteType;
 
     /// <summary>

--- a/src/Riok.Mapperly/Symbols/Members/NonEmptyMemberPath.cs
+++ b/src/Riok.Mapperly/Symbols/Members/NonEmptyMemberPath.cs
@@ -28,6 +28,14 @@ public class NonEmptyMemberPath : MemberPath
     public override ITypeSymbol MemberType =>
         IsAnyReadNullable() ? Member.Type.WithNullableAnnotation(NullableAnnotation.Annotated) : Member.Type;
 
+    //todo - summary
+    public override ITypeSymbol MemberReadType =>
+        IsAnyReadNullable() ? Member.Type.WithNullableAnnotation(NullableAnnotation.Annotated) : Member.Type;
+
+    //todo - summary
+    public override ITypeSymbol MemberWriteType =>
+        IsWriteNullable() ? Member.Type.WithNullableAnnotation(NullableAnnotation.Annotated) : Member.Type;
+
     public MemberPathSetter BuildSetter(SimpleMappingBuilderContext ctx) => MemberPathSetter.Build(ctx, this);
 
     public override string ToDisplayString(bool includeRootType = true, bool includeMemberType = true)

--- a/src/Riok.Mapperly/Symbols/Members/ParameterSourceMember.cs
+++ b/src/Riok.Mapperly/Symbols/Members/ParameterSourceMember.cs
@@ -20,9 +20,9 @@ public class ParameterSourceMember(MethodParameter parameter, SymbolAccessor sym
     public ITypeSymbol Type => parameter.Type;
     public INamedTypeSymbol? ContainingType => null;
     public bool IsReadNullable =>
-        parameter.symbol is not null ? symbolAccessor.IsReadNullable(parameter.symbol) : parameter.Type.IsNullable();
+        parameter.Symbol is not null ? symbolAccessor.IsReadNullable(parameter.Symbol) : parameter.Type.IsNullable();
     public bool IsWriteNullable =>
-        parameter.symbol is not null ? symbolAccessor.IsWriteNullable(parameter.symbol) : parameter.Type.IsNullable();
+        parameter.Symbol is not null ? symbolAccessor.IsWriteNullable(parameter.Symbol) : parameter.Type.IsNullable();
     public bool CanGet => true;
     public bool CanGetDirectly => true;
     public bool CanSet => false;

--- a/src/Riok.Mapperly/Symbols/Members/ParameterSourceMember.cs
+++ b/src/Riok.Mapperly/Symbols/Members/ParameterSourceMember.cs
@@ -20,6 +20,8 @@ public class ParameterSourceMember(MethodParameter parameter) : IMappableMember,
     public ITypeSymbol Type => parameter.Type;
     public INamedTypeSymbol? ContainingType => null;
     public bool IsNullable => parameter.Type.IsNullable();
+    public bool IsReadNullable => parameter.Type.IsNullable();
+    public bool IsWriteNullable => parameter.Type.IsNullable();
     public bool CanGet => true;
     public bool CanGetDirectly => true;
     public bool CanSet => false;

--- a/src/Riok.Mapperly/Symbols/Members/ParameterSourceMember.cs
+++ b/src/Riok.Mapperly/Symbols/Members/ParameterSourceMember.cs
@@ -14,13 +14,15 @@ namespace Riok.Mapperly.Symbols.Members;
 /// and is therefore in terms of the mapping the same.
 /// </summary>
 [DebuggerDisplay("{Name}")]
-public class ParameterSourceMember(MethodParameter parameter) : IMappableMember, IMemberGetter
+public class ParameterSourceMember(MethodParameter parameter, SymbolAccessor symbolAccessor) : IMappableMember, IMemberGetter
 {
     public string Name => parameter.Name;
     public ITypeSymbol Type => parameter.Type;
     public INamedTypeSymbol? ContainingType => null;
-    public bool IsReadNullable => parameter.Type.IsNullable();
-    public bool IsWriteNullable => parameter.Type.IsNullable();
+    public bool IsReadNullable =>
+        parameter.symbol is not null ? symbolAccessor.IsReadNullable(parameter.symbol) : parameter.Type.IsNullable();
+    public bool IsWriteNullable =>
+        parameter.symbol is not null ? symbolAccessor.IsWriteNullable(parameter.symbol) : parameter.Type.IsNullable();
     public bool CanGet => true;
     public bool CanGetDirectly => true;
     public bool CanSet => false;

--- a/src/Riok.Mapperly/Symbols/Members/ParameterSourceMember.cs
+++ b/src/Riok.Mapperly/Symbols/Members/ParameterSourceMember.cs
@@ -19,7 +19,6 @@ public class ParameterSourceMember(MethodParameter parameter) : IMappableMember,
     public string Name => parameter.Name;
     public ITypeSymbol Type => parameter.Type;
     public INamedTypeSymbol? ContainingType => null;
-    public bool IsNullable => parameter.Type.IsNullable();
     public bool IsReadNullable => parameter.Type.IsNullable();
     public bool IsWriteNullable => parameter.Type.IsNullable();
     public bool CanGet => true;

--- a/src/Riok.Mapperly/Symbols/Members/PropertyMember.cs
+++ b/src/Riok.Mapperly/Symbols/Members/PropertyMember.cs
@@ -19,8 +19,6 @@ public class PropertyMember(IPropertySymbol symbol, SymbolAccessor symbolAccesso
 
     public INamedTypeSymbol? ContainingType { get; } = symbol.ContainingType;
 
-    public bool IsNullable => symbolAccessor.IsNullable(Symbol);
-
     public bool IsReadNullable => symbolAccessor.IsReadNullable(Symbol);
 
     public bool IsWriteNullable => symbolAccessor.IsWriteNullable(Symbol);

--- a/src/Riok.Mapperly/Symbols/Members/PropertyMember.cs
+++ b/src/Riok.Mapperly/Symbols/Members/PropertyMember.cs
@@ -21,6 +21,10 @@ public class PropertyMember(IPropertySymbol symbol, SymbolAccessor symbolAccesso
 
     public bool IsNullable => symbolAccessor.IsNullable(Symbol);
 
+    public bool IsReadNullable => symbolAccessor.IsReadNullable(Symbol);
+
+    public bool IsWriteNullable => symbolAccessor.IsWriteNullable(Symbol);
+
     public bool CanGet => !Symbol.IsWriteOnly && (Symbol.GetMethod == null || symbolAccessor.IsMemberAccessible(Symbol.GetMethod));
 
     public bool CanGetDirectly =>

--- a/src/Riok.Mapperly/Symbols/MethodParameter.cs
+++ b/src/Riok.Mapperly/Symbols/MethodParameter.cs
@@ -7,7 +7,7 @@ public readonly record struct MethodParameter(
     int Ordinal,
     string Name,
     ITypeSymbol Type,
-    IParameterSymbol? symbol = null,
+    IParameterSymbol? Symbol = null,
     RefKind RefKind = RefKind.None
 )
 {

--- a/src/Riok.Mapperly/Symbols/MethodParameter.cs
+++ b/src/Riok.Mapperly/Symbols/MethodParameter.cs
@@ -3,15 +3,22 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Riok.Mapperly.Symbols;
 
-public readonly record struct MethodParameter(int Ordinal, string Name, ITypeSymbol Type, RefKind RefKind = RefKind.None)
+public readonly record struct MethodParameter(
+    int Ordinal,
+    string Name,
+    ITypeSymbol Type,
+    IParameterSymbol? symbol = null,
+    RefKind RefKind = RefKind.None
+)
 {
+    //todo - has doubt
     private static readonly SymbolDisplayFormat _parameterNameFormat = new(
         parameterOptions: SymbolDisplayParameterOptions.IncludeName,
         miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers
     );
 
     public MethodParameter(IParameterSymbol symbol, ITypeSymbol parameterType)
-        : this(symbol.Ordinal, symbol.ToDisplayString(_parameterNameFormat), parameterType, symbol.RefKind) { }
+        : this(symbol.Ordinal, symbol.ToDisplayString(_parameterNameFormat), parameterType, symbol, symbol.RefKind) { }
 
     /// <summary>
     /// The parameter name with the verbatim identifier prefix (<c>@</c>) removed.

--- a/src/Riok.Mapperly/Symbols/MethodParameter.cs
+++ b/src/Riok.Mapperly/Symbols/MethodParameter.cs
@@ -11,7 +11,6 @@ public readonly record struct MethodParameter(
     RefKind RefKind = RefKind.None
 )
 {
-    //todo - has doubt
     private static readonly SymbolDisplayFormat _parameterNameFormat = new(
         parameterOptions: SymbolDisplayParameterOptions.IncludeName,
         miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
@@ -790,8 +790,21 @@ public class ObjectPropertyFlatteningTest
         );
 
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.NullableSourceValueToNonNullableTargetValue,
+                "Mapping the nullable source property Value1.Id100 of A to the target property Value2.Id200 of B which is not nullable"
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.NullableSourceValueToNonNullableTargetValue,
+                "Mapping the nullable source property Value1.Value1.Id1 of A to the target property Value2.Value2.Id2 of B which is not nullable"
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.NullableSourceValueToNonNullableTargetValue,
+                "Mapping the nullable source property Value1.Value1.Id10 of A to the target property Value2.Value2.Id20 of B which is not nullable"
+            )
+            .HaveAssertedAllDiagnostics()
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFlatteningTest.cs
@@ -774,7 +774,7 @@ public class ObjectPropertyFlatteningTest
     }
 
     [Fact]
-    public void ManualNestedPropertyNullablePath()
+    public void ManualNestedPropertyNullablePathShouldDiagnoseNullableProperty()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             "[MapProperty(\"Value1.Value1.Id1\", \"Value2.Value2.Id2\")]"

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFromSourceTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFromSourceTest.cs
@@ -441,7 +441,7 @@ public class ObjectPropertyFromSourceTest
     }
 
     [Fact]
-    public void ReturnMaybeNullMethodToMaybeNullTargetProperty()
+    public void ReturnMaybeNullMethodToMaybeNullTargetPropertyShouldDiagnoseNullableSource()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             """
@@ -479,7 +479,7 @@ public class ObjectPropertyFromSourceTest
     }
 
     [Fact]
-    public void ReturnMaybeNullMethodToMaybeNullTargetPropertyv2()
+    public void ReturnMaybeNullMethodToAllowNullTargetProperty()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             """

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFromSourceTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyFromSourceTest.cs
@@ -462,6 +462,44 @@ public class ObjectPropertyFromSourceTest
         );
 
         TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.NullableSourceTypeToNonNullableTargetType,
+                "Mapping the nullable source of type string? to target of type string which is not nullable"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = BuildValue(source) ?? throw new global::System.NullReferenceException("BuildValue returned null");
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ReturnMaybeNullMethodToMaybeNullTargetPropertyv2()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapPropertyFromSource(nameof(B.Value), Use = nameof(BuildValue))]
+            partial B Map(A source);
+
+            [return: System.Diagnostics.CodeAnalysis.MaybeNull]
+            string BuildValue(A a) => a.Name;
+            """,
+            "class A { public string Name { get; set; } }",
+            """
+            class B
+            {
+                [System.Diagnostics.CodeAnalysis.AllowNull]
+                public string Value { get; set; } = default!;
+            }
+            """
+        );
+
+        TestHelper
             .GenerateMapper(source)
             .Should()
             .HaveSingleMethodBody(

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNestedTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNestedTest.cs
@@ -45,8 +45,13 @@ public class ObjectPropertyNestedTest
         );
 
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.NullableSourceValueToNonNullableTargetValue,
+                "Mapping the nullable source property Value.IntValue of A to the target property Value.StringValue of B which is not nullable"
+            )
+            .HaveAssertedAllDiagnostics()
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNestedTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNestedTest.cs
@@ -31,7 +31,7 @@ public class ObjectPropertyNestedTest
     }
 
     [Fact]
-    public void ManualNullableNestedToNullableNestedProperty()
+    public void ManualNullableNestedToNullableNestedPropertyShouldDiagnoseNullableSourceProperty()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             """

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
@@ -1071,8 +1071,13 @@ public class ObjectPropertyNullableTest
         );
 
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.NullableSourceValueToNonNullableTargetValue,
+                "Mapping the nullable source property Name of A to the target property Name of B which is not nullable"
+            )
+            .HaveAssertedAllDiagnostics()
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();
@@ -1174,8 +1179,13 @@ public class ObjectPropertyNullableTest
         );
 
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.NullableSourceValueToNonNullableTargetValue,
+                "Mapping the nullable source property Value of A to the target property Value of B which is not nullable"
+            )
+            .HaveAssertedAllDiagnostics()
             .HaveMapMethodBody(
                 """
                 var target = new global::B();
@@ -1217,8 +1227,13 @@ public class ObjectPropertyNullableTest
         );
 
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.NullableSourceValueToNonNullableTargetValue,
+                "Mapping the nullable source property Value of A to the target property Value of B which is not nullable"
+            )
+            .HaveAssertedAllDiagnostics()
             .HaveMapMethodBody(
                 """
                 var target = new global::B();
@@ -1226,6 +1241,40 @@ public class ObjectPropertyNullableTest
                 {
                     target.Value = MapToD(source.Value);
                 }
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MaybeNullSourceToAllowNullTargetProperty()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            """
+            class A
+            {
+                [System.Diagnostics.CodeAnalysis.MaybeNull]
+                public string Name { get; set; } = default!;
+            }
+            """,
+            """
+            class B
+            {
+                [System.Diagnostics.CodeAnalysis.AllowNull]
+                public string Name { get; set; } = default!;
+            }
+            """
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Name = source.Name;
                 return target;
                 """
             );

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
@@ -1076,7 +1076,10 @@ public class ObjectPropertyNullableTest
             .HaveSingleMethodBody(
                 """
                 var target = new global::B();
-                target.Name = source.Name;
+                if (source.Name != null)
+                {
+                    target.Name = source.Name;
+                }
                 return target;
                 """
             );
@@ -1179,10 +1182,6 @@ public class ObjectPropertyNullableTest
                 if (source.Value != null)
                 {
                     target.Value = MapToD(source.Value);
-                }
-                else
-                {
-                    target.Value = null;
                 }
                 return target;
                 """

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
@@ -1049,7 +1049,7 @@ public class ObjectPropertyNullableTest
     }
 
     [Fact]
-    public void MaybeNullSourceToMaybeNullTargetProperty()
+    public void MaybeNullSourceToMaybeNullTargetPropertyShouldDiagnoseNullableSource()
     {
         var source = TestSourceBuilder.Mapping(
             "A",
@@ -1155,7 +1155,7 @@ public class ObjectPropertyNullableTest
     }
 
     [Fact]
-    public void MaybeNullSourceClassToMaybeNullTargetClassPropertyShouldSetNull()
+    public void MaybeNullSourceClassToMaybeNullTargetClassPropertyShouldDiagnoseNullableSourceClass()
     {
         var source = TestSourceBuilder.Mapping(
             "A",
@@ -1199,7 +1199,7 @@ public class ObjectPropertyNullableTest
     }
 
     [Fact]
-    public void MaybeNullSourceClassToMaybeNullTargetClassPropertyWithNoNullAssignment()
+    public void MaybeNullSourceClassToMaybeNullTargetClassPropertyWithNoNullAssignmentShouldDiagnoseNullableSourceClass()
     {
         var source = TestSourceBuilder.Mapping(
             "A",

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
@@ -1279,4 +1279,118 @@ public class ObjectPropertyNullableTest
                 """
             );
     }
+
+    [Fact]
+    public void NonNullableSourceToAllowNullTargetProperty()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            "class A { public string Name { get; set; } }",
+            """
+            class B
+            {
+                [System.Diagnostics.CodeAnalysis.AllowNull]
+                public string Name { get; set; } = default!;
+            }
+            """
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Name = source.Name;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MaybeNullSourceClassToAllowNullTargetClassPropertyShouldSetNull()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            """
+            class A
+            {
+                [System.Diagnostics.CodeAnalysis.MaybeNull]
+                public C Value { get; set; } = default!;
+            }
+            """,
+            """
+            class B
+            {
+                [System.Diagnostics.CodeAnalysis.AllowNull]
+                public D Value { get; set; } = default!;
+            }
+            """,
+            "class C { public string V { get; set; } }",
+            "class D { public string V { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                if (source.Value != null)
+                {
+                    target.Value = MapToD(source.Value);
+                }
+                else
+                {
+                    target.Value = null;
+                }
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MaybeNullSourceClassToAllowNullTargetClassPropertyWithNoNullAssignment()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            TestSourceBuilderOptions.Default with
+            {
+                AllowNullPropertyAssignment = false,
+            },
+            """
+            class A
+            {
+                [System.Diagnostics.CodeAnalysis.MaybeNull]
+                public C Value { get; set; } = default!;
+            }
+            """,
+            """
+            class B
+            {
+                [System.Diagnostics.CodeAnalysis.AllowNull]
+                public D Value { get; set; } = default!;
+            }
+            """,
+            "class C { public string V { get; set; } }",
+            "class D { public string V { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                if (source.Value != null)
+                {
+                    target.Value = MapToD(source.Value);
+                }
+                return target;
+                """
+            );
+    }
 }

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyValueMethodTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyValueMethodTest.cs
@@ -686,7 +686,7 @@ public class ObjectPropertyValueMethodTest
             .Should()
             .HaveDiagnostic(
                 DiagnosticDescriptors.MapValueMethodTypeMismatch,
-                "Cannot assign method return type string of BuildValue() to B.Value of type string"
+                "Cannot assign method return type string? of BuildValue() to B.Value of type string"
             )
             .HaveAssertedAllDiagnostics();
     }
@@ -715,7 +715,7 @@ public class ObjectPropertyValueMethodTest
             .Should()
             .HaveDiagnostic(
                 DiagnosticDescriptors.MapValueMethodTypeMismatch,
-                "Cannot assign method return type string of BuildValue() to B.Value of type string"
+                "Cannot assign method return type string? of BuildValue() to B.Value of type string"
             )
             .HaveAssertedAllDiagnostics();
     }

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyValueMethodTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyValueMethodTest.cs
@@ -611,7 +611,7 @@ public class ObjectPropertyValueMethodTest
     }
 
     [Fact]
-    public void MethodToMaybeNullTargetPropertyShouldAllowNullableReturnType()
+    public void ReturnNullableMethodToMaybeNullTargetPropertyShouldDiagnoseNullableReturnType()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             """
@@ -692,7 +692,7 @@ public class ObjectPropertyValueMethodTest
     }
 
     [Fact]
-    public void ReturnMaybeNullMethodToMaybeNullTargetProperty()
+    public void ReturnMaybeNullMethodToMaybeNullTargetPropertyShouldDiagnostic()
     {
         var source = TestSourceBuilder.MapperWithBodyAndTypes(
             """

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyValueMethodTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyValueMethodTest.cs
@@ -629,15 +629,13 @@ public class ObjectPropertyValueMethodTest
         );
 
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
-            .HaveSingleMethodBody(
-                """
-                var target = new global::B();
-                target.Value = BuildValue();
-                return target;
-                """
-            );
+            .HaveDiagnostic(
+                DiagnosticDescriptors.MapValueMethodTypeMismatch,
+                "Cannot assign method return type string? of BuildValue() to B.Value of type string"
+            )
+            .HaveAssertedAllDiagnostics();
     }
 
     [Fact]
@@ -713,14 +711,12 @@ public class ObjectPropertyValueMethodTest
         );
 
         TestHelper
-            .GenerateMapper(source)
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
             .Should()
-            .HaveSingleMethodBody(
-                """
-                var target = new global::B();
-                target.Value = BuildValue();
-                return target;
-                """
-            );
+            .HaveDiagnostic(
+                DiagnosticDescriptors.MapValueMethodTypeMismatch,
+                "Cannot assign method return type string of BuildValue() to B.Value of type string"
+            )
+            .HaveAssertedAllDiagnostics();
     }
 }

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyValueMethodTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyValueMethodTest.cs
@@ -719,4 +719,95 @@ public class ObjectPropertyValueMethodTest
             )
             .HaveAssertedAllDiagnostics();
     }
+
+    [Fact]
+    public void MethodToAllowNullTargetPropertyShouldAllowNullableReturnType()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("Value", Use = nameof(BuildValue))] partial B Map(A source);
+            string? BuildValue() => null;
+            """,
+            "class A;",
+            """
+            class B
+            {
+                [System.Diagnostics.CodeAnalysis.AllowNull]
+                public string Value { get; set; } = default!;
+            }
+            """
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = BuildValue();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void MethodToAllowTargetPropertyShouldAllowNonNullableReturnType()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("Value", Use = nameof(BuildValue))] partial B Map(A source);
+            string BuildValue() => "hello";
+            """,
+            "class A;",
+            """
+            class B
+            {
+                [System.Diagnostics.CodeAnalysis.AllowNull]
+                public string Value { get; set; } = default!;
+            }
+            """
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = BuildValue();
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ReturnMaybeNullMethodToAllowNullTargetProperty()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapValue("Value", Use = nameof(BuildValue))] partial B Map(A source);
+            [return: System.Diagnostics.CodeAnalysis.MaybeNull]
+            string BuildValue() => null!;
+            """,
+            "class A;",
+            """
+            class B
+            {
+                [System.Diagnostics.CodeAnalysis.AllowNull]
+                public string Value { get; set; } = default!;
+            }
+            """
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Value = BuildValue();
+                return target;
+                """
+            );
+    }
 }


### PR DESCRIPTION
# Add null checks when mapping nullable sources to non-nullable targets with MayBeNull Attribute

## Description

<!-- Please include a summary of the changes and the related issue. -->

For target members, [MaybeNull] should not be considered when determining nullability. 
Otherwise, it may lead to incorrect nullable analysis and result in CS8601 ("Possible null reference assignment") warnings.

Fixes #2192

## Checklist

- [x] I did not use AI tools to generate this PR, or I have manually verified that the code is correct, optimal, and follows the project guidelines and architecture
- [x] I understand that low-quality, AI-generated PRs will be closed immediately without further explanation
- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
