### PR TITLE
Fix list initialization syntax in `SourceEmitter`

### DIFF
--- a/src/Riok.Mapperly/Emit/SourceEmitter.cs
+++ b/src/Riok.Mapperly/Emit/SourceEmitter.cs
@@ -20,7 +20,7 @@ public static class SourceEmitter
         );
         var mapper = BuildMapper(ctx, descriptor, cancellationToken);
 
-        var members = new List<MemberDeclarationSyntax>(descriptor.UnsafeAccessors?.Count ?? 0 + 1) { mapper };
+        var members = new List<MemberDeclarationSyntax>((descriptor.UnsafeAccessors?.Count ?? 0) + 1) { mapper };
         members.AddRange(descriptor.UnsafeAccessors?.Build(ctx, cancellationToken) ?? []);
 
         var memberSyntaxes = List(members.SeparateByTrailingLineFeed(ctx.SyntaxFactory.Indentation));


### PR DESCRIPTION
# Fix list initialization syntax in `SourceEmitter`

## Description

Parenthesize `??` as `+` binds stronger

<!-- Please include a summary of the changes and the related issue. -->

Fixes # (issue)

## Checklist

- [x] I did not use AI tools to generate this PR, or I have manually verified that the code is correct, optimal, and follows the project guidelines and architecture
- [x] I understand that low-quality, AI-generated PRs will be closed immediately without further explanation
- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
