### PR TITLE
feat: allow multiple IncludeMappingConfiguration attributes

### DIFF
--- a/src/Riok.Mapperly.Abstractions/IncludeMappingConfigurationAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/IncludeMappingConfigurationAttribute.cs
@@ -6,7 +6,7 @@ namespace Riok.Mapperly.Abstractions;
 /// An attribute used to include the mapping configuration of another mapping method in the attributed method.
 /// Use the other mapping's method name to identify the configuration.
 /// </summary>
-[AttributeUsage(AttributeTargets.Method)]
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 [Conditional("MAPPERLY_ABSTRACTIONS_SCOPE_RUNTIME")]
 public sealed class IncludeMappingConfigurationAttribute : Attribute
 {

--- a/test/Riok.Mapperly.Abstractions.Tests/_snapshots/PublicApiTest.PublicApiHasNotChanged.verified.cs
+++ b/test/Riok.Mapperly.Abstractions.Tests/_snapshots/PublicApiTest.PublicApiHasNotChanged.verified.cs
@@ -34,7 +34,7 @@ namespace Riok.Mapperly.Abstractions
         Source = 1,
         Target = 2,
     }
-    [System.AttributeUsage(System.AttributeTargets.Method)]
+    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=true)]
     [System.Diagnostics.Conditional("MAPPERLY_ABSTRACTIONS_SCOPE_RUNTIME")]
     public sealed class IncludeMappingConfigurationAttribute : System.Attribute
     {


### PR DESCRIPTION
Allows multiple `IncludeMappingConfiguration` attributes. A test already existed: `Riok.Mapperly.Tests.Mapping.IncludeMappingConfigurationTest.IncludesMultipleConfigs`.
Fixes #2315
