### PR TITLE
fix: detect MaybeNull/AllowNull on properties from referenced assemblies

### DIFF
--- a/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
@@ -96,7 +96,7 @@ public class SymbolAccessor(CompilationContext compilationContext, INamedTypeSym
         return symbol switch
         {
             ITypeSymbol t => t.IsNullable(),
-            IPropertySymbol p => p.Type.IsNullable() || TryHasAttribute<MaybeNullAttribute>(p),
+            IPropertySymbol p => p.Type.IsNullable() || TryHasGetAttribute<MaybeNullAttribute>(p),
             IFieldSymbol f => f.Type.IsNullable() || TryHasAttribute<MaybeNullAttribute>(f),
             IParameterSymbol p => p.Type.IsNullable() || TryHasAttribute<MaybeNullAttribute>(p),
             _ => false,
@@ -108,7 +108,7 @@ public class SymbolAccessor(CompilationContext compilationContext, INamedTypeSym
         return symbol switch
         {
             ITypeSymbol t => t.IsNullable(),
-            IPropertySymbol p => p.Type.IsNullable() || TryHasAttribute<AllowNullAttribute>(p),
+            IPropertySymbol p => p.Type.IsNullable() || TryHasSetAttribute<AllowNullAttribute>(p),
             IFieldSymbol f => f.Type.IsNullable() || TryHasAttribute<AllowNullAttribute>(f),
             IParameterSymbol p => p.Type.IsNullable() || TryHasAttribute<AllowNullAttribute>(p),
             _ => false,
@@ -353,6 +353,26 @@ public class SymbolAccessor(CompilationContext compilationContext, INamedTypeSym
 
     internal bool TryHasAttribute<T>(IEnumerable<AttributeData> symbol)
         where T : Attribute => TryGetAttributes<T>(symbol).Any();
+
+    /// <summary>
+    /// Whether the property or its getter is annotated with the attribute <typeparamref name="T"/>.
+    /// For properties loaded from metadata (e.g. referenced assemblies) Roslyn exposes flow attributes
+    /// such as <see cref="MaybeNullAttribute"/> on the return value of the getter instead of the property itself,
+    /// therefore both locations need to be checked.
+    /// </summary>
+    internal bool TryHasGetAttribute<T>(IPropertySymbol symbol)
+        where T : Attribute =>
+        TryHasAttribute<T>(symbol) || (symbol.GetMethod != null && TryHasAttribute<T>(symbol.GetMethod.GetReturnTypeAttributes()));
+
+    /// <summary>
+    /// Whether the property or its setter value parameter is annotated with the attribute <typeparamref name="T"/>.
+    /// For properties loaded from metadata (e.g. referenced assemblies) Roslyn exposes flow attributes
+    /// such as <see cref="AllowNullAttribute"/> on the value parameter of the setter instead of the property itself,
+    /// therefore both locations need to be checked.
+    /// </summary>
+    internal bool TryHasSetAttribute<T>(IPropertySymbol symbol)
+        where T : Attribute =>
+        TryHasAttribute<T>(symbol) || (symbol.SetMethod is { Parameters: [var valueParameter, ..] } && TryHasAttribute<T>(valueParameter));
 
     internal IEnumerable<IMethodSymbol> GetAllMethods(ITypeSymbol symbol) => GetAllMembers(symbol).OfType<IMethodSymbol>();
 

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
@@ -1091,6 +1091,80 @@ public class ObjectPropertyNullableTest
     }
 
     [Fact]
+    public void MaybeNullSourceFromExternalAssemblyToNonNullableTargetProperty()
+    {
+        // https://github.com/riok/mapperly/issues/2192
+        // Roslyn exposes the MaybeNullAttribute of a property loaded from metadata (referenced assembly)
+        // on the return value of the getter instead of the property itself.
+        var aSource = TestSourceBuilder.SyntaxTree(
+            """
+            using System.Diagnostics.CodeAnalysis;
+            namespace External;
+            public class A
+            {
+                [MaybeNull]
+                public string Name { get; set; } = default!;
+            }
+            """
+        );
+        using var aAssembly = TestHelper.BuildAssembly("A", aSource);
+
+        var source = TestSourceBuilder.Mapping("External.A", "B", "class B { public string Name { get; set; } }");
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics, [aAssembly])
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.NullableSourceValueToNonNullableTargetValue,
+                "Mapping the nullable source property Name of External.A to the target property Name of B which is not nullable"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                if (source.Name != null)
+                {
+                    target.Name = source.Name;
+                }
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void NullableSourceToAllowNullTargetPropertyFromExternalAssembly()
+    {
+        // https://github.com/riok/mapperly/issues/2192
+        // Roslyn exposes the AllowNullAttribute of a property loaded from metadata (referenced assembly)
+        // on the value parameter of the setter instead of the property itself.
+        var bSource = TestSourceBuilder.SyntaxTree(
+            """
+            using System.Diagnostics.CodeAnalysis;
+            namespace External;
+            public class B
+            {
+                [AllowNull]
+                public string Name { get; set; } = default!;
+            }
+            """
+        );
+        using var bAssembly = TestHelper.BuildAssembly("B", bSource);
+
+        var source = TestSourceBuilder.Mapping("A", "External.B", "class A { public string? Name { get; set; } }");
+
+        TestHelper
+            .GenerateMapper(source, additionalAssemblies: [bAssembly])
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::External.B();
+                target.Name = source.Name;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public void MaybeNullSourceToNonNullableTargetProperty()
     {
         var source = TestSourceBuilder.Mapping(


### PR DESCRIPTION
For symbols loaded from metadata, Roslyn exposes the MaybeNull/AllowNull flow attributes on the getter return value / setter value parameter instead of the property itself. SymbolAccessor only checked the property symbol, so cross-assembly source properties were treated as non-nullable, omitting the null guard and producing CS8601.

Add TryHasGetAttribute/TryHasSetAttribute helpers that also inspect the accessors and use them in IsReadNullable/IsWriteNullable.

Fixes #2192

## Checklist

- [ ] I did not use AI tools to generate this PR, or I have manually verified that the code is correct, optimal, and follows the project guidelines and architecture
- [ ] I understand that low-quality, AI-generated PRs will be closed immediately without further explanation
- [ ] The existing code style is followed
- [ ] The commit message follows our guidelines
- [ ] Performed a self-review of my code
- [ ] Hard-to-understand areas of my code are commented
- [ ] The documentation is updated (as applicable)
- [ ] Unit tests are added/updated
- [ ] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
