### PR TITLE
fix: honor NotNull and DisallowNull nullability attributes

### DIFF
--- a/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
+++ b/src/Riok.Mapperly/Descriptors/SymbolAccessor.cs
@@ -93,24 +93,32 @@ public class SymbolAccessor(CompilationContext compilationContext, INamedTypeSym
 
     public bool IsReadNullable(ISymbol symbol)
     {
+        // A nullable typed member can only be narrowed to non-nullable by NotNull,
+        // a non-nullable typed member can only be widened to nullable by MaybeNull,
+        // therefore at most one attribute lookup is required.
         return symbol switch
         {
             ITypeSymbol t => t.IsNullable(),
-            IPropertySymbol p => p.Type.IsNullable() || TryHasGetAttribute<MaybeNullAttribute>(p),
-            IFieldSymbol f => f.Type.IsNullable() || TryHasAttribute<MaybeNullAttribute>(f),
-            IParameterSymbol p => p.Type.IsNullable() || TryHasAttribute<MaybeNullAttribute>(p),
+            IPropertySymbol p => p.Type.IsNullable() ? !TryHasGetAttribute<NotNullAttribute>(p) : TryHasGetAttribute<MaybeNullAttribute>(p),
+            IFieldSymbol f => f.Type.IsNullable() ? !TryHasAttribute<NotNullAttribute>(f) : TryHasAttribute<MaybeNullAttribute>(f),
+            IParameterSymbol p => p.Type.IsNullable() ? !TryHasAttribute<NotNullAttribute>(p) : TryHasAttribute<MaybeNullAttribute>(p),
             _ => false,
         };
     }
 
     public bool IsWriteNullable(ISymbol symbol)
     {
+        // A nullable typed member can only be narrowed to non-nullable by DisallowNull,
+        // a non-nullable typed member can only be widened to nullable by AllowNull,
+        // therefore at most one attribute lookup is required.
         return symbol switch
         {
             ITypeSymbol t => t.IsNullable(),
-            IPropertySymbol p => p.Type.IsNullable() || TryHasSetAttribute<AllowNullAttribute>(p),
-            IFieldSymbol f => f.Type.IsNullable() || TryHasAttribute<AllowNullAttribute>(f),
-            IParameterSymbol p => p.Type.IsNullable() || TryHasAttribute<AllowNullAttribute>(p),
+            IPropertySymbol p => p.Type.IsNullable()
+                ? !TryHasSetAttribute<DisallowNullAttribute>(p)
+                : TryHasSetAttribute<AllowNullAttribute>(p),
+            IFieldSymbol f => f.Type.IsNullable() ? !TryHasAttribute<DisallowNullAttribute>(f) : TryHasAttribute<AllowNullAttribute>(f),
+            IParameterSymbol p => p.Type.IsNullable() ? !TryHasAttribute<DisallowNullAttribute>(p) : TryHasAttribute<AllowNullAttribute>(p),
             _ => false,
         };
     }

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyNullableTest.cs
@@ -1165,6 +1165,142 @@ public class ObjectPropertyNullableTest
     }
 
     [Fact]
+    public void NotNullSourceToNonNullableTargetProperty()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            """
+            class A
+            {
+                [System.Diagnostics.CodeAnalysis.NotNull]
+                public string? Name { get; set; }
+            }
+            """,
+            "class B { public string Name { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Name = source.Name;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void NotNullSourceFromExternalAssemblyToNonNullableTargetProperty()
+    {
+        // Roslyn exposes the NotNullAttribute of a property loaded from metadata (referenced assembly)
+        // on the return value of the getter instead of the property itself.
+        var aSource = TestSourceBuilder.SyntaxTree(
+            """
+            using System.Diagnostics.CodeAnalysis;
+            namespace External;
+            public class A
+            {
+                [NotNull]
+                public string? Name { get; set; }
+            }
+            """
+        );
+        using var aAssembly = TestHelper.BuildAssembly("A", aSource);
+
+        var source = TestSourceBuilder.Mapping("External.A", "B", "class B { public string Name { get; set; } }");
+
+        TestHelper
+            .GenerateMapper(source, additionalAssemblies: [aAssembly])
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                target.Name = source.Name;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void NullableSourceToDisallowNullTargetProperty()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "A",
+            "B",
+            "class A { public string? Name { get; set; } }",
+            """
+            class B
+            {
+                [System.Diagnostics.CodeAnalysis.DisallowNull]
+                public string? Name { get; set; }
+            }
+            """
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.NullableSourceValueToNonNullableTargetValue,
+                "Mapping the nullable source property Name of A to the target property Name of B which is not nullable"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::B();
+                if (source.Name != null)
+                {
+                    target.Name = source.Name;
+                }
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void NullableSourceToDisallowNullTargetPropertyFromExternalAssembly()
+    {
+        // Roslyn exposes the DisallowNullAttribute of a property loaded from metadata (referenced assembly)
+        // on the value parameter of the setter instead of the property itself.
+        var bSource = TestSourceBuilder.SyntaxTree(
+            """
+            using System.Diagnostics.CodeAnalysis;
+            namespace External;
+            public class B
+            {
+                [DisallowNull]
+                public string? Name { get; set; }
+            }
+            """
+        );
+        using var bAssembly = TestHelper.BuildAssembly("B", bSource);
+
+        var source = TestSourceBuilder.Mapping("A", "External.B", "class A { public string? Name { get; set; } }");
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics, [bAssembly])
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.NullableSourceValueToNonNullableTargetValue,
+                "Mapping the nullable source property Name of A to the target property Name of External.B which is not nullable"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::External.B();
+                if (source.Name != null)
+                {
+                    target.Name = source.Name;
+                }
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public void MaybeNullSourceToNonNullableTargetProperty()
     {
         var source = TestSourceBuilder.Mapping(


### PR DESCRIPTION
Already honored MaybeNull (read) and AllowNull (write) to widen a non-nullable typed member to nullable. Add the symmetric narrowing:

- NotNull on a nullable-typed source member treats the read value as non-nullable, so no null guard is emitted.
- DisallowNull on a nullable-typed target member treats the write as non-nullable, so a null source is guarded/skipped.
