### PR TITLE
fix: don't let generic user mapping override explicitly referenced mappings

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/UseNamedMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/UseNamedMappingBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Riok.Mapperly.Descriptors.Mappings;
 using Riok.Mapperly.Descriptors.Mappings.ExistingTarget;
+using Riok.Mapperly.Descriptors.Mappings.UserMappings;
 using Riok.Mapperly.Diagnostics;
 using Riok.Mapperly.Helpers;
 
@@ -18,6 +19,23 @@ public static class UseNamedMappingBuilder
         {
             ctx.ReportDiagnostic(DiagnosticDescriptors.ReferencedMappingNotFound, ctx.MappingKey.Configuration.UseNamedMapping);
             return null;
+        }
+
+        // if a generic user-implemented mapping is referenced by name,
+        // create a concrete instantiation for the current source and target types
+        if (mapping is GenericUserImplementedNewInstanceMethodMapping genericTemplate)
+        {
+            mapping = genericTemplate.TryCreateConcreteMapping(ctx.GenericTypeChecker, ctx.Source, ctx.Target);
+            if (mapping == null)
+            {
+                ctx.ReportDiagnostic(
+                    DiagnosticDescriptors.ReferencedMappingSourceTypeMismatch,
+                    ctx.MappingKey.Configuration.UseNamedMapping,
+                    genericTemplate.SourceType.ToDisplayString(),
+                    ctx.Source.ToDisplayString()
+                );
+                return null;
+            }
         }
 
         if (!ctx.ParameterScope.TryUseParameters(mapping))
@@ -54,6 +72,23 @@ public static class UseNamedMappingBuilder
         var existingTargetMapping = ctx.FindExistingTargetNamedMapping(useNamedMapping);
         if (existingTargetMapping is null)
             return null;
+
+        // if a generic user-implemented mapping is referenced by name,
+        // create a concrete instantiation for the current source and target types
+        if (existingTargetMapping is GenericUserImplementedExistingTargetMethodMapping genericTemplate)
+        {
+            existingTargetMapping = genericTemplate.TryCreateConcreteMapping(ctx.GenericTypeChecker, ctx.Source, ctx.Target);
+            if (existingTargetMapping == null)
+            {
+                ctx.ReportDiagnostic(
+                    DiagnosticDescriptors.ReferencedMappingSourceTypeMismatch,
+                    useNamedMapping,
+                    genericTemplate.SourceType.ToDisplayString(),
+                    ctx.Source.ToDisplayString()
+                );
+                return null;
+            }
+        }
 
         if (!ctx.ParameterScope.TryUseParameters(existingTargetMapping))
         {

--- a/src/Riok.Mapperly/Descriptors/MappingCollection.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingCollection.cs
@@ -74,16 +74,40 @@ public class MappingCollection(GenericTypeChecker genericTypeChecker)
             .Concat(_newInstanceMappings.UsedDuplicatedNonDefaultNonReferencedUserMappings)
             .Concat(_existingTargetMappings.UsedDuplicatedNonDefaultNonReferencedUserMappings);
 
-    public INewInstanceMapping? FindNewInstanceMapping(TypeMappingKey mappingKey, ParameterScope? scope = null) =>
-        _newInstanceMappings.Find(mappingKey, scope) ?? TryMatchGenericNewInstanceTemplate(mappingKey);
+    public INewInstanceMapping? FindNewInstanceMapping(TypeMappingKey mappingKey, ParameterScope? scope = null)
+    {
+        if (_newInstanceMappings.Find(mappingKey, scope) is { } mapping)
+            return mapping;
+
+        // If an explicit mapping is referenced by name (Use = ...),
+        // do not match generic templates here.
+        // The referenced mapping is resolved later by the UseNamedMappingBuilder,
+        // otherwise a generic template would shadow the explicitly referenced mapping.
+        if (mappingKey.Configuration.UseNamedMapping != null)
+            return null;
+
+        return TryMatchGenericNewInstanceTemplate(mappingKey);
+    }
 
     public INewInstanceUserMapping? FindNewInstanceUserMapping(IMethodSymbol method) => _newInstanceMappings.FindUserMapping(method);
 
     public INewInstanceMapping? FindNamedNewInstanceMapping(string name, out bool ambiguousName) =>
         _newInstanceMappings.FindNamed(name, out ambiguousName);
 
-    public IExistingTargetMapping? FindExistingInstanceMapping(TypeMappingKey mappingKey) =>
-        _existingTargetMappings.Find(mappingKey) ?? TryMatchGenericExistingTargetTemplate(mappingKey);
+    public IExistingTargetMapping? FindExistingInstanceMapping(TypeMappingKey mappingKey)
+    {
+        if (_existingTargetMappings.Find(mappingKey) is { } mapping)
+            return mapping;
+
+        // If an explicit mapping is referenced by name (Use = ...),
+        // do not match generic templates here.
+        // The referenced mapping is resolved later by the UseNamedMappingBuilder,
+        // otherwise a generic template would shadow the explicitly referenced mapping.
+        if (mappingKey.Configuration.UseNamedMapping != null)
+            return null;
+
+        return TryMatchGenericExistingTargetTemplate(mappingKey);
+    }
 
     public IExistingTargetMapping? FindExistingInstanceNamedMapping(string name, out bool ambiguousName) =>
         _existingTargetMappings.FindNamed(name, out ambiguousName);

--- a/test/Riok.Mapperly.Tests/Mapping/UserMethodTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/UserMethodTest.cs
@@ -1222,4 +1222,76 @@ public class UserMethodTest
                 """
             );
     }
+
+    [Fact]
+    public void WithGenericUserImplementedDoesNotOverrideExplicitlyReferencedMapping()
+    {
+        // https://github.com/riok/mapperly/issues/2277
+        // a generic user-implemented mapping must not shadow a mapping
+        // which is explicitly referenced via Use on another member.
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapProperty(nameof(A.Value), nameof(B.Value), Use = nameof(MapInt))]
+            [MapProperty(nameof(A.Other), nameof(B.Other), Use = nameof(Identity))]
+            partial B Map(A source);
+
+            [UserMapping(Default = false)]
+            private T Identity<T>(T value) => value;
+
+            [UserMapping(Default = false)]
+            private int MapInt(int value) => value + 1;
+            """,
+            "class A { public int Value { get; set; } public int Other { get; set; } }",
+            "class B { public int Value { get; set; } public int Other { get; set; } }"
+        );
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                target.Value = MapInt(source.Value);
+                target.Other = Identity<int>(source.Other);
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void WithGenericUserImplementedExistingTargetDoesNotOverrideExplicitlyReferencedMapping()
+    {
+        // https://github.com/riok/mapperly/issues/2277
+        // same as above but for existing target (void) mappings.
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapProperty(nameof(A.Value), nameof(B.Value), Use = nameof(MapValue))]
+            [MapProperty(nameof(A.Other), nameof(B.Other), Use = nameof(MapGeneric))]
+            partial void Map(A source, B target);
+
+            [UserMapping(Default = false)]
+            private void MapGeneric<TSource, TTarget>(TSource source, [MappingTarget] TTarget target)
+                where TSource : IEntity
+                where TTarget : IDto
+                => target.Id = source.Id;
+
+            [UserMapping(Default = false)]
+            private void MapValue(C source, [MappingTarget] CDto target) => target.Id = source.Id + 1;
+            """,
+            "public interface IEntity { public int Id { get; } }",
+            "public interface IDto { public int Id { get; set; } }",
+            "public class C : IEntity { public int Id { get; set; } }",
+            "public class CDto : IDto { public int Id { get; set; } }",
+            "public class A { public C Value { get; set; } public C Other { get; set; } }",
+            "public class B { public CDto Value { get; set; } public CDto Other { get; set; } }"
+        );
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                MapValue(source.Value, target.Value);
+                MapGeneric<global::C, global::CDto>(source.Other, target.Other);
+                """
+            );
+    }
 }


### PR DESCRIPTION
A generic user-implemented mapping method matched any source/target type pair during mapping resolution, which happens before the Use= named mapping reference is resolved. As a result a generic method (e.g. T Identity<T>(T)) shadowed mappings that were explicitly referenced via Use on individual members.

Generic template matching is now skipped when a mapping is explicitly referenced by name, letting the UseNamedMappingBuilder resolve it. The named mapping builder also instantiates a concrete mapping when a generic method is referenced by name directly.

Closes #2277

## Checklist

- [x] I did not use AI tools to generate this PR, or I have manually verified that the code is correct, optimal, and follows the project guidelines and architecture
- [x] I understand that low-quality, AI-generated PRs will be closed immediately without further explanation
- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
