### PR TITLE
docs: csp

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "prebuild": "ts-node prebuild.ts",
+    "postbuild": "ts-node postbuild.ts",
     "prestart": "ts-node prebuild.ts",
     "docusaurus": "docusaurus",
     "start": "docusaurus start",

--- a/docs/postbuild.ts
+++ b/docs/postbuild.ts
@@ -1,0 +1,147 @@
+const { createHash } = require('crypto');
+const fsPromises = require('fs').promises;
+const path = require('path');
+
+const buildDir = './build';
+const headersFile = path.join(buildDir, '_headers');
+const externalScriptSources = [
+  'https://*.cloudflareinsights.com',
+  'https://cloudflareinsights.com',
+];
+const cspHeaderName = 'Content-Security-Policy';
+
+function createSha256Hash(content: string): string {
+  return `'sha256-${createHash('sha256').update(content, 'utf8').digest('base64')}'`;
+}
+
+async function findHtmlFiles(dir: string): Promise<string[]> {
+  const entries = await fsPromises.readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        return await findHtmlFiles(entryPath);
+      }
+
+      return entry.name.endsWith('.html') ? [entryPath] : [];
+    }),
+  );
+
+  return files.flat();
+}
+
+function hashInlineScripts(html: string): string[] {
+  const scriptRegex = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+  const hashes = new Set<string>();
+  let match: RegExpExecArray | null;
+
+  while ((match = scriptRegex.exec(html)) !== null) {
+    const [, attributes, body] = match;
+
+    if (/\bsrc\s*=/.test(attributes) || body.length === 0) {
+      continue;
+    }
+
+    hashes.add(createSha256Hash(body));
+  }
+
+  return [...hashes];
+}
+
+function hashInlineStyleAttributes(html: string): string[] {
+  const styleRegex = /\sstyle=(['"])([\s\S]*?)\1/gi;
+  const hashes = new Set<string>();
+  let match: RegExpExecArray | null;
+
+  while ((match = styleRegex.exec(html)) !== null) {
+    hashes.add(createSha256Hash(match[2]));
+  }
+
+  return [...hashes];
+}
+
+function createCsp(
+  scriptHashes: string[],
+  styleAttributeHashes: string[],
+): string {
+  const scriptSrc = [
+    'script-src',
+    "'self'",
+    ...scriptHashes.sort(),
+    ...externalScriptSources,
+  ].join(' ');
+
+  const styleAttributeSrc = [
+    'style-src-attr',
+    "'unsafe-hashes'",
+    ...styleAttributeHashes.sort(),
+  ].join(' ');
+
+  return [
+    'upgrade-insecure-requests',
+    'block-all-mixed-content',
+    "default-src 'self'",
+    scriptSrc,
+    "script-src-attr 'none'",
+    "style-src 'self' 'unsafe-hashes'",
+    "style-src-elem 'self'",
+    styleAttributeSrc,
+    "img-src 'self' data: https://img.shields.io/",
+    "object-src 'none'",
+    "connect-src 'self' https://*.cloudflareinsights.com https://cloudflareinsights.com",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+  ].join('; ');
+}
+
+function insertCspHeader(headers: string, csp: string): string {
+  const cspHeaderRegex = new RegExp(`^  ${cspHeaderName}: .+$`, 'm');
+  const cspHeader = `  ${cspHeaderName}: ${csp}`;
+
+  if (cspHeaderRegex.test(headers)) {
+    return headers.replace(cspHeaderRegex, cspHeader);
+  }
+
+  const referrerPolicyHeader = /^  Referrer-Policy: .+$/m;
+
+  if (!referrerPolicyHeader.test(headers)) {
+    throw new Error(`Could not find insertion point for ${cspHeaderName}`);
+  }
+
+  return headers.replace(
+    referrerPolicyHeader,
+    (match) => `${match}\n${cspHeader}`,
+  );
+}
+
+async function updateHeaders(): Promise<void> {
+  const headers = await fsPromises.readFile(headersFile, 'utf-8');
+
+  const scriptHashes = new Set<string>();
+  const styleAttributeHashes = new Set<string>();
+  const htmlFiles = await findHtmlFiles(buildDir);
+
+  for (const file of htmlFiles) {
+    const html = await fsPromises.readFile(file, 'utf-8');
+
+    for (const hash of hashInlineScripts(html)) {
+      scriptHashes.add(hash);
+    }
+
+    for (const hash of hashInlineStyleAttributes(html)) {
+      styleAttributeHashes.add(hash);
+    }
+  }
+
+  const csp = createCsp([...scriptHashes], [...styleAttributeHashes]);
+
+  if (/\b(?:script-src|style-src)\b[^;]*'unsafe-inline'/.test(csp)) {
+    throw new Error('Generated CSP unexpectedly allows unsafe-inline');
+  }
+
+  await fsPromises.writeFile(headersFile, insertCspHeader(headers, csp));
+}
+
+updateHeaders();

--- a/docs/static/_headers
+++ b/docs/static/_headers
@@ -4,7 +4,6 @@
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   X-Frame-Options: Deny
   Referrer-Policy: no-referrer
-  Content-Security-Policy: upgrade-insecure-requests; block-all-mixed-content; :default-src 'self'; script-src 'self' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'sha256-pBkmluod9Ko4GzDfbWgKM/wxzujFXUdGVOePkwOQT+c=' https://*.cloudflareinsights.com https://cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://img.shields.io/; object-src 'none'; connect-src 'self' https://*.cloudflareinsights.com https://cloudflareinsights.com; frame-ancestors 'none'
   Cross-Origin-Opener-Policy: same-origin
   Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()
 


### PR DESCRIPTION
Adds a docs postbuild step that generates the Content Security Policy from the built HTML output. This hashes inline scripts and style attributes, injects the CSP into the generated `_headers` file, and removes the stale static CSP header.