### PR TITLE
feat: elevate default severity of RMG068 from info to warning

### DIFF
--- a/docs/docs/breaking-changes/5-0.md
+++ b/docs/docs/breaking-changes/5-0.md
@@ -21,6 +21,7 @@ description: How to upgrade to Mapperly 5.0 and a list of all its breaking chang
 - `AllowNull` attributes are now respected for fields, properties and constructor parameters when writing values.
 - Copy constructors are no longer selected over constructors annotated with `[MapperConstructor]` or when `[MapProperty]` configurations are present.
 - Generic and runtime target type mappings now correctly match derived types handled by a child `[MapDerivedType]` mapping.
+- The default severity of `RMG068` (cannot inline user implemented queryable expression mapping) has been raised from info to warning, see below.
 
 ## Inaccessible members from other assemblies included
 
@@ -326,4 +327,19 @@ public partial global::FruitDto MapDerivedTypes(global::Fruit source)
         _ => throw new global::System.ArgumentException($"Cannot map {source.GetType()} to FruitDto as there is no known derived type mapping", nameof(source)),
     };
 }
+```
+
+## `RMG068` default severity raised to warning
+
+When Mapperly cannot inline a user-implemented mapping method into an `IQueryable` projection,
+it reports `RMG068`. Non-inlined method invocations can lead to more data being loaded than necessary,
+or cause the query provider (e.g. EF Core) to evaluate the projection client-side instead of translating it to SQL.
+
+Starting with v5.0, the default severity of `RMG068` has been raised from info to warning to make these
+potentially expensive situations more visible.
+
+To restore the previous behavior, set the severity back to info in an `.editorconfig` file:
+
+```editorconfig
+dotnet_diagnostic.RMG068.severity = suggestion
 ```

--- a/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Shipped.md
@@ -225,3 +225,9 @@ RMG096 | Mapper | Hidden | A MapperIgnore* attribute does not specify a justific
 RMG097 | Mapper | Error   | MapValue Use method parameters cannot be satisfied
 RMG098 | Mapper | Error   | Named mapping additional parameters cannot be satisfied
 RMG099 | Mapper | Error   | Duplicate additional parameter names differing only in casing
+
+### Changed Rules
+
+Rule ID | New Category | New Severity | Old Category | Old Severity | Notes
+--------|--------------|--------------|--------------|--------------|--------------------
+RMG068  | Mapper       | Warning      | Mapper       | Info         | Cannot inline user implemented queryable expression mapping

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -561,7 +561,7 @@ public static class DiagnosticDescriptors
         "Cannot inline user implemented queryable expression mapping",
         "Cannot inline user implemented queryable expression mapping",
         DiagnosticCategories.Mapper,
-        DiagnosticSeverity.Info,
+        DiagnosticSeverity.Warning,
         true
     );
 

--- a/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassNonInlinedMethod.verified.txt
+++ b/test/Riok.Mapperly.Tests/_snapshots/QueryableProjectionUserImplementedTest.ClassToClassNonInlinedMethod.verified.txt
@@ -9,14 +9,14 @@
 */
  : (11,4)-(11,84),
       Message: Cannot inline user implemented queryable expression mapping,
-      Severity: Info,
+      Severity: Warning,
       WarningLevel: 1,
       Descriptor: {
         Id: RMG068,
         Title: Cannot inline user implemented queryable expression mapping,
         MessageFormat: Cannot inline user implemented queryable expression mapping,
         Category: Mapper,
-        DefaultSeverity: Info,
+        DefaultSeverity: Warning,
         IsEnabledByDefault: true
       }
     }


### PR DESCRIPTION
Raise the default severity of the queryable projection non-inlinable user-implemented mapping diagnostic (RMG068) from info to warning so that potential unintended client-side evaluations are more visible.

Closes https://github.com/riok/mapperly/issues/2250