### PR TITLE
fix: respect Use configuration on read-only collection members to improve reported diagnostics

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBodyBuilders/ObjectMemberMappingBodyBuilder.cs
@@ -215,6 +215,14 @@ public static class ObjectMemberMappingBodyBuilder
         if (memberMappingInfo.SourceMember == null)
             return false;
 
+        // if the user explicitly referenced a mapping by name (Use = ...)
+        // which is not an existing target mapping,
+        // respect the configuration and do not build an implicit existing target mapping,
+        // which would silently ignore the referenced new instance mapping.
+        // Usually this leads to a mapping error, which is the expected behavior.
+        if (memberMappingInfo.Configuration?.Use is not null && !HasExistingTargetNamedMapping(ctx, memberMappingInfo))
+            return false;
+
         var sourceMemberPath = memberMappingInfo.SourceMember;
         var targetMemberPath = memberMappingInfo.TargetMember;
 

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyUseNamedMappingTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyUseNamedMappingTest.cs
@@ -867,4 +867,82 @@ public class ObjectPropertyUseNamedMappingTest
 
         return TestHelper.VerifyGenerator(source);
     }
+
+    [Fact]
+    public void NewInstanceMappingToSettableCollectionShouldUseReferencedMapping()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapProperty(nameof(A.Value), nameof(B.Values), Use = nameof(MapValues))]
+            public partial B Map(A source);
+
+            private Dictionary<string, string> MapValues(C source) => source.Values;
+            """,
+            """
+            class A
+            {
+                public C Value { get; set; }
+            }
+            class C
+            {
+                public Dictionary<string, string> Values { get; set; }
+            }
+            """,
+            """
+            class B
+            {
+                public Dictionary<string, string> Values { get; set; }
+            }
+            """
+        );
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                target.Values = MapValues(source.Value);
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void NewInstanceMappingToReadOnlyCollectionShouldDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            [MapProperty(nameof(A.Value), nameof(B.Values), Use = nameof(MapValues))]
+            public partial B Map(A source);
+
+            private Dictionary<string, string> MapValues(C source) => source.Values;
+            """,
+            """
+            class A
+            {
+                public C Value { get; set; }
+            }
+            class C
+            {
+                public Dictionary<string, string> Values { get; set; }
+            }
+            """,
+            """
+            class B
+            {
+                public Dictionary<string, string> Values { get; } = new();
+            }
+            """
+        );
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.CannotMapToReadOnlyMember, "Cannot map A.Value to read only member B.Values")
+            .HaveMapMethodBody(
+                """
+                var target = new global::B();
+                return target;
+                """
+            );
+    }
 }


### PR DESCRIPTION
When a member mapping referenced a mapping by name (Use = ...) that is a new instance mapping, and the target member was a read-only collection or dictionary (e.g. a protobuf MapField), Mapperly silently ignored the configuration and built an implicit existing target mapping instead, producing a confusing RMG020 diagnostic.

The referenced new instance mapping is now respected: it is assigned for settable members and reports RMG009 (cannot map to read only member) when the target cannot be set, instead of being silently ignored.

Closes #2352

## Checklist

- [x] I did not use AI tools to generate this PR, or I have manually verified that the code is correct, optimal, and follows the project guidelines and architecture
- [x] I understand that low-quality, AI-generated PRs will be closed immediately without further explanation
- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
