### PR TITLE
fix: prevent delegation to inexact user mappings

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
@@ -343,7 +343,7 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
         }
 
         var existingMapping = FindMapping(source, target);
-        return existingMapping == null ? null : new DelegateMapping(Source, Target, existingMapping);
+        return existingMapping is null or IUserMapping ? null : new DelegateMapping(Source, Target, existingMapping);
     }
 
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, params object[] messageArgs) =>

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyConstructorResolverTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyConstructorResolverTest.cs
@@ -386,6 +386,50 @@ public class ObjectPropertyConstructorResolverTest
     }
 
     [Fact]
+    public void RecordToRecordShouldNotDelegateToInexactUserMapping()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            public static partial TargetWrapper MapToTargetWrapper(SourceWrapper source);
+
+            private static Target[] CustomMapToTargetArray(ICollection<Source?> sources) =>
+                sources.Where(s => s is not null).Select(s => s!.MapToTarget()).ToArray();
+
+            [MapperIgnoreSource(nameof(Source.B))]
+            private static partial Target MapToTarget(this Source source);
+            """,
+            TestSourceBuilderOptions.Default with
+            {
+                Static = true,
+            },
+            "record Source(string A, string B);",
+            "record SourceWrapper(ICollection<Source?> Values);",
+            "record Target(string A);",
+            "record TargetWrapper(IEnumerable<Target> Values);"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.NullableSourceTypeToNonNullableTargetType,
+                "Mapping the nullable source of type Source? to target of type Target which is not nullable"
+            )
+            .HaveDiagnostic(
+                DiagnosticDescriptors.SourceMemberNotMapped,
+                "The member B on the mapping source type Source is not mapped to any member on the mapping target type Target"
+            )
+            .HaveAssertedAllDiagnostics()
+            .HaveMethodBody(
+                "MapToTargetWrapper",
+                """
+                var target = new global::TargetWrapper(MapToTargetArray(source.Values));
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public void RecordToFlattenedRecordNullablePathNoThrow()
     {
         var source = TestSourceBuilder.Mapping(


### PR DESCRIPTION
Fixes #1793.

## Summary

Mapperly could reuse a user-defined mapping through `BuildDelegatedMapping` even when the requested source and target types did not match the user mapping exactly. For example, a mapping returning `Target[]` could be selected when Mapperly needed `IEnumerable<Target>`.

## Root cause

`MappingBuilderContext.BuildDelegatedMapping` accepted any existing mapping found for compatible types. This also included `IUserMapping` implementations, although user-defined mappings should only participate when their source and target types match exactly.

## Changes

- Exclude `IUserMapping` instances from generalized delegated mapping resolution.
- Continue allowing Mapperly-generated mappings to be reused through delegation.
- Add a regression test based on the reproduction from #1793.

## Impact

Mapperly now generates the appropriate collection and element mappings instead of selecting an inexact user-defined mapping. User mappings continue to work when their source and target types match exactly.

This changes the behavior of inexact user mappings and is therefore appropriate for the next major release, as discussed in the issue.

## Validation

- `dotnet build Riok.Mapperly.slnx /p:TreatWarningsAsErrors=true`
- `dotnet test Riok.Mapperly.slnx --no-build --no-restore`
- 1,726 tests passed, 2 skipped, 0 failed
- CSharpier, style, and analyzer checks passed