### PR TITLE
fix: guard nullable paths in existing target mappings

### DIFF
--- a/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/NullDelegateExistingTargetMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/ExistingTarget/NullDelegateExistingTargetMapping.cs
@@ -19,7 +19,10 @@ public class NullDelegateExistingTargetMapping(
 {
     private const string NullableValueProperty = nameof(Nullable<>.Value);
 
-    public override IEnumerable<StatementSyntax> Build(TypeMappingBuildContext ctx, ExpressionSyntax target)
+    public override IEnumerable<StatementSyntax> Build(TypeMappingBuildContext ctx, ExpressionSyntax target) =>
+        Build(ctx, target, ctx.Source);
+
+    public IEnumerable<StatementSyntax> Build(TypeMappingBuildContext ctx, ExpressionSyntax target, ExpressionSyntax sourceNullCheckAccess)
     {
         // if the source or target type is nullable, add a null guard.
         if (!SourceType.IsNullable() && !TargetType.IsNullable())
@@ -32,7 +35,7 @@ public class NullDelegateExistingTargetMapping(
             return [];
 
         // if (source != null && target != null) { body }
-        var condition = IfNoneNull((SourceType, ctx.Source), (TargetType, target));
+        var condition = IfNoneNull((SourceType, sourceNullCheckAccess), (TargetType, target));
         var ifStatement = ctx.SyntaxFactory.If(condition, body);
         return [ifStatement];
     }

--- a/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberExistingTargetMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/MemberMappings/MemberExistingTargetMapping.cs
@@ -27,6 +27,13 @@ public class MemberExistingTargetMapping(
     {
         var source = sourcePath.BuildAccess(ctx.Source);
         var target = targetPath.BuildAccess(targetAccess);
-        return delegateMapping.Build(ctx.WithSource(source), target);
+        var mappingCtx = ctx.WithSource(source);
+        if (delegateMapping is NullDelegateExistingTargetMapping nullDelegateMapping)
+        {
+            var nullConditionalSource = sourcePath.BuildAccess(ctx.Source, nullConditional: true);
+            return nullDelegateMapping.Build(mappingCtx, target, nullConditionalSource);
+        }
+
+        return delegateMapping.Build(mappingCtx, target);
     }
 }

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableExistingTargetTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableExistingTargetTest.cs
@@ -1,4 +1,5 @@
 using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Diagnostics;
 
 namespace Riok.Mapperly.Tests.Mapping;
 
@@ -64,6 +65,76 @@ public class EnumerableExistingTargetTest
                         target.Values.Add(item);
                     }
                 }
+                """
+            );
+    }
+
+    [Fact]
+    public void NestedEnumerableToExistingReadOnlyCollectionInDisabledNullableContext()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapProperty(new[] { nameof(Source.Nested), nameof(Nested.Items) }, nameof(Target.Items))] partial Target Map(Source source);",
+            "class Source { public Nested Nested { get; set; } }",
+            "class Nested { public IEnumerable<int> Items { get; set; } }",
+            "class Target { public readonly List<int> Items = []; }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.DisabledNullable)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                if (source == null)
+                    return default;
+                var target = new global::Target();
+                if (source.Nested?.Items != null && target.Items != null)
+                {
+                    if (global::System.Linq.Enumerable.TryGetNonEnumeratedCount(source.Nested.Items, out var sourceCount))
+                    {
+                        target.Items.EnsureCapacity(sourceCount + target.Items.Count);
+                    }
+                    foreach (var item in source.Nested.Items)
+                    {
+                        target.Items.Add(item);
+                    }
+                }
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void NestedEnumerableToExistingReadOnlyCollectionWithNullableIntermediateMember()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "[MapProperty(new[] { nameof(Source.Nested), nameof(Nested.Items) }, nameof(Target.Items))] partial Target Map(Source source);",
+            "class Source { public Nested? Nested { get; set; } }",
+            "class Nested { public IEnumerable<int> Items { get; set; } = []; }",
+            "class Target { public readonly List<int> Items = []; }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(
+                DiagnosticDescriptors.NullableSourceTypeToNonNullableTargetType,
+                "Mapping the nullable source of type System.Collections.Generic.IEnumerable<int>? to target of type System.Collections.Generic.List<int> which is not nullable"
+            )
+            .HaveSingleMethodBody(
+                """
+                var target = new global::Target();
+                if (source.Nested?.Items != null)
+                {
+                    if (global::System.Linq.Enumerable.TryGetNonEnumeratedCount(source.Nested.Items, out var sourceCount))
+                    {
+                        target.Items.EnsureCapacity(sourceCount + target.Items.Count);
+                    }
+                    foreach (var item in source.Nested.Items)
+                    {
+                        target.Items.Add(item);
+                    }
+                }
+                return target;
                 """
             );
     }


### PR DESCRIPTION
Fixes #2303.

## Summary

Existing-target mappings for nested collections could dereference a nullable intermediate source member while evaluating the generated null guard. For example, Mapperly generated `source.Nested.Items != null`, which throws when `source.Nested` is null.

## Root cause

`MemberExistingTargetMapping` passed the same direct member-access expression to both the null guard and the mapping body. The mapping body should use direct access after the guard has succeeded, but the guard itself needs null-conditional access across nullable intermediate members.

## Changes

- Allow `NullDelegateExistingTargetMapping` to receive a separate source expression for its null check.
- Build that guard expression with null-conditional member access in `MemberExistingTargetMapping`.
- Keep direct source access inside the guarded mapping body, preserving non-null flow and avoiding redundant conditional access.
- Add regression coverage for both disabled-nullability code and nullable-aware code.

## Impact

Generated mappings now safely check paths such as `source.Nested?.Items` before populating an existing readonly target collection. When an intermediate source object is null, the collection mapping is skipped instead of throwing `NullReferenceException`.

## Validation

- `dotnet build Riok.Mapperly.slnx /p:TreatWarningsAsErrors=true --no-restore`
- `dotnet test Riok.Mapperly.slnx --no-build --no-restore`
- 1,727 tests passed, 2 skipped, 0 failed
- CSharpier, style, and analyzer checks passed