### PR TITLE
feat: add RequireExplicitMapping option to mapper configuration

### DIFF
--- a/docs/docs/configuration/analyzer-diagnostics/RMG101.mdx
+++ b/docs/docs/configuration/analyzer-diagnostics/RMG101.mdx
@@ -1,0 +1,51 @@
+---
+sidebar_label: RMG101
+description: 'Mapperly analyzer diagnostic RMG101 — Explicit mapping required'
+---
+
+# RMG101 — Explicit mapping required
+
+When `RequireExplicitMapping` is set to `true` on the `MapperAttribute`,
+Mapperly will not automatically generate mapping methods for nested types.
+An explicit mapping method must be defined by the user for each nested type mapping.
+
+## Example
+
+The following example will produce `RMG101` because `B` cannot be mapped to `BTarget` automatically:
+
+```csharp
+[Mapper(RequireExplicitMapping = true)]
+public partial class MyMapper
+{
+    public partial ATarget MapToA(A source);
+    // Missing: public partial BTarget MapToB(B source);
+}
+
+public class A { public B B { get; set; } }
+public class ATarget { public BTarget B { get; set; } }
+public class B { }
+public class BTarget { }
+```
+
+## How to fix
+
+Add an explicit mapping method for the nested types:
+
+```csharp
+[Mapper(RequireExplicitMapping = true)]
+public partial class MyMapper
+{
+    public partial ATarget MapToA(A source);
+    public partial BTarget MapToB(B source); // Added
+}
+```
+
+Or disable `RequireExplicitMapping`:
+
+```csharp
+[Mapper(RequireExplicitMapping = false)] // or simply omit it
+public partial class MyMapper
+{
+    public partial ATarget MapToA(A source);
+}
+```

--- a/docs/docs/configuration/mapper.mdx
+++ b/docs/docs/configuration/mapper.mdx
@@ -310,6 +310,27 @@ the `RequiredMappingStrategy` can be used.
 
 </Tabs>
 
+### Require explicit mapping
+
+By default, Mapperly automatically generates mapping methods for nested types.
+To require explicit mapping methods for all nested types, set `RequireExplicitMapping` to `true`.
+
+When enabled, Mapperly will report `RMG101` if a nested type mapping is needed but no explicit mapping method is defined.
+
+```csharp
+// highlight-start
+[Mapper(RequireExplicitMapping = true)]
+// highlight-end
+public partial class CarMapper
+{
+    public partial CarDto ToDto(Car car);
+    // Must also define: public partial MakeDto ToDto(Make make);
+}
+```
+
+This is useful when you want full control over how nested types are mapped
+and want to avoid accidental auto-generated mappings.
+
 ### String format
 
 The string format passed to `ToString` calls when converting to a string can be customized

--- a/src/Riok.Mapperly.Abstractions/MapperAttribute.cs
+++ b/src/Riok.Mapperly.Abstractions/MapperAttribute.cs
@@ -142,4 +142,11 @@ public class MapperAttribute : Attribute
     /// partial methods are discovered.
     /// </summary>
     public bool AutoUserMappings { get; set; } = true;
+
+    /// <summary>
+    /// When set to <c>true</c>, Mapperly will not automatically generate mapping methods for nested types.
+    /// An explicit mapping method must be defined by the user for each nested type mapping.
+    /// If set to <c>false</c> (default), Mapperly automatically generates mapping methods for nested types.
+    /// </summary>
+    public bool RequireExplicitMapping { get; set; }
 }

--- a/src/Riok.Mapperly/AnalyzerReleases.Unshipped.md
+++ b/src/Riok.Mapperly/AnalyzerReleases.Unshipped.md
@@ -1,2 +1,7 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+RMG101 | Mapper | Error | ExplicitMappingRequired

--- a/src/Riok.Mapperly/Configuration/MapperConfiguration.cs
+++ b/src/Riok.Mapperly/Configuration/MapperConfiguration.cs
@@ -135,4 +135,11 @@ public record MapperConfiguration
     /// Can be overwritten on specific enums via mapping method configurations.
     /// </summary>
     public EnumNamingStrategy? EnumNamingStrategy { get; init; }
+
+    /// <summary>
+    /// When set to <c>true</c>, Mapperly will not automatically generate mapping methods for nested types.
+    /// An explicit mapping method must be defined by the user for each nested type mapping.
+    /// If set to <c>false</c> (default), Mapperly automatically generates mapping methods for nested types.
+    /// </summary>
+    public bool? RequireExplicitMapping { get; init; }
 }

--- a/src/Riok.Mapperly/Configuration/MapperConfigurationMerger.cs
+++ b/src/Riok.Mapperly/Configuration/MapperConfigurationMerger.cs
@@ -27,6 +27,7 @@ public static class MapperConfigurationMerger
             PreferParameterlessConstructors = highPriority.PreferParameterlessConstructors ?? lowPriority.PreferParameterlessConstructors,
             AutoUserMappings = highPriority.AutoUserMappings ?? lowPriority.AutoUserMappings,
             EnumNamingStrategy = highPriority.EnumNamingStrategy ?? lowPriority.EnumNamingStrategy,
+            RequireExplicitMapping = highPriority.RequireExplicitMapping ?? lowPriority.RequireExplicitMapping,
         };
     }
 
@@ -103,6 +104,11 @@ public static class MapperConfigurationMerger
 
         mapper.EnumNamingStrategy =
             mapperConfiguration.EnumNamingStrategy ?? defaultMapperConfiguration.EnumNamingStrategy ?? mapper.EnumNamingStrategy;
+
+        mapper.RequireExplicitMapping =
+            mapperConfiguration.RequireExplicitMapping
+            ?? defaultMapperConfiguration.RequireExplicitMapping
+            ?? mapper.RequireExplicitMapping;
 
         return mapper;
     }

--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/NewInstanceObjectMemberMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/NewInstanceObjectMemberMappingBuilder.cs
@@ -17,6 +17,20 @@ public static class NewInstanceObjectMemberMappingBuilder
         if (ctx.Source.IsDelegate() || ctx.Target.IsDelegate())
             return null;
 
+        if (ctx.Configuration.Mapper.RequireExplicitMapping)
+        {
+            var existingMapping = ctx.FindMapping(ctx.Source, ctx.Target);
+            if (existingMapping == null)
+            {
+                ctx.ReportDiagnostic(
+                    DiagnosticDescriptors.ExplicitMappingRequired,
+                    ctx.Source.ToDisplayString(),
+                    ctx.Target.ToDisplayString()
+                );
+                return null;
+            }
+        }
+
         if (ctx.InstanceConstructors.TryBuildObjectFactory(ctx.Source, ctx.Target, out var constructor))
         {
             return new NewInstanceObjectMemberMethodMapping(

--- a/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Riok.Mapperly/Diagnostics/DiagnosticDescriptors.cs
@@ -857,6 +857,16 @@ public static class DiagnosticDescriptors
         isEnabledByDefault: true
     );
 
+    public static readonly DiagnosticDescriptor ExplicitMappingRequired = new(
+        "RMG101",
+        "Explicit mapping required",
+        "No explicit mapping found from {0} to {1}. Define an explicit mapping method or set RequireExplicitMapping to false.",
+        DiagnosticCategories.Mapper,
+        DiagnosticSeverity.Error,
+        true,
+        helpLinkUri: BuildHelpUri("RMG101")
+    );
+
     private static string BuildHelpUri(string id)
     {
 #if ENV_NEXT

--- a/src/Riok.Mapperly/Riok.Mapperly.targets
+++ b/src/Riok.Mapperly/Riok.Mapperly.targets
@@ -23,5 +23,6 @@
     <CompilerVisibleProperty Include="MapperlyIncludedConstructors" />
     <CompilerVisibleProperty Include="MapperlyPreferParameterlessConstructors" />
     <CompilerVisibleProperty Include="MapperlyAutoUserMappings" />
+    <CompilerVisibleProperty Include="MapperlyRequireExplicitMapping" />
   </ItemGroup>
 </Project>

--- a/test/Riok.Mapperly.Abstractions.Tests/_snapshots/PublicApiTest.PublicApiHasNotChanged.verified.cs
+++ b/test/Riok.Mapperly.Abstractions.Tests/_snapshots/PublicApiTest.PublicApiHasNotChanged.verified.cs
@@ -140,6 +140,7 @@ namespace Riok.Mapperly.Abstractions
         public Riok.Mapperly.Abstractions.MemberVisibility IncludedMembers { get; set; }
         public bool PreferParameterlessConstructors { get; set; }
         public Riok.Mapperly.Abstractions.PropertyNameMappingStrategy PropertyNameMappingStrategy { get; set; }
+        public bool RequireExplicitMapping { get; set; }
         public Riok.Mapperly.Abstractions.RequiredMappingStrategy RequiredEnumMappingStrategy { get; set; }
         public Riok.Mapperly.Abstractions.RequiredMappingStrategy RequiredMappingStrategy { get; set; }
         public Riok.Mapperly.Abstractions.StackCloningStrategy StackCloningStrategy { get; set; }

--- a/test/Riok.Mapperly.Tests/Mapping/RequireExplicitMappingTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/RequireExplicitMappingTest.cs
@@ -1,0 +1,128 @@
+using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Diagnostics;
+
+namespace Riok.Mapperly.Tests.Mapping;
+
+public class RequireExplicitMappingTest
+{
+    [Fact]
+    public void RequireExplicitMappingTrueWithoutExplicitMappingReportsDiagnostic()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "private partial ATarget MapToA(A source);",
+            TestSourceBuilderOptions.WithRequireExplicitMapping,
+            "class A { public B B { get; set; } }",
+            "class ATarget { public BTarget B { get; set; } }",
+            "class B { }",
+            "class BTarget { }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.ExplicitMappingRequired)
+            .HaveDiagnostic(DiagnosticDescriptors.CouldNotMapMember)
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotMapped)
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotFound)
+            .HaveAssertedAllDiagnostics();
+    }
+
+    [Fact]
+    public void RequireExplicitMappingTrueWithExplicitMappingSucceeds()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            private partial ATarget MapToA(A source);
+            private partial BTarget MapToB(B source);
+            """,
+            TestSourceBuilderOptions.WithRequireExplicitMapping,
+            "class A { public B B { get; set; } }",
+            "class ATarget { public BTarget B { get; set; } }",
+            "class B { }",
+            "class BTarget { }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMethodBody(
+                "MapToA",
+                """
+                var target = new global::ATarget();
+                target.B = MapToB(source.B);
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void RequireExplicitMappingFalseAutoGeneratesNestedMapping()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "private partial ATarget MapToA(A source);",
+            "class A { public B B { get; set; } }",
+            "class ATarget { public BTarget B { get; set; } }",
+            "class B { }",
+            "class BTarget { }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMethodBody(
+                "MapToA",
+                """
+                var target = new global::ATarget();
+                target.B = MapToBTarget(source.B);
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void RequireExplicitMappingTrueWithPrimitiveTypesSucceeds()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "private partial ATarget MapToA(A source);",
+            TestSourceBuilderOptions.WithRequireExplicitMapping,
+            "class A { public int Value { get; set; } public string Name { get; set; } }",
+            "class ATarget { public int Value { get; set; } public string Name { get; set; } }"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::ATarget();
+                target.Value = source.Value;
+                target.Name = source.Name;
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void RequireExplicitMappingTrueWithMultipleNestedTypesReportsDiagnostics()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            "private partial ATarget MapToA(A source);",
+            TestSourceBuilderOptions.WithRequireExplicitMapping,
+            "class A { public B B { get; set; } public C C { get; set; } }",
+            "class ATarget { public BTarget B { get; set; } public CTarget C { get; set; } }",
+            "class B { }",
+            "class BTarget { }",
+            "class C { }",
+            "class CTarget { }"
+        );
+
+        TestHelper
+            .GenerateMapper(source, TestHelperOptions.AllowDiagnostics)
+            .Should()
+            .HaveDiagnostic(DiagnosticDescriptors.ExplicitMappingRequired)
+            .HaveDiagnostic(DiagnosticDescriptors.CouldNotMapMember)
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotMapped)
+            .HaveDiagnostic(DiagnosticDescriptors.SourceMemberNotFound)
+            .HaveAssertedAllDiagnostics();
+    }
+}

--- a/test/Riok.Mapperly.Tests/TestSourceBuilder.cs
+++ b/test/Riok.Mapperly.Tests/TestSourceBuilder.cs
@@ -107,6 +107,7 @@ public static class TestSourceBuilder
             Attribute(options.IncludedConstructors),
             Attribute(options.PreferParameterlessConstructors),
             Attribute(options.AutoUserMappings),
+            Attribute(options.RequireExplicitMapping),
         }.WhereNotNull();
 
         return $"[Mapper({string.Join(", ", attrs)})]";

--- a/test/Riok.Mapperly.Tests/TestSourceBuilderOptions.cs
+++ b/test/Riok.Mapperly.Tests/TestSourceBuilderOptions.cs
@@ -24,7 +24,8 @@ public record TestSourceBuilderOptions(
     MemberVisibility? IncludedConstructors = null,
     bool Static = false,
     bool PreferParameterlessConstructors = true,
-    bool AutoUserMappings = true
+    bool AutoUserMappings = true,
+    bool? RequireExplicitMapping = null
 )
 {
     public const string DefaultMapperClassName = "Mapper";
@@ -49,6 +50,8 @@ public record TestSourceBuilderOptions(
         EnabledConversions: MappingConversionType.All
     );
     public static readonly TestSourceBuilderOptions WithDisabledAutoUserMappings = new(AutoUserMappings: false);
+
+    public static readonly TestSourceBuilderOptions WithRequireExplicitMapping = new(RequireExplicitMapping: true);
 
     public static readonly TestSourceBuilderOptions PreferParameterizedConstructors = new(PreferParameterlessConstructors: false);
 


### PR DESCRIPTION
# feat: add RequireExplicitMapping option to mapper configuration

## Description

Adds a new `RequireExplicitMapping` property to `[Mapper]` and `[MapperConfiguration]` that prevents automatic generation of nested type mappings, requiring explicit mapping methods instead.

When `RequireExplicitMapping = true` and a nested type mapping is missing, the new diagnostic **RMG101 (ExplicitMappingRequired)** is reported.

**Changes:**
- Added `RequireExplicitMapping` property
- Added RMG101 diagnostic
- Added `CompilerVisibleProperty` in `Riok.Mapperly.targets`
- Added unit tests
- Added documentation section and RMG101 diagnostic page

Fixes [#1179](https://github.com/riok/mapperly/issues/1179)

## Checklist

- [x] I did not use AI tools to generate this PR, or I have manually verified that the code is correct, optimal, and follows the project guidelines and architecture
- [x] I understand that low-quality, AI-generated PRs will be closed immediately without further explanation
- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)