### PR TITLE
fix: prevent delegation to inexact user mappings

### DIFF
--- a/docs/docs/breaking-changes/5-0.md
+++ b/docs/docs/breaking-changes/5-0.md
@@ -22,6 +22,16 @@ description: How to upgrade to Mapperly 5.0 and a list of all its breaking chang
 - Copy constructors are no longer selected over constructors annotated with `[MapperConstructor]` or when `[MapProperty]` configurations are present.
 - Generic and runtime target type mappings now correctly match derived types handled by a child `[MapDerivedType]` mapping.
 - The default severity of `RMG068` (cannot inline user implemented queryable expression mapping) has been raised from info to warning, see below.
+- User-implemented mappings are no longer reused for mappings with inexact source or target types, see below.
+
+## User-implemented mappings require exact types
+
+Mapperly no longer reuses user-implemented mappings when optimizing collection mappings if their source or target types do not match exactly.
+Previously, a user-implemented mapping returning an array could be selected for a mapping targeting an implemented collection interface,
+even though user-implemented mappings otherwise require exact types, including nullability.
+
+To migrate, change the user-implemented mapping signature so its source and target types exactly match the requested mapping,
+or add a separate user-implemented mapping for each required type pair.
 
 ## Inaccessible members from other assemblies included
 

--- a/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilderContext.cs
@@ -371,7 +371,9 @@ public class MappingBuilderContext : SimpleMappingBuilderContext
         }
 
         var existingMapping = FindMapping(source, target);
-        return existingMapping == null ? null : new DelegateMapping(Source, Target, existingMapping);
+
+        // User mappings require exact type matches and must not be reused through generalized delegation.
+        return existingMapping is null or IUserMapping ? null : new DelegateMapping(Source, Target, existingMapping);
     }
 
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, params object[] messageArgs) =>

--- a/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyConstructorResolverTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/ObjectPropertyConstructorResolverTest.cs
@@ -386,6 +386,38 @@ public class ObjectPropertyConstructorResolverTest
     }
 
     [Fact]
+    public void RecordToRecordShouldNotDelegateToInexactUserMapping()
+    {
+        var source = TestSourceBuilder.MapperWithBodyAndTypes(
+            """
+            public static partial TargetWrapper MapToTargetWrapper(SourceWrapper source);
+
+            private static Target[] CustomMapToTargetArray(ICollection<Source> sources) =>
+                sources.Select(s => new Target(s.Value)).ToArray();
+            """,
+            TestSourceBuilderOptions.Default with
+            {
+                Static = true,
+            },
+            "record Source(string Value);",
+            "record SourceWrapper(ICollection<Source> Values);",
+            "record Target(string Value);",
+            "record TargetWrapper(IEnumerable<Target> Values);"
+        );
+
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveMethodBody(
+                "MapToTargetWrapper",
+                """
+                var target = new global::TargetWrapper(MapToTargetArray(source.Values));
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public void RecordToFlattenedRecordNullablePathNoThrow()
     {
         var source = TestSourceBuilder.Mapping(


### PR DESCRIPTION
Prevents Mapperly from reusing user mappings through generalized delegation when their source or target types do not match exactly. Mapperly-generated mappings remain eligible for delegation.

Adds regression coverage for #1793 and documents the breaking change for v5.

Fixes #1793

## Checklist

- [x] I did not use AI tools to generate this PR, or I have manually verified that the code is correct, optimal, and follows the project guidelines and architecture
- [x] I understand that low-quality, AI-generated PRs will be closed immediately without further explanation
- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
