### PR TITLE
perf: optimize order-preserving stack mappings

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
@@ -143,6 +143,34 @@ public static class EnumerableMappingBuilder
             return BuildEnumerableToListMapping(ctx, elementMapping);
         }
 
+        // use count-aware loops for transformed stacks and order-preserving copies to avoid LINQ allocations
+        if (ctx.CollectionInfos.Target.CollectionType.HasFlag(CollectionType.Stack))
+        {
+            var stackCloningStrategy = ctx.Configuration.StackCloningStrategy;
+
+            // Stack(IEnumerable<T>) is already efficient when no element mapping or order preservation is needed.
+            if (elementMapping.IsSynthetic && stackCloningStrategy == StackCloningStrategy.ReverseOrder)
+                return null;
+
+            var sourceCountAccessor = ctx.CollectionInfos.Source.CountMember.BuildGetter(ctx.UnsafeAccessorContext);
+            if (
+                SourceSupportsIndexAccess(ctx.CollectionInfos.Source.CollectionType)
+                && (elementMapping.IsSynthetic || stackCloningStrategy == StackCloningStrategy.ReverseOrder)
+            )
+            {
+                return new StackForMapping(ctx.Source, ctx.Target, elementMapping, sourceCountAccessor, stackCloningStrategy);
+            }
+
+            return new StackForEachMapping(
+                ctx.Source,
+                ctx.Target,
+                elementMapping,
+                elementMapping.TargetType,
+                sourceCountAccessor,
+                stackCloningStrategy
+            );
+        }
+
         // if target is not an array or a type implemented by array return early
         if (
             ctx.CollectionInfos.Target.CollectionType
@@ -271,6 +299,9 @@ public static class EnumerableMappingBuilder
 
         return null;
     }
+
+    private static bool SourceSupportsIndexAccess(CollectionType sourceCollectionType) =>
+        sourceCollectionType is CollectionType.Array or CollectionType.List;
 
     private static LinqConstructorMapping BuildLinqConstructorMapping(
         MappingBuilderContext ctx,

--- a/src/Riok.Mapperly/Descriptors/Mappings/StackForEachMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/StackForEachMapping.cs
@@ -1,0 +1,86 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Symbols.Members;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Riok.Mapperly.Emit.Syntax.SyntaxFactoryHelper;
+
+namespace Riok.Mapperly.Descriptors.Mappings;
+
+/// <summary>
+/// Represents a count-known enumerable to stack mapping which controls the target order while mapping elements forwards.
+/// </summary>
+public class StackForEachMapping(
+    ITypeSymbol sourceType,
+    ITypeSymbol targetType,
+    INewInstanceMapping elementMapping,
+    ITypeSymbol targetElementType,
+    IMemberGetter sourceCountAccessor,
+    StackCloningStrategy stackCloningStrategy
+) : NewInstanceMethodMapping(sourceType, targetType)
+{
+    private const string TargetVariableName = "target";
+    private const string LoopItemVariableName = "item";
+    private const string LoopCounterName = "i";
+    private const string ArrayLengthProperty = nameof(Array.Length);
+    private const string PushMethodName = nameof(Stack<>.Push);
+
+    public override IEnumerable<StatementSyntax> BuildBody(TypeMappingBuildContext ctx)
+    {
+        return stackCloningStrategy == StackCloningStrategy.PreserveOrder ? BuildPreserveOrderBody(ctx) : BuildReverseOrderBody(ctx);
+    }
+
+    private IEnumerable<StatementSyntax> BuildPreserveOrderBody(TypeMappingBuildContext ctx)
+    {
+        var targetVariableName = ctx.NameBuilder.New(TargetVariableName);
+        var loopCounterVariableName = ctx.NameBuilder.New(LoopCounterName);
+
+        // A non-indexable source cannot be traversed backwards. Fill an array backwards so the Stack(IEnumerable<T>)
+        // constructor reverses it again and preserves the source order.
+        // var target = new T[source.Count];
+        var targetInitializationValue = CreateArray(targetElementType, sourceCountAccessor.BuildAccess(ctx.Source));
+        yield return ctx.SyntaxFactory.DeclareLocalVariable(targetVariableName, targetInitializationValue);
+
+        // var i = target.Length;
+        var targetLength = MemberAccess(IdentifierName(targetVariableName), ArrayLengthProperty);
+        yield return ctx.SyntaxFactory.DeclareLocalVariable(loopCounterVariableName, targetLength);
+
+        // foreach (var item in source)
+        // {
+        //     target[--i] = Map(item);
+        // }
+        var (loopItemCtx, loopItemVariableName) = ctx.WithNewSource(LoopItemVariableName);
+        var convertedSourceItemExpression = elementMapping.Build(loopItemCtx.AddIndentation());
+        var decrementedCounter = PrefixUnaryExpression(SyntaxKind.PreDecrementExpression, IdentifierName(loopCounterVariableName));
+        var assignment = Assignment(ElementAccess(IdentifierName(targetVariableName), decrementedCounter), convertedSourceItemExpression);
+        yield return ctx.SyntaxFactory.ForEach(loopItemVariableName, ctx.Source, assignment);
+
+        // return new Stack<T>(target);
+        var targetStack = ctx.SyntaxFactory.CreateInstance(TargetType, IdentifierName(targetVariableName));
+        yield return ctx.SyntaxFactory.Return(targetStack);
+    }
+
+    private IEnumerable<StatementSyntax> BuildReverseOrderBody(TypeMappingBuildContext ctx)
+    {
+        var targetVariableName = ctx.NameBuilder.New(TargetVariableName);
+
+        // Reverse the source order by pushing mapped elements into a pre-sized stack in their enumeration order.
+        // var target = new Stack<T>(source.Count);
+        var sourceCount = sourceCountAccessor.BuildAccess(ctx.Source);
+        var targetInitializationValue = ctx.SyntaxFactory.CreateInstance(TargetType, sourceCount);
+        yield return ctx.SyntaxFactory.DeclareLocalVariable(targetVariableName, targetInitializationValue);
+
+        // foreach (var item in source)
+        // {
+        //     target.Push(Map(item));
+        // }
+        var (loopItemCtx, loopItemVariableName) = ctx.WithNewSource(LoopItemVariableName);
+        var convertedSourceItemExpression = elementMapping.Build(loopItemCtx.AddIndentation());
+        var push = ctx.SyntaxFactory.Invocation(MemberAccess(targetVariableName, PushMethodName), convertedSourceItemExpression);
+        yield return ctx.SyntaxFactory.ForEach(loopItemVariableName, ctx.Source, push);
+
+        // return target;
+        yield return ctx.SyntaxFactory.ReturnVariable(targetVariableName);
+    }
+}

--- a/src/Riok.Mapperly/Descriptors/Mappings/StackForMapping.cs
+++ b/src/Riok.Mapperly/Descriptors/Mappings/StackForMapping.cs
@@ -1,0 +1,51 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Symbols.Members;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Riok.Mapperly.Emit.Syntax.SyntaxFactoryHelper;
+
+namespace Riok.Mapperly.Descriptors.Mappings;
+
+/// <summary>
+/// Represents an indexable collection to stack mapping which controls the target order through the iteration direction.
+/// </summary>
+public class StackForMapping(
+    ITypeSymbol sourceType,
+    ITypeSymbol targetType,
+    INewInstanceMapping elementMapping,
+    IMemberGetter sourceCountAccessor,
+    StackCloningStrategy stackCloningStrategy
+) : NewInstanceMethodMapping(sourceType, targetType)
+{
+    private const string TargetVariableName = "target";
+    private const string LoopCounterName = "i";
+    private const string PushMethodName = nameof(Stack<>.Push);
+
+    public override IEnumerable<StatementSyntax> BuildBody(TypeMappingBuildContext ctx)
+    {
+        var targetVariableName = ctx.NameBuilder.New(TargetVariableName);
+        var loopCounterVariableName = ctx.NameBuilder.New(LoopCounterName);
+        var sourceCount = sourceCountAccessor.BuildAccess(ctx.Source);
+
+        // Pre-size the stack and push the indexable source without an intermediate buffer.
+        // var target = new Stack<T>(source.Count);
+        var targetInitializationValue = ctx.SyntaxFactory.CreateInstance(TargetType, sourceCount);
+        yield return ctx.SyntaxFactory.DeclareLocalVariable(targetVariableName, targetInitializationValue);
+
+        // Iterate backwards to preserve the source order or forwards to reverse it.
+        // for (var i = ...)
+        // {
+        //     target.Push(Map(source[i]));
+        // }
+        var indexedSource = ElementAccess(ctx.Source, IdentifierName(loopCounterVariableName));
+        var mappedSource = elementMapping.Build(ctx.WithSource(indexedSource).AddIndentation());
+        var push = ctx.SyntaxFactory.Invocation(MemberAccess(targetVariableName, PushMethodName), mappedSource);
+        yield return stackCloningStrategy == StackCloningStrategy.PreserveOrder
+            ? ctx.SyntaxFactory.DecrementalForLoop(loopCounterVariableName, sourceCount, push)
+            : ctx.SyntaxFactory.IncrementalForLoop(loopCounterVariableName, sourceCount, push);
+
+        // return target;
+        yield return ctx.SyntaxFactory.ReturnVariable(targetVariableName);
+    }
+}

--- a/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Loop.cs
+++ b/src/Riok.Mapperly/Emit/Syntax/SyntaxFactoryHelper.Loop.cs
@@ -49,4 +49,29 @@ public partial struct SyntaxFactoryHelper
             Block(expressions)
         );
     }
+
+    public ForStatementSyntax DecrementalForLoop(
+        string counterName,
+        ExpressionSyntax maxValueExclusive,
+        params ExpressionSyntax[] expressions
+    )
+    {
+        var maxValueInclusive = BinaryExpression(SyntaxKind.SubtractExpression, maxValueExclusive, IntLiteral(1));
+        var counterDeclaration = DeclareVariable(counterName, maxValueInclusive);
+        var counterDecrement = PostfixUnaryExpression(SyntaxKind.PostDecrementExpression, IdentifierName(counterName));
+        var condition = BinaryExpression(SyntaxKind.GreaterThanOrEqualExpression, IdentifierName(counterName), IntLiteral(0));
+        return ForStatement(
+            default,
+            LeadingLineFeedTrailingSpaceToken(SyntaxKind.ForKeyword),
+            Token(SyntaxKind.OpenParenToken),
+            counterDeclaration,
+            default,
+            TrailingSpacedToken(SyntaxKind.SemicolonToken),
+            condition,
+            TrailingSpacedToken(SyntaxKind.SemicolonToken),
+            SingletonSeparatedList<ExpressionSyntax>(counterDecrement),
+            Token(SyntaxKind.CloseParenToken),
+            Block(expressions)
+        );
+    }
 }

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/DeepCloningMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/DeepCloningMapperTest.SnapshotGeneratedSource.verified.cs
@@ -92,7 +92,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.NullableReadOnlyObjectCollection = null;
             }
             target.MemoryValue = src.MemoryValue.Span.ToArray();
-            target.StackValue = new global::System.Collections.Generic.Stack<string>(global::System.Linq.Enumerable.Reverse(src.StackValue));
+            target.StackValue = MapToStackOfString(src.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<string>(src.QueueValue);
             target.ImmutableArrayValue = src.ImmutableArrayValue;
             target.ImmutableListValue = src.ImmutableListValue;
@@ -242,6 +242,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 i++;
             }
             return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.Stack<string> MapToStackOfString(global::System.Collections.Generic.Stack<string> source)
+        {
+            var target = new string[source.Count];
+            var i = target.Length;
+            foreach (var item in source)
+            {
+                target[--i] = item;
+            }
+            return new global::System.Collections.Generic.Stack<string>(target);
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/DeepCloningMapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/DeepCloningMapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
@@ -92,7 +92,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.NullableReadOnlyObjectCollection = null;
             }
             target.MemoryValue = src.MemoryValue.Span.ToArray();
-            target.StackValue = new global::System.Collections.Generic.Stack<string>(global::System.Linq.Enumerable.Reverse(src.StackValue));
+            target.StackValue = MapToStackOfString(src.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<string>(src.QueueValue);
             target.ImmutableArrayValue = src.ImmutableArrayValue;
             target.ImmutableListValue = src.ImmutableListValue;
@@ -244,6 +244,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 i++;
             }
             return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.Stack<string> MapToStackOfString(global::System.Collections.Generic.Stack<string> source)
+        {
+            var target = new string[source.Count];
+            var i = target.Length;
+            foreach (var item in source)
+            {
+                target[--i] = item;
+            }
+            return new global::System.Collections.Generic.Stack<string>(target);
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource.verified.cs
@@ -133,11 +133,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(testObject.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
             );
@@ -300,11 +296,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.NullableReadOnlyObjectCollection = null;
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<string>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString(_formatDeCh))
-                )
-            );
+            target.StackValue = MapToStackOfString(dto.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<string>(
                 global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString(_formatDeCh))
             );
@@ -446,11 +438,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(source.SpanValue);
             target.MemoryValue = MapToInt32Array1(source.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(source.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
             );
@@ -653,11 +641,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(testObject.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
             );
@@ -816,6 +800,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.Stack<int> MapToStackOfInt32(global::System.Collections.Generic.Stack<string> source)
+        {
+            var target = new int[source.Count];
+            var i = target.Length;
+            foreach (var item in source)
+            {
+                target[--i] = ParseableInt(item);
+            }
+            return new global::System.Collections.Generic.Stack<int>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private string MapToString(global::Riok.Mapperly.IntegrationTests.Models.TestEnum source)
         {
             return source switch
@@ -887,6 +883,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[i] = source[i].ToString(_formatDeCh);
             }
             return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.Stack<string> MapToStackOfString(global::System.Collections.Generic.Stack<int> source)
+        {
+            var target = new string[source.Count];
+            var i = target.Length;
+            foreach (var item in source)
+            {
+                target[--i] = item.ToString(_formatDeCh);
+            }
+            return new global::System.Collections.Generic.Stack<string>(target);
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
@@ -139,11 +139,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(testObject.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
             );
@@ -312,11 +308,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.NullableReadOnlyObjectCollection = null;
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<string>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString(_formatDeCh))
-                )
-            );
+            target.StackValue = MapToStackOfString(dto.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<string>(
                 global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString(_formatDeCh))
             );
@@ -467,11 +459,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(source.SpanValue);
             target.MemoryValue = MapToInt32Array1(source.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(source.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
             );
@@ -680,11 +668,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(testObject.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
             );
@@ -864,6 +848,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.Stack<int> MapToStackOfInt32(global::System.Collections.Generic.Stack<string> source)
+        {
+            var target = new int[source.Count];
+            var i = target.Length;
+            foreach (var item in source)
+            {
+                target[--i] = ParseableInt(item);
+            }
+            return new global::System.Collections.Generic.Stack<int>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private string MapToString(global::Riok.Mapperly.IntegrationTests.Models.TestEnum source)
         {
             return source switch
@@ -931,6 +927,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[i] = source[i].ToString(_formatDeCh);
             }
             return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.Stack<string> MapToStackOfString(global::System.Collections.Generic.Stack<int> source)
+        {
+            var target = new string[source.Count];
+            var i = target.Length;
+            foreach (var item in source)
+            {
+                target[--i] = item.ToString(_formatDeCh);
+            }
+            return new global::System.Collections.Generic.Stack<string>(target);
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET9_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET9_0.verified.cs
@@ -139,11 +139,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(testObject.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
             );
@@ -313,11 +309,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.NullableReadOnlyObjectCollection = null;
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<string>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString(_formatDeCh))
-                )
-            );
+            target.StackValue = MapToStackOfString(dto.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<string>(
                 global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString(_formatDeCh))
             );
@@ -469,11 +461,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(source.SpanValue);
             target.MemoryValue = MapToInt32Array1(source.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(source.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
             );
@@ -683,11 +671,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(testObject.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
             );
@@ -868,6 +852,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.Stack<int> MapToStackOfInt32(global::System.Collections.Generic.Stack<string> source)
+        {
+            var target = new int[source.Count];
+            var i = target.Length;
+            foreach (var item in source)
+            {
+                target[--i] = ParseableInt(item);
+            }
+            return new global::System.Collections.Generic.Stack<int>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private string MapToString(global::Riok.Mapperly.IntegrationTests.Models.TestEnum source)
         {
             return source switch
@@ -948,6 +944,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[i] = source[i].ToString(_formatDeCh);
             }
             return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.Stack<string> MapToStackOfString(global::System.Collections.Generic.Stack<int> source)
+        {
+            var target = new string[source.Count];
+            var i = target.Length;
+            foreach (var item in source)
+            {
+                target[--i] = item.ToString(_formatDeCh);
+            }
+            return new global::System.Collections.Generic.Stack<string>(target);
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StackDeepCloningMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StackDeepCloningMapperTest.SnapshotGeneratedSource.verified.cs
@@ -7,7 +7,13 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         public static partial global::System.Collections.Generic.Stack<int> Copy(global::System.Collections.Generic.Stack<int> src)
         {
-            return new global::System.Collections.Generic.Stack<int>(global::System.Linq.Enumerable.Reverse(src));
+            var target = new int[src.Count];
+            var i = target.Length;
+            foreach (var item in src)
+            {
+                target[--i] = item;
+            }
+            return new global::System.Collections.Generic.Stack<int>(target);
         }
     }
 }

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StackDeepCloningMapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StackDeepCloningMapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
@@ -7,7 +7,13 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         public static partial global::System.Collections.Generic.Stack<int> Copy(global::System.Collections.Generic.Stack<int> src)
         {
-            return new global::System.Collections.Generic.Stack<int>(global::System.Linq.Enumerable.Reverse(src));
+            var target = new int[src.Count];
+            var i = target.Length;
+            foreach (var item in src)
+            {
+                target[--i] = item;
+            }
+            return new global::System.Collections.Generic.Stack<int>(target);
         }
     }
 }

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -146,11 +146,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array1(src.SpanValue);
             target.MemoryValue = MapToInt32Array2(src.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(src.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(src.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(src.QueueValue, x => ParseableInt(x))
             );
@@ -322,11 +318,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array1(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array2(testObject.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(testObject.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
             );
@@ -482,11 +474,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.NullableReadOnlyObjectCollection = null;
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<string>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString())
-                )
-            );
+            target.StackValue = MapToStackOfString(dto.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<string>(
                 global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString())
             );
@@ -624,11 +612,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array1(source.SpanValue);
             target.MemoryValue = MapToInt32Array2(source.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(source.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
             );
@@ -1064,6 +1048,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.Stack<int> MapToStackOfInt32(global::System.Collections.Generic.Stack<string> source)
+        {
+            var target = new int[source.Count];
+            var i = target.Length;
+            foreach (var item in source)
+            {
+                target[--i] = ParseableInt(item);
+            }
+            return new global::System.Collections.Generic.Stack<int>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private static string MapToString(global::Riok.Mapperly.IntegrationTests.Models.TestEnum source)
         {
             return source switch
@@ -1135,6 +1131,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[i] = source[i].ToString();
             }
             return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.Stack<string> MapToStackOfString(global::System.Collections.Generic.Stack<int> source)
+        {
+            var target = new string[source.Count];
+            var i = target.Length;
+            foreach (var item in source)
+            {
+                target[--i] = item.ToString();
+            }
+            return new global::System.Collections.Generic.Stack<string>(target);
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
@@ -146,11 +146,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array1(src.SpanValue);
             target.MemoryValue = MapToInt32Array2(src.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(src.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(src.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(src.QueueValue, x => ParseableInt(x))
             );
@@ -327,11 +323,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array1(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array2(testObject.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(testObject.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(testObject.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
             );
@@ -492,11 +484,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.NullableReadOnlyObjectCollection = null;
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<string>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(dto.StackValue, x => x.ToString())
-                )
-            );
+            target.StackValue = MapToStackOfString(dto.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<string>(
                 global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString())
             );
@@ -642,11 +630,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.SpanValue = MapToInt32Array1(source.SpanValue);
             target.MemoryValue = MapToInt32Array2(source.MemoryValue.Span);
-            target.StackValue = new global::System.Collections.Generic.Stack<int>(
-                global::System.Linq.Enumerable.Reverse(
-                    global::System.Linq.Enumerable.Select(source.StackValue, x => ParseableInt(x))
-                )
-            );
+            target.StackValue = MapToStackOfInt32(source.StackValue);
             target.QueueValue = new global::System.Collections.Generic.Queue<int>(
                 global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
             );
@@ -1087,6 +1071,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.Stack<int> MapToStackOfInt32(global::System.Collections.Generic.Stack<string> source)
+        {
+            var target = new int[source.Count];
+            var i = target.Length;
+            foreach (var item in source)
+            {
+                target[--i] = ParseableInt(item);
+            }
+            return new global::System.Collections.Generic.Stack<int>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private static string MapToString(global::Riok.Mapperly.IntegrationTests.Models.TestEnum source)
         {
             return source switch
@@ -1154,6 +1150,18 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[i] = source[i].ToString();
             }
             return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.Stack<string> MapToStackOfString(global::System.Collections.Generic.Stack<int> source)
+        {
+            var target = new string[source.Count];
+            var i = target.Length;
+            foreach (var item in source)
+            {
+                target[--i] = item.ToString();
+            }
+            return new global::System.Collections.Generic.Stack<string>(target);
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.Tests/Mapping/StackDeepCloningTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/StackDeepCloningTest.cs
@@ -12,7 +12,15 @@ public class StackDeepCloningTest
             .GenerateMapper(source)
             .Should()
             .HaveSingleMethodBody(
-                "return new global::System.Collections.Generic.Stack<string>(global::System.Linq.Enumerable.Reverse(source));"
+                """
+                var target = new string[source.Count];
+                var i = target.Length;
+                foreach (var item in source)
+                {
+                    target[--i] = item;
+                }
+                return new global::System.Collections.Generic.Stack<string>(target);
+                """
             );
     }
 
@@ -34,6 +42,32 @@ public class StackDeepCloningTest
     }
 
     [Fact]
+    public void StackToStackWithConversionReverseOrder()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "Stack<int>",
+            "Stack<string>",
+            TestSourceBuilderOptions.WithDeepCloning with
+            {
+                StackCloningStrategy = StackCloningStrategy.ReverseOrder,
+            }
+        );
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::System.Collections.Generic.Stack<string>(source.Count);
+                foreach (var item in source)
+                {
+                    target.Push(item.ToString());
+                }
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public void StackToStackWithConversion()
     {
         var source = TestSourceBuilder.Mapping("Stack<int>", "Stack<string>", TestSourceBuilderOptions.WithDeepCloning);
@@ -41,9 +75,125 @@ public class StackDeepCloningTest
             .GenerateMapper(source)
             .Should()
             .HaveSingleMethodBody(
-                @"return new global::System.Collections.Generic.Stack<string>(
-    global::System.Linq.Enumerable.Reverse(global::System.Linq.Enumerable.Select(source, x => x.ToString()))
-);"
+                """
+                var target = new string[source.Count];
+                var i = target.Length;
+                foreach (var item in source)
+                {
+                    target[--i] = item.ToString();
+                }
+                return new global::System.Collections.Generic.Stack<string>(target);
+                """
+            );
+    }
+
+    [Fact]
+    public void ArrayToStack()
+    {
+        var source = TestSourceBuilder.Mapping("int[]", "Stack<int>");
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::System.Collections.Generic.Stack<int>(source.Length);
+                for (var i = source.Length - 1; i >= 0; i--)
+                {
+                    target.Push(source[i]);
+                }
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ListToStack()
+    {
+        var source = TestSourceBuilder.Mapping("List<int>", "Stack<int>");
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::System.Collections.Generic.Stack<int>(source.Count);
+                for (var i = source.Count - 1; i >= 0; i--)
+                {
+                    target.Push(source[i]);
+                }
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ListToStackWithConversion()
+    {
+        var source = TestSourceBuilder.Mapping("List<int>", "Stack<string>");
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new string[source.Count];
+                var i = target.Length;
+                foreach (var item in source)
+                {
+                    target[--i] = item.ToString();
+                }
+                return new global::System.Collections.Generic.Stack<string>(target);
+                """
+            );
+    }
+
+    [Fact]
+    public void ArrayToStackWithConversionLegacy()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "int[]",
+            "Stack<string>",
+            TestSourceBuilderOptions.Default with
+            {
+                StackCloningStrategy = StackCloningStrategy.ReverseOrder,
+            }
+        );
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::System.Collections.Generic.Stack<string>(source.Length);
+                for (var i = 0; i < source.Length; i++)
+                {
+                    target.Push(source[i].ToString());
+                }
+                return target;
+                """
+            );
+    }
+
+    [Fact]
+    public void ListToStackWithConversionLegacy()
+    {
+        var source = TestSourceBuilder.Mapping(
+            "List<int>",
+            "Stack<string>",
+            TestSourceBuilderOptions.Default with
+            {
+                StackCloningStrategy = StackCloningStrategy.ReverseOrder,
+            }
+        );
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::System.Collections.Generic.Stack<string>(source.Count);
+                for (var i = 0; i < source.Count; i++)
+                {
+                    target.Push(source[i].ToString());
+                }
+                return target;
+                """
             );
     }
 }


### PR DESCRIPTION
Optimize order-preserving stack mappings by using reverse for loops to reduce allocations

## Checklist

- [x] I did not use AI tools to generate this PR, or I have manually verified that the code is correct, optimal, and follows the project guidelines and architecture
- [x] I understand that low-quality, AI-generated PRs will be closed immediately without further explanation
- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
