### PR TITLE
perf: pre-size transformed set mappings

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
@@ -143,6 +143,12 @@ public static class EnumerableMappingBuilder
             return BuildEnumerableToListMapping(ctx, elementMapping);
         }
 
+        // if target is a set or type implemented by HashSet
+        if (ctx.CollectionInfos.Target.CollectionType is CollectionType.HashSet or CollectionType.ISet or CollectionType.IReadOnlySet)
+        {
+            return BuildEnumerableToHashSetMapping(ctx, elementMapping);
+        }
+
         // use count-aware loops for transformed stacks and order-preserving copies to avoid LINQ allocations
         if (ctx.CollectionInfos.Target.CollectionType.HasFlag(CollectionType.Stack))
         {
@@ -206,6 +212,35 @@ public static class EnumerableMappingBuilder
         var collectionInfos = new CollectionInfos(
             BuildCollectionTypeForICollection(ctx, ctx.CollectionInfos!.Source),
             CollectionInfoBuilder.BuildGenericCollectionInfo(ctx, CollectionType.List, ctx.CollectionInfos.Target)
+        );
+        var existingMapping = ctx.BuildDelegatedMapping(collectionInfos.Source.Type, collectionInfos.Target.Type);
+        if (existingMapping != null)
+            return new DelegateMapping(ctx.Source, ctx.Target, existingMapping);
+
+        return new ForEachAddEnumerableMapping(
+            null,
+            collectionInfos,
+            elementMapping,
+            ctx.Configuration.Mapper.UseReferenceHandling,
+            collectionInfos.Target.AddMethodName!
+        );
+    }
+
+    /// <summary>
+    /// Tries to build a mapping for a source for which the count is known and
+    /// a target type assignable from a hash set.
+    /// </summary>
+    private static INewInstanceMapping? BuildEnumerableToHashSetMapping(MappingBuilderContext ctx, INewInstanceMapping elementMapping)
+    {
+        // the existing LINQ path already avoids projection overhead for synthetic mappings
+        if (elementMapping.IsSynthetic)
+            return null;
+
+        // assume the mapped elements have the same deduplicated count as the source elements
+        // try to reuse an ICollection<S> => HashSet<T> mapping
+        var collectionInfos = new CollectionInfos(
+            BuildCollectionTypeForICollection(ctx, ctx.CollectionInfos!.Source),
+            CollectionInfoBuilder.BuildGenericCollectionInfo(ctx, CollectionType.HashSet, ctx.CollectionInfos.Target)
         );
         var existingMapping = ctx.BuildDelegatedMapping(collectionInfos.Source.Type, collectionInfos.Target.Type);
         if (existingMapping != null)

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource.verified.cs
@@ -182,12 +182,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(testObject.ISet);
+            target.HashSet = MapToHashSetOfInt321(testObject.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x))
             );
@@ -345,12 +341,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(item3.ToString(_formatDeCh));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(dto.ISet, x => x.ToString(_formatDeCh))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(dto.HashSet, x => x.ToString(_formatDeCh))
-            );
+            target.ISet = MapToHashSetOfString(dto.ISet);
+            target.HashSet = MapToHashSetOfString1(dto.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(
                 global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString(_formatDeCh))
             );
@@ -487,12 +479,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(source.ISet);
+            target.HashSet = MapToHashSetOfInt321(source.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x))
             );
@@ -690,12 +678,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(testObject.ISet);
+            target.HashSet = MapToHashSetOfInt321(testObject.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x))
             );
@@ -812,6 +796,28 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt32(global::System.Collections.Generic.ICollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt321(global::System.Collections.Generic.IReadOnlyCollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private string MapToString(global::Riok.Mapperly.IntegrationTests.Models.TestEnum source)
         {
             return source switch
@@ -895,6 +901,28 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[--i] = item.ToString(_formatDeCh);
             }
             return new global::System.Collections.Generic.Stack<string>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.HashSet<string> MapToHashSetOfString(global::System.Collections.Generic.ICollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(item.ToString(_formatDeCh));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.HashSet<string> MapToHashSetOfString1(global::System.Collections.Generic.IReadOnlyCollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(item.ToString(_formatDeCh));
+            }
+            return target;
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
@@ -189,15 +189,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x))
-            );
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.IReadOnlySet, x => ParseableInt(x))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(testObject.ISet);
+            target.IReadOnlySet = MapToHashSetOfInt321(testObject.IReadOnlySet);
+            target.HashSet = MapToHashSetOfInt321(testObject.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x))
             );
@@ -358,15 +352,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(item3.ToString(_formatDeCh));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(dto.ISet, x => x.ToString(_formatDeCh))
-            );
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(dto.IReadOnlySet, x => x.ToString(_formatDeCh))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(dto.HashSet, x => x.ToString(_formatDeCh))
-            );
+            target.ISet = MapToHashSetOfString(dto.ISet);
+            target.IReadOnlySet = MapToHashSetOfString1(dto.IReadOnlySet);
+            target.HashSet = MapToHashSetOfString1(dto.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(
                 global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString(_formatDeCh))
             );
@@ -509,15 +497,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x))
-            );
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(source.IReadOnlySet, x => ParseableInt(x))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(source.ISet);
+            target.IReadOnlySet = MapToHashSetOfInt321(source.IReadOnlySet);
+            target.HashSet = MapToHashSetOfInt321(source.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x))
             );
@@ -718,15 +700,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x))
-            );
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.IReadOnlySet, x => ParseableInt(x))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(testObject.ISet);
+            target.IReadOnlySet = MapToHashSetOfInt321(testObject.IReadOnlySet);
+            target.HashSet = MapToHashSetOfInt321(testObject.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x))
             );
@@ -860,6 +836,28 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt32(global::System.Collections.Generic.ICollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt321(global::System.Collections.Generic.IReadOnlyCollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private string MapToString(global::Riok.Mapperly.IntegrationTests.Models.TestEnum source)
         {
             return source switch
@@ -939,6 +937,28 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[--i] = item.ToString(_formatDeCh);
             }
             return new global::System.Collections.Generic.Stack<string>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.HashSet<string> MapToHashSetOfString(global::System.Collections.Generic.ICollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(item.ToString(_formatDeCh));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.HashSet<string> MapToHashSetOfString1(global::System.Collections.Generic.IReadOnlyCollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(item.ToString(_formatDeCh));
+            }
+            return target;
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET9_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET9_0.verified.cs
@@ -189,15 +189,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x))
-            );
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.IReadOnlySet, x => ParseableInt(x))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(testObject.ISet);
+            target.IReadOnlySet = MapToHashSetOfInt321(testObject.IReadOnlySet);
+            target.HashSet = MapToHashSetOfInt321(testObject.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x))
             );
@@ -359,15 +353,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(item3.ToString(_formatDeCh));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(dto.ISet, x => x.ToString(_formatDeCh))
-            );
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(dto.IReadOnlySet, x => x.ToString(_formatDeCh))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(dto.HashSet, x => x.ToString(_formatDeCh))
-            );
+            target.ISet = MapToHashSetOfString(dto.ISet);
+            target.IReadOnlySet = MapToHashSetOfString1(dto.IReadOnlySet);
+            target.HashSet = MapToHashSetOfString1(dto.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(
                 global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString(_formatDeCh))
             );
@@ -511,15 +499,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x))
-            );
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(source.IReadOnlySet, x => ParseableInt(x))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(source.ISet);
+            target.IReadOnlySet = MapToHashSetOfInt321(source.IReadOnlySet);
+            target.HashSet = MapToHashSetOfInt321(source.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x))
             );
@@ -721,15 +703,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(ParseableInt(item3));
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x))
-            );
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.IReadOnlySet, x => ParseableInt(x))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(testObject.ISet);
+            target.IReadOnlySet = MapToHashSetOfInt321(testObject.IReadOnlySet);
+            target.HashSet = MapToHashSetOfInt321(testObject.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x))
             );
@@ -864,6 +840,28 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt32(global::System.Collections.Generic.ICollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt321(global::System.Collections.Generic.IReadOnlyCollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private string MapToString(global::Riok.Mapperly.IntegrationTests.Models.TestEnum source)
         {
             return source switch
@@ -956,6 +954,28 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[--i] = item.ToString(_formatDeCh);
             }
             return new global::System.Collections.Generic.Stack<string>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.HashSet<string> MapToHashSetOfString(global::System.Collections.Generic.ICollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(item.ToString(_formatDeCh));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.HashSet<string> MapToHashSetOfString1(global::System.Collections.Generic.IReadOnlyCollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(item.ToString(_formatDeCh));
+            }
+            return target;
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -191,10 +191,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.ExistingSortedSet.Add(ParseableInt(item2));
             }
             MapExistingList(src.ExistingList, target.ExistingList);
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(src.ISet, x => ParseableInt(x)));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(src.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(src.ISet);
+            target.HashSet = MapToHashSetOfInt321(src.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(src.SortedSet, x => ParseableInt(x))
             );
@@ -363,12 +361,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.ExistingSortedSet.Add(ParseableInt(item2));
             }
             MapExistingList(testObject.ExistingList, target.ExistingList);
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(testObject.ISet);
+            target.HashSet = MapToHashSetOfInt321(testObject.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x))
             );
@@ -523,8 +517,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(item3.ToString());
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.ISet, x => x.ToString()));
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.HashSet, x => x.ToString()));
+            target.ISet = MapToHashSetOfString(dto.ISet);
+            target.HashSet = MapToHashSetOfString1(dto.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(
                 global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString())
             );
@@ -657,12 +651,8 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.ExistingSortedSet.Add(ParseableInt(item2));
             }
             MapExistingList(source.ExistingList, target.ExistingList);
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(source.ISet);
+            target.HashSet = MapToHashSetOfInt321(source.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x))
             );
@@ -1060,6 +1050,28 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt32(global::System.Collections.Generic.ICollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt321(global::System.Collections.Generic.IReadOnlyCollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private static string MapToString(global::Riok.Mapperly.IntegrationTests.Models.TestEnum source)
         {
             return source switch
@@ -1143,6 +1155,28 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[--i] = item.ToString();
             }
             return new global::System.Collections.Generic.Stack<string>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.HashSet<string> MapToHashSetOfString(global::System.Collections.Generic.ICollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(item.ToString());
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.HashSet<string> MapToHashSetOfString1(global::System.Collections.Generic.IReadOnlyCollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(item.ToString());
+            }
+            return target;
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
@@ -192,13 +192,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.ExistingSortedSet.Add(ParseableInt(item2));
             }
             MapExistingList(src.ExistingList, target.ExistingList);
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(src.ISet, x => ParseableInt(x)));
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(src.IReadOnlySet, x => ParseableInt(x))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(src.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(src.ISet);
+            target.IReadOnlySet = MapToHashSetOfInt321(src.IReadOnlySet);
+            target.HashSet = MapToHashSetOfInt321(src.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(src.SortedSet, x => ParseableInt(x))
             );
@@ -369,15 +365,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.ExistingSortedSet.Add(ParseableInt(item2));
             }
             MapExistingList(testObject.ExistingList, target.ExistingList);
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.ISet, x => ParseableInt(x))
-            );
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.IReadOnlySet, x => ParseableInt(x))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(testObject.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(testObject.ISet);
+            target.IReadOnlySet = MapToHashSetOfInt321(testObject.IReadOnlySet);
+            target.HashSet = MapToHashSetOfInt321(testObject.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(testObject.SortedSet, x => ParseableInt(x))
             );
@@ -534,11 +524,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             {
                 target.ExistingList.Add(item3.ToString());
             }
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.ISet, x => x.ToString()));
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(dto.IReadOnlySet, x => x.ToString())
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(global::System.Linq.Enumerable.Select(dto.HashSet, x => x.ToString()));
+            target.ISet = MapToHashSetOfString(dto.ISet);
+            target.IReadOnlySet = MapToHashSetOfString1(dto.IReadOnlySet);
+            target.HashSet = MapToHashSetOfString1(dto.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<string>(
                 global::System.Linq.Enumerable.Select(dto.SortedSet, x => x.ToString())
             );
@@ -676,15 +664,9 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target.ExistingSortedSet.Add(ParseableInt(item2));
             }
             MapExistingList(source.ExistingList, target.ExistingList);
-            target.ISet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(source.ISet, x => ParseableInt(x))
-            );
-            target.IReadOnlySet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(source.IReadOnlySet, x => ParseableInt(x))
-            );
-            target.HashSet = global::System.Linq.Enumerable.ToHashSet(
-                global::System.Linq.Enumerable.Select(source.HashSet, x => ParseableInt(x))
-            );
+            target.ISet = MapToHashSetOfInt32(source.ISet);
+            target.IReadOnlySet = MapToHashSetOfInt321(source.IReadOnlySet);
+            target.HashSet = MapToHashSetOfInt321(source.HashSet);
             target.SortedSet = new global::System.Collections.Generic.SortedSet<int>(
                 global::System.Linq.Enumerable.Select(source.SortedSet, x => ParseableInt(x))
             );
@@ -1083,6 +1065,28 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt32(global::System.Collections.Generic.ICollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt321(global::System.Collections.Generic.IReadOnlyCollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private static string MapToString(global::Riok.Mapperly.IntegrationTests.Models.TestEnum source)
         {
             return source switch
@@ -1162,6 +1166,28 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[--i] = item.ToString();
             }
             return new global::System.Collections.Generic.Stack<string>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.HashSet<string> MapToHashSetOfString(global::System.Collections.Generic.ICollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(item.ToString());
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.HashSet<string> MapToHashSetOfString1(global::System.Collections.Generic.IReadOnlyCollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.HashSet<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Add(item.ToString());
+            }
+            return target;
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableSetTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableSetTest.cs
@@ -44,6 +44,28 @@ public class EnumerableSetTest
             );
     }
 
+    [Theory]
+    [InlineData("HashSet<int>")]
+    [InlineData("ISet<int>")]
+    [InlineData("IReadOnlySet<int>")]
+    public void ReadOnlyCollectionToSetOfDifferentTypes(string targetType)
+    {
+        var source = TestSourceBuilder.Mapping("IReadOnlyCollection<long>", targetType, TestSourceBuilderOptions.AllConversions);
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::System.Collections.Generic.HashSet<int>(source.Count);
+                foreach (var item in source)
+                {
+                    target.Add((int)item);
+                }
+                return target;
+                """
+            );
+    }
+
     [Fact]
     public void EnumerableToSortedSet()
     {


### PR DESCRIPTION
Use pre-sized set mappings to reduce allocations.

## Checklist

- [x] I did not use AI tools to generate this PR, or I have manually verified that the code is correct, optimal, and follows the project guidelines and architecture
- [x] I understand that low-quality, AI-generated PRs will be closed immediately without further explanation
- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
