### PR TITLE
perf: pre-size transformed queue mappings

### DIFF
--- a/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
+++ b/src/Riok.Mapperly/Descriptors/MappingBuilders/EnumerableMappingBuilder.cs
@@ -149,6 +149,11 @@ public static class EnumerableMappingBuilder
             return BuildEnumerableToHashSetMapping(ctx, elementMapping);
         }
 
+        if (ctx.CollectionInfos.Target.CollectionType == CollectionType.Queue)
+        {
+            return BuildEnumerableToQueueMapping(ctx, elementMapping);
+        }
+
         // use count-aware loops for transformed stacks and order-preserving copies to avoid LINQ allocations
         if (ctx.CollectionInfos.Target.CollectionType.HasFlag(CollectionType.Stack))
         {
@@ -241,6 +246,33 @@ public static class EnumerableMappingBuilder
         var collectionInfos = new CollectionInfos(
             BuildCollectionTypeForICollection(ctx, ctx.CollectionInfos!.Source),
             CollectionInfoBuilder.BuildGenericCollectionInfo(ctx, CollectionType.HashSet, ctx.CollectionInfos.Target)
+        );
+        var existingMapping = ctx.BuildDelegatedMapping(collectionInfos.Source.Type, collectionInfos.Target.Type);
+        if (existingMapping != null)
+            return new DelegateMapping(ctx.Source, ctx.Target, existingMapping);
+
+        return new ForEachAddEnumerableMapping(
+            null,
+            collectionInfos,
+            elementMapping,
+            ctx.Configuration.Mapper.UseReferenceHandling,
+            collectionInfos.Target.AddMethodName!
+        );
+    }
+
+    /// <summary>
+    /// Tries to build a mapping for a source for which the count is known and a queue target.
+    /// </summary>
+    private static INewInstanceMapping? BuildEnumerableToQueueMapping(MappingBuilderContext ctx, INewInstanceMapping elementMapping)
+    {
+        // Queue(IEnumerable<T>) is already efficient when no element mapping is needed.
+        if (elementMapping.IsSynthetic)
+            return null;
+
+        // try to reuse an ICollection<S> => Queue<T> mapping
+        var collectionInfos = new CollectionInfos(
+            BuildCollectionTypeForICollection(ctx, ctx.CollectionInfos!.Source),
+            CollectionInfoBuilder.BuildGenericCollectionInfo(ctx, CollectionType.Queue, ctx.CollectionInfos.Target)
         );
         var existingMapping = ctx.BuildDelegatedMapping(collectionInfos.Source.Type, collectionInfos.Target.Type);
         if (existingMapping != null)

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource.verified.cs
@@ -134,9 +134,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(testObject.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(testObject.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -293,9 +291,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
             target.StackValue = MapToStackOfString(dto.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<string>(
-                global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString(_formatDeCh))
-            );
+            target.QueueValue = MapToQueueOfString(dto.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString(_formatDeCh))
             );
@@ -431,9 +427,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array(source.SpanValue);
             target.MemoryValue = MapToInt32Array1(source.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(source.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(source.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -630,9 +624,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(testObject.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(testObject.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -796,6 +788,17 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.Queue<int> MapToQueueOfInt32(global::System.Collections.Generic.IReadOnlyCollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.Queue<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Enqueue(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt32(global::System.Collections.Generic.ICollection<string> source)
         {
             var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
@@ -901,6 +904,17 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[--i] = item.ToString(_formatDeCh);
             }
             return new global::System.Collections.Generic.Stack<string>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.Queue<string> MapToQueueOfString(global::System.Collections.Generic.IReadOnlyCollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.Queue<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Enqueue(item.ToString(_formatDeCh));
+            }
+            return target;
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
@@ -140,9 +140,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(testObject.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(testObject.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -303,9 +301,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
             target.StackValue = MapToStackOfString(dto.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<string>(
-                global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString(_formatDeCh))
-            );
+            target.QueueValue = MapToQueueOfString(dto.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString(_formatDeCh))
             );
@@ -448,9 +444,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array(source.SpanValue);
             target.MemoryValue = MapToInt32Array1(source.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(source.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(source.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -651,9 +645,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(testObject.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(testObject.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -836,6 +828,17 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.Queue<int> MapToQueueOfInt32(global::System.Collections.Generic.IReadOnlyCollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.Queue<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Enqueue(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt32(global::System.Collections.Generic.ICollection<string> source)
         {
             var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
@@ -937,6 +940,17 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[--i] = item.ToString(_formatDeCh);
             }
             return new global::System.Collections.Generic.Stack<string>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.Queue<string> MapToQueueOfString(global::System.Collections.Generic.IReadOnlyCollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.Queue<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Enqueue(item.ToString(_formatDeCh));
+            }
+            return target;
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET9_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/MapperTest.SnapshotGeneratedSource_NET9_0.verified.cs
@@ -140,9 +140,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(testObject.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(testObject.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -304,9 +302,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
             target.StackValue = MapToStackOfString(dto.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<string>(
-                global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString(_formatDeCh))
-            );
+            target.QueueValue = MapToQueueOfString(dto.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString(_formatDeCh))
             );
@@ -450,9 +446,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array(source.SpanValue);
             target.MemoryValue = MapToInt32Array1(source.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(source.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(source.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -654,9 +648,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array1(testObject.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(testObject.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(testObject.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -840,6 +832,17 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.Queue<int> MapToQueueOfInt32(global::System.Collections.Generic.IReadOnlyCollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.Queue<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Enqueue(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt32(global::System.Collections.Generic.ICollection<string> source)
         {
             var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
@@ -954,6 +957,17 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[--i] = item.ToString(_formatDeCh);
             }
             return new global::System.Collections.Generic.Stack<string>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private global::System.Collections.Generic.Queue<string> MapToQueueOfString(global::System.Collections.Generic.IReadOnlyCollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.Queue<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Enqueue(item.ToString(_formatDeCh));
+            }
+            return target;
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource.verified.cs
@@ -147,9 +147,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array1(src.SpanValue);
             target.MemoryValue = MapToInt32Array2(src.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(src.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(src.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(src.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(src.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -317,9 +315,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array1(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array2(testObject.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(testObject.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(testObject.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -469,9 +465,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
             target.StackValue = MapToStackOfString(dto.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<string>(
-                global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString())
-            );
+            target.QueueValue = MapToQueueOfString(dto.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString())
             );
@@ -607,9 +601,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array1(source.SpanValue);
             target.MemoryValue = MapToInt32Array2(source.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(source.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(source.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -1050,6 +1042,17 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.Queue<int> MapToQueueOfInt32(global::System.Collections.Generic.IReadOnlyCollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.Queue<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Enqueue(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private static global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt32(global::System.Collections.Generic.ICollection<string> source)
         {
             var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
@@ -1155,6 +1158,17 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[--i] = item.ToString();
             }
             return new global::System.Collections.Generic.Stack<string>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.Queue<string> MapToQueueOfString(global::System.Collections.Generic.IReadOnlyCollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.Queue<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Enqueue(item.ToString());
+            }
+            return target;
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
+++ b/test/Riok.Mapperly.IntegrationTests/_snapshots/StaticMapperTest.SnapshotGeneratedSource_NET8_0.verified.cs
@@ -147,9 +147,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array1(src.SpanValue);
             target.MemoryValue = MapToInt32Array2(src.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(src.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(src.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(src.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(src.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -320,9 +318,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array1(testObject.SpanValue);
             target.MemoryValue = MapToInt32Array2(testObject.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(testObject.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(testObject.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(testObject.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(testObject.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -475,9 +471,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             }
             target.MemoryValue = MapToStringArray(dto.MemoryValue.Span);
             target.StackValue = MapToStackOfString(dto.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<string>(
-                global::System.Linq.Enumerable.Select(dto.QueueValue, x => x.ToString())
-            );
+            target.QueueValue = MapToQueueOfString(dto.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(dto.ImmutableArrayValue, x => x.ToString())
             );
@@ -619,9 +613,7 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
             target.SpanValue = MapToInt32Array1(source.SpanValue);
             target.MemoryValue = MapToInt32Array2(source.MemoryValue.Span);
             target.StackValue = MapToStackOfInt32(source.StackValue);
-            target.QueueValue = new global::System.Collections.Generic.Queue<int>(
-                global::System.Linq.Enumerable.Select(source.QueueValue, x => ParseableInt(x))
-            );
+            target.QueueValue = MapToQueueOfInt32(source.QueueValue);
             target.ImmutableArrayValue = global::System.Collections.Immutable.ImmutableArray.ToImmutableArray(
                 global::System.Linq.Enumerable.Select(source.ImmutableArrayValue, x => ParseableInt(x))
             );
@@ -1065,6 +1057,17 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.Queue<int> MapToQueueOfInt32(global::System.Collections.Generic.IReadOnlyCollection<string> source)
+        {
+            var target = new global::System.Collections.Generic.Queue<int>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Enqueue(ParseableInt(item));
+            }
+            return target;
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
         private static global::System.Collections.Generic.HashSet<int> MapToHashSetOfInt32(global::System.Collections.Generic.ICollection<string> source)
         {
             var target = new global::System.Collections.Generic.HashSet<int>(DirectInt(source.Count));
@@ -1166,6 +1169,17 @@ namespace Riok.Mapperly.IntegrationTests.Mapper
                 target[--i] = item.ToString();
             }
             return new global::System.Collections.Generic.Stack<string>(target);
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]
+        private static global::System.Collections.Generic.Queue<string> MapToQueueOfString(global::System.Collections.Generic.IReadOnlyCollection<int> source)
+        {
+            var target = new global::System.Collections.Generic.Queue<string>(DirectInt(source.Count));
+            foreach (var item in source)
+            {
+                target.Enqueue(item.ToString());
+            }
+            return target;
         }
 
         [global::System.CodeDom.Compiler.GeneratedCode("Riok.Mapperly", "0.0.1.0")]

--- a/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
+++ b/test/Riok.Mapperly.Tests/Mapping/EnumerableTest.cs
@@ -493,6 +493,25 @@ public class EnumerableTest
     }
 
     [Fact]
+    public void ReadOnlyCollectionToCreatedQueueOfCastedTypes()
+    {
+        var source = TestSourceBuilder.Mapping("IReadOnlyCollection<int>", "Queue<long>");
+        TestHelper
+            .GenerateMapper(source)
+            .Should()
+            .HaveSingleMethodBody(
+                """
+                var target = new global::System.Collections.Generic.Queue<long>(source.Count);
+                foreach (var item in source)
+                {
+                    target.Enqueue((long)item);
+                }
+                return target;
+                """
+            );
+    }
+
+    [Fact]
     public Task ArrayToReadOnlyCollectionShouldUpgradeNullability()
     {
         var source = TestSourceBuilder.Mapping(


### PR DESCRIPTION
perf: pre-size transformed queue mappings

## Checklist

- [x] I did not use AI tools to generate this PR, or I have manually verified that the code is correct, optimal, and follows the project guidelines and architecture
- [x] I understand that low-quality, AI-generated PRs will be closed immediately without further explanation
- [x] The existing code style is followed
- [x] The commit message follows our guidelines
- [x] Performed a self-review of my code
- [x] Hard-to-understand areas of my code are commented
- [x] The documentation is updated (as applicable)
- [x] Unit tests are added/updated
- [x] Integration tests are added/updated (as applicable, especially if feature/bug depends on roslyn or framework version in use)
